### PR TITLE
Send SMS/RCS DMs on the matching service

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -569,6 +569,20 @@ FocusScope {
     }))
   }
 
+  /** SMS/RCS, or SMS after a failed iMessage to a phone (error 22). */
+  function sendService() {
+    var chat = String(root.active && root.active.chat ? root.active.chat : "")
+    var phone = /^\+?[0-9]{5,}$/.test(chat)
+    if (phone) {
+      for (var i = 0; i < root.bubbles.length; i++) {
+        if (root.bubbles[i].from_me === true && root.bubbles[i].failed === true) return "SMS"
+      }
+    }
+    var s = String(root.active && root.active.service ? root.active.service : "")
+    if (s === "SMS" || s === "RCS") return s
+    return "iMessage"
+  }
+
   function send() {
     var text = composeField.text
     if (!root.inThread) return
@@ -602,7 +616,7 @@ FocusScope {
       sendDraftPath = draftPath
       // caption on stdin — never in this process's argv (audit #4, war room #1/#13)
       fileSendProc.command = ["bun", root.sendFileScript, sendChat, draftPath, "--caption-stdin"]
-        .concat(/^(SMS|RCS)$/i.test(String(root.active.service || "")) ? ["--service", String(root.active.service).toUpperCase()] : [])
+        .concat(/^(SMS|RCS)$/i.test(root.sendService()) ? ["--service", root.sendService()] : [])
       fileSendProc.stdinEnabled = true
       fileSendProc.running = true
       fileSendProc.write(trimmed !== "" ? text : "")
@@ -615,9 +629,10 @@ FocusScope {
     var target = root.activeIsGroup
       ? ["--chat-id", String(root.active.guid)]
       : ["--to", sendChat]
-    // green-bubble (SMS/RCS) threads send on their own service (war room #2)
-    var svc = String(root.active.service || "")
-    if (!root.activeIsGroup && /^(SMS|RCS)$/i.test(svc)) target = target.concat(["--service", svc.toUpperCase()])
+    // green-bubble (SMS/RCS) threads send on their own service (war room #2).
+    // A failed iMessage to a phone (error 22) also sends SMS on the next try.
+    var svc = root.sendService()
+    if (!root.activeIsGroup && /^(SMS|RCS)$/i.test(svc)) target = target.concat(["--service", svc])
     sendProc.command = [root.home + "/bin/imsg-send"].concat(target).concat(["--yes", "--text-stdin", "--keep-dashes"])
     sendProc.stdinEnabled = true
     sendProc.running = true
@@ -1991,7 +2006,7 @@ FocusScope {
             readOnly: !root.online || !root.isSendable(root.active)
             placeholderText: root.draftPath !== ""
               ? "caption (optional) — Enter sends the file"
-              : root.isSendable(root.active) ? "iMessage" : "Read-only — group id unknown"
+              : root.isSendable(root.active) ? root.sendService() : "Read-only — group id unknown"
             foreground: root.foreground
             accent: root.mineFill
             font.family: root.fontFamily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- **Failed iMessage to a phone number sends SMS next.** 2.2.0 already passes
+  `--service` when the thread is already SMS/RCS. A new chat to an Android
+  number still starts as iMessage; AppleScript then fails with error 22
+  (not registered) and the last bubble stays iMessage, so the next Enter
+  retried iMessage. Last inbound still wins; if there is none and the only
+  rows are failed iMessage to a phone, the next send is SMS. Compose
+  placeholder follows. (PR #4)
+
 ## 2.2.2 — 2026-09-02
 
 - **Group sends failed with -1728 on Macs that keep one chat row per

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,9 @@ what it is handed. Keep it that way.
   member spoke last. `isSendable()` tests the *chat* id; groups send
   `--chat-id <full guid>` (`any;+;<32hex>`, or `<Service>;+;chat<digits>` on
   Macs that keep one chat row per service — `imsg groups` returns ONE row per
-  identifier, the newest, so an empty shell never wins; #8), DMs send `--to <chat>`.
+  identifier, the newest, so an empty shell never wins; #8), DMs send `--to <chat>`
+  and `--service SMS|RCS` when last inbound (or a failed iMessage to a phone)
+  says so.
 - **Two read marks.** `watermark` = what the collector has seen (drives toasts).
   `readMark` / `readMarks[chat]` = what the user has looked at (drives the badge
   and the blue dots). Collapsing them makes the badge flash and reset.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -167,7 +167,8 @@ panel (3 lenses × finding, against current main) confirmed 11 closed and
 
 - [x] One BarWidget per monitor → leader election (2.2.0; follower bars
   show the badge from state.json and forward clicks over IPC).
-- [x] SMS/RCS threads send on their own service (2.2.0).
+- [x] SMS/RCS threads send on their own service (2.2.0). Last inbound
+  wins; a failed iMessage to a phone (error 22) sends SMS next (PR #4).
 - [ ] **3–4 digit short codes classify as groups** — `isGroupChat()` treats a
   digits-only id shorter than 5 as "not a phone", so a carrier-style sender
   opens read-only with "group id unknown". Widen to `{3,15}` (E.164 max is

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -17,7 +17,9 @@ import {
   loadAllowlist,
   loadState,
   maxTs,
+  normalizeSendService,
   saveState,
+  sendServiceForMessages,
   selectToasts,
   toastKey,
   unreadCounts,
@@ -110,6 +112,25 @@ describe("buildThreads", () => {
 
   test("handles an empty window", () => {
     expect(buildThreads([], "2026-01-01 00:00:00")).toEqual([]);
+  });
+
+  test("SMS inbound then a failed iMessage still sends as SMS", () => {
+    const threads = buildThreads(
+      [
+        msg({ ts: "2026-09-01 13:00:00", from_me: false, service: "SMS", text: "in" }),
+        msg({ ts: "2026-09-01 21:45:00", from_me: true, service: "iMessage", text: "out", error: 3 }),
+      ],
+      "2026-09-01 12:00:00",
+    );
+    expect(threads[0]!.service).toBe("SMS");
+  });
+
+  test("a failed iMessage to a phone with no inbound sends as SMS next", () => {
+    const threads = buildThreads(
+      [msg({ ts: "2026-09-02 16:21:00", from_me: true, service: "iMessage", error: 22, text: "out" })],
+      "2026-09-02 16:00:00",
+    );
+    expect(threads[0]!.service).toBe("SMS");
   });
 
   test("a per-thread read mark clears only that thread", () => {
@@ -715,6 +736,46 @@ describe("failed-delivery detection", () => {
     const first = selectFailures([mine({ error: 25 })], [], now);
     const again = selectFailures([mine({ error: 25 })], first.map((f) => f.key), now);
     expect(again.length).toBe(0);
+  });
+});
+
+describe("send service", () => {
+  test("normalizes sms/rcs and defaults everything else to iMessage", () => {
+    expect(normalizeSendService("SMS")).toBe("SMS");
+    expect(normalizeSendService("rcs")).toBe("RCS");
+    expect(normalizeSendService("")).toBe("iMessage");
+  });
+
+  test("last inbound SMS wins over a later failed iMessage outbound", () => {
+    expect(sendServiceForMessages([
+      msg({ ts: "2026-09-01 13:00:00", from_me: false, service: "SMS" }),
+      msg({ ts: "2026-09-01 21:45:00", from_me: true, service: "iMessage", error: 3 }),
+    ])).toBe("SMS");
+  });
+
+  test("last inbound iMessage wins over older SMS history", () => {
+    expect(sendServiceForMessages([
+      msg({ ts: "2026-08-01 10:00:00", from_me: false, service: "SMS" }),
+      msg({ ts: "2026-09-01 10:00:00", from_me: false, service: "iMessage" }),
+    ])).toBe("iMessage");
+  });
+
+  test("failed iMessage to a phone with no inbound is SMS next (error 22)", () => {
+    expect(sendServiceForMessages([
+      msg({ ts: "2026-09-02 16:21:00", from_me: true, service: "iMessage", error: 22 }),
+    ])).toBe("SMS");
+  });
+
+  test("failed iMessage to an email stays iMessage", () => {
+    expect(sendServiceForMessages([
+      msg({ chat: "them@icloud.com", handle: "them@icloud.com", from_me: true, service: "iMessage", error: 22 }),
+    ])).toBe("iMessage");
+  });
+
+  test("successful iMessage with no inbound stays iMessage", () => {
+    expect(sendServiceForMessages([
+      msg({ from_me: true, service: "iMessage", error: 0 }),
+    ])).toBe("iMessage");
   });
 });
 

--- a/collector.ts
+++ b/collector.ts
@@ -360,6 +360,46 @@ export function groupName(chat: string, info: GroupInfo | undefined, byHandle: M
   return members.length ? members.join(", ") : chat;
 }
 
+export type SendService = "iMessage" | "SMS" | "RCS";
+
+/** Map a chat.db / thread service string onto what `imsg-send --service` accepts. */
+export function normalizeSendService(raw: string | undefined | null): SendService {
+  const s = String(raw ?? "").trim().toLowerCase();
+  if (s === "sms") return "SMS";
+  if (s === "rcs") return "RCS";
+  return "iMessage";
+}
+
+/**
+ * Service a DM should send on.
+ *
+ * Last inbound wins (the service they actually receive on). A failed iMessage
+ * outbound must not flip an SMS contact back to iMessage. No inbound → last
+ * successful outbound. Only failed iMessage rows to a phone number → SMS:
+ * AppleScript does not fall back the way Messages.app GUI does (error 22 =
+ * not registered for iMessage). Groups send `--chat-id` and ignore this.
+ */
+export function sendServiceForMessages(msgs: ImsgMessage[]): SendService {
+  if (!msgs.length) return "iMessage";
+  const sorted = [...msgs].sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    if (!sorted[i]!.from_me) return normalizeSendService(sorted[i]!.service);
+  }
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const m = sorted[i]!;
+    if (m.from_me && !(typeof m.error === "number" && m.error !== 0)) {
+      return normalizeSendService(m.service);
+    }
+  }
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const s = normalizeSendService(sorted[i]!.service);
+    if (s !== "iMessage") return s;
+  }
+  const chat = chatKey(sorted[sorted.length - 1]);
+  if (/^\+?[0-9]{5,}$/.test(chat)) return "SMS";
+  return "iMessage";
+}
+
 export function buildThreads(
   msgs: ImsgMessage[],
   watermark: string,
@@ -392,7 +432,7 @@ export function buildThreads(
       guid: isGroupChat(chat) ? groups[chat]?.guid ?? "" : "",
       name: isGroupChat(chat) ? groupName(chat, groups[chat], byHandle) : displayName(sorted),
       handle: String(last.handle || chat),
-      service: last.service,
+      service: sendServiceForMessages(sorted),
       last_ts: last.ts,
       last_text: last.text,
       last_from_me: last.from_me,

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -11,6 +11,11 @@ describe("QML safety invariants", () => {
     expect(panel).toContain('["--to", sendChat]');
   });
 
+  test("DM sends pass SMS after a failed iMessage to a phone", () => {
+    expect(panel).toContain("function sendService()");
+    expect(panel).toContain("root.bubbles[i].failed === true) return \"SMS\"");
+  });
+
   test("thread results are accepted only for the active chat", () => {
     expect(panel).toContain('String(root.active.chat) === root.threadRunningChat');
     expect(panel).toContain("if (!belongsHere) return");


### PR DESCRIPTION
## Why

2.2.0 already sends SMS/RCS when `thread.service` is already SMS/RCS. A **new** chat to an Android number still starts as iMessage. AppleScript does not fall back the way Messages.app GUI does, so the send fails with **error 22** (not registered for iMessage). The failed bubble keeps `service: iMessage`, so the next Enter retries iMessage.

This is the leftover from the ROADMAP item 2.2.0 closed: last-inbound (and failed-iMessage-to-phone → SMS).

Useful if Omarchy (`omacom/omarchy`) vendors Blip: first-hour SMS to a non-Apple phone currently looks broken.

## What

Rebased onto **2.2.2**.

- Thread `service` is last **inbound**.
- If there is no inbound and the only rows are **failed iMessage to a phone number**, next send is **SMS**.
- Email handles stay iMessage.
- Compose placeholder follows (`SMS` while the failed bubble is on screen).
- Groups still send `--chat-id` only.

New chats with no history still try iMessage first (same as Messages.app). After error 22, the next send is SMS. SMS still needs Text Message Forwarding on the paired iPhone.

## Tests

`bun test` — 204 pass. Logic in TypeScript (`sendServiceForMessages`); QML only binds. Injected runners only; no live send to a real contact.

## Invariant

DMs send `--to <chat>` plus `--service SMS|RCS` when last inbound (or a failed iMessage to a phone) says so. Message bodies stay on stdin.