### PR TITLE
blip-check: probe every Contacts source, not just glob()[0]

### DIFF
--- a/bridge/mac/blip-check
+++ b/bridge/mac/blip-check
@@ -20,7 +20,8 @@ import subprocess
 import sys
 
 CHAT_DB = os.path.expanduser("~/Library/Messages/chat.db")
-AB_GLOB = os.path.expanduser("~/Library/Application Support/AddressBook/Sources/*/AddressBook-v22.abcddb")
+AB_DIR = os.path.expanduser("~/Library/Application Support/AddressBook")
+AB_GLOB = os.path.join(AB_DIR, "Sources", "*", "AddressBook-v22.abcddb")
 
 FIX = {
     "chatdb": "System Settings → Privacy & Security → Full Disk Access → add "
@@ -59,17 +60,41 @@ def check_automation() -> tuple[bool, str]:
     return False, err[:200]
 
 
+def _addressbook_dbs() -> list[str]:
+    """One .abcddb per Contacts source/account, plus the root db, like the
+    `contacts` tool. Order is stable so the check is deterministic."""
+    paths = sorted(glob.glob(AB_GLOB))
+    root = os.path.join(AB_DIR, "AddressBook-v22.abcddb")
+    if os.path.exists(root):
+        paths.append(root)
+    return paths
+
+
 def check_contacts() -> tuple[bool, str]:
-    paths = glob.glob(AB_GLOB)
+    # Disabled or stale CardDAV sources leave .abcddb files that never open
+    # ("unable to open database file") no matter what TCC grants exist — the
+    # `contacts` tool warns and skips them. So this must probe every source and
+    # fail only when NOTHING opens, which is the real "Full Disk Access missing"
+    # signal. Testing a single source (previously glob()[0], unordered) reported
+    # a false ❌ whenever a dead source sorted first.
+    paths = _addressbook_dbs()
     if not paths:
         return False, "no AddressBook sources found"
-    try:
-        con = sqlite3.connect(f"file:{paths[0]}?mode=ro", uri=True)
-        n = con.execute("SELECT COUNT(*) FROM ZABCDRECORD").fetchone()[0]
-        con.close()
-        return True, f"{n} contacts readable"
-    except sqlite3.DatabaseError as e:
-        return False, str(e)
+    readable = total = 0
+    last_err = ""
+    for p in paths:
+        try:
+            con = sqlite3.connect(f"file:{p}?mode=ro", uri=True)
+            total += con.execute("SELECT COUNT(*) FROM ZABCDRECORD").fetchone()[0]
+            con.close()
+            readable += 1
+        except sqlite3.DatabaseError as e:
+            last_err = str(e)
+    if readable:
+        skipped = len(paths) - readable
+        tail = f", {skipped} stale source(s) skipped" if skipped else ""
+        return True, f"{total} contacts readable ({readable}/{len(paths)} sources{tail})"
+    return False, last_err or "no AddressBook source could be opened"
 
 
 def main() -> None:


### PR DESCRIPTION
## Problem

`check_contacts()` in `bridge/mac/blip-check` opens **one** `.abcddb` — `glob.glob(AB_GLOB)[0]`, and `glob` order is filesystem order, not sorted — and reports the entire contacts check as failed if that single DB does not open.

Macs accumulate disabled / stale CardDAV account sources whose `AddressBook-v22.abcddb` never opens (`unable to open database file`) no matter what TCC grants exist. The `contacts` tool already handles this — it `warn: skipping …` and moves on. But when one of those dead sources happens to sort first, `blip-setup` prints:

```
❌  contacts   unable to open database file
    fix: Same Full Disk Access grant as chat.db …
```

The suggested fix does nothing (FDA is already granted — `chatdb` passes), and `contacts list` / avatars over the bridge work fine. On a real machine here: 7 of 16 source DBs open, `contacts list` returns real contacts, but `blip-check` reported `contacts ❌` because a dead source sorted first.

## Fix

- Iterate **all** sources — `sorted(glob(...))` plus the root `AddressBook-v22.abcddb`, matching `contacts`' own `source_dbs()`.
- Sum records across the DBs that open; fail only when **nothing** opens (the real missing-FDA signal).
- Detail line now reads e.g. `13950 contacts readable (7/16 sources, 9 stale source(s) skipped)` so stale sources are visible but not alarming.

Deterministic now (sorted), so no more order-dependent flapping.

## Test

```
$ python3 -m py_compile bridge/mac/blip-check   # CI byte-compile: OK
```

Local harness with a dead source sorted ahead of a good one:

```
first source (old code would test only this): AAA/AddressBook-v22.abcddb
NEW check_contacts -> (True, '42 contacts readable (1/2 sources, 1 stale source(s) skipped)')
all-dead          -> (False, 'file is not a database')
```

Also verified against a live bridge: `blip-check` now reports contacts ✅ where it previously reported ❌.

## Note

`bridge/mac/tcc-check`'s `contacts_db()` has a related weakness (loops all sources but raises on the first that fails). Left out of this PR to keep it focused on the `blip-setup` path; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)