### PR TITLE
Fix Blip window QML parsing

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -285,9 +285,10 @@ FocusScope {
     // .desktop name (brave-browser, firefox, chromium, google-chrome…).
     Quickshell.execDetached(["sh", "-c",
       'xdg-open "$1" >/dev/null 2>&1; b=$(xdg-settings get default-web-browser 2>/dev/null | sed "s/\\.desktop$//" | tr "[:upper:]" "[:lower:]"); [ -n "$b" ] || exit 0; ' +
-      'for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do a=$(hyprctl clients -j 2>/dev/null | jq -r --arg b "$b" '[.[] | select(((.class // "") | ascii_downcase | contains($b)) or ((.initialClass // "") | ascii_downcase | contains($b)))] | sort_by(.focusHistoryID) | .[0].address // empty'); ' +
+      'for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do a=$(hyprctl clients -j 2>/dev/null | jq -r --arg b "$b" "$2"); ' +
       '[ -n "$a" ] && { hyprctl dispatch "hl.dsp.focus({ window = \\"address:$a\\" })" >/dev/null 2>&1; exit 0; }; sleep 0.2; done',
-      "blip", u])
+      "blip", u,
+      "[.[] | select(((.class? | strings) | ascii_downcase | contains($b)) or ((.initialClass? | strings) | ascii_downcase | contains($b)))] | sort_by(.focusHistoryID) | try .[0].address catch empty"])
   }
 
 

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -33,6 +33,13 @@ describe("QML safety invariants", () => {
     expect(panel).not.toContain('["--yes", "--", text]');
   });
 
+  test("browser-focus jq is passed outside the QML shell string", () => {
+    expect(panel).toContain("try .[0].address catch empty");
+    expect(panel).toContain('jq -r --arg b "$b" "$2"');
+    expect(panel).not.toContain('.class // ""');
+    expect(panel).not.toContain('.address // empty');
+  });
+
   test("read marks are queued and only applied after a successful load", () => {
     expect(widget).toContain("property var refreshQueue: []");
     expect(widget).not.toContain("property var queued: null");


### PR DESCRIPTION
## Summary

- pass the jq browser-window filter as a separate positional argument instead of nesting single quotes inside the QML JavaScript string
- avoid jq fallback operators in the embedded command boundary
- add a regression test covering the QML/shell quoting contract

## Why

The browser-focus command introduced in 2.1.4 nested a single-quoted jq program inside a single-quoted QML string. `BlipView.qml` therefore failed to parse, which made both the panel view and standalone `BlipWindow` unavailable. A stale IPC handler could still return `app shown + focused`, masking the load failure.

## Verification

- `bun test`: 185 passed, 0 failed
- `git diff --check` passed
- deployed locally and restarted the Omarchy shell
- `qs ... ipc call nixfred.blip app` created a real `Blip` Hyprland client
- fresh Quickshell log contained no `BlipView` parser errors

This preserves the existing browser-focus behavior and restores the window recreation / IPC lifecycle invariant.