### PR TITLE
toasts: notify new inbound as system notifications by default

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -11,9 +11,10 @@ import qs.Ui
 // widget owns the single poller; the panel reads its state rather than running
 // its own collector.
 //
-// Badge counts EVERY unread. Toasts fire only for allowlisted handles
-// (~/.config/blip/allowlist.json) — chat.db is mostly bank alerts and 2FA codes,
-// and none of that deserves an interruption.
+// Badge counts EVERY unread. Toasts fire for every new inbound as a system
+// notification. An optional ~/.config/blip/allowlist.json restricts that to
+// listed handles — chat.db is mostly bank alerts and 2FA codes, so the
+// allowlist is how you quiet the noise without losing the badge.
 //
 // Left-click = panel · double-click = the app window · middle-click = refresh · right-click = mark all read.
 BarWidget {
@@ -417,12 +418,14 @@ BarWidget {
   }
 
   // ------------------------------------------------------------ toasts
-  // One notify-send per allowlisted inbound message. The collector has already
-  // applied the allowlist and the dedupe ring, so anything arriving here is
-  // meant to interrupt. Reuses the no-focus-steal notification behaviour.
+  // One notify-send per Toast the collector emitted. Policy (all / allow /
+  // off), open-chat skip, self-thread skip, preview sanitizing, and the
+  // batch cap all live in collector.ts — this just renders. Reuses the
+  // no-focus-steal notification behaviour.
   // With --wait + actions, clicking the toast (default) or its Reply button
   // opens the panel ON that conversation, compose focused — the daemon
   // advertises the "actions" capability (verified via GetCapabilities).
+  // Flag set must match collector.notifySendArgv (ui.test.ts).
   Process {
     id: notifyProc
     stdout: StdioCollector {
@@ -458,7 +461,9 @@ BarWidget {
       "notify-send",
       "--app-name=Blip",
       "--icon=mail-message-new",
-      "--expire-time=8000",
+      "--urgency=normal",
+      "--category=im.received",
+      "--expire-time=15000",
       // --wait blocks until the toast closes and prints the chosen action.
       // Only `default` (clicking the card): the Omarchy notification daemon
       // renders no action BUTTONS and only ever invokes default — an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2.0.4 — 2026-09-01
+
+**Changed**
+- New inbound messages fire a **system notification** by default (Omarchy's
+  notification daemon via `notify-send`). The tiny bar badge is no longer
+  the only alert. Click the toast to open that conversation.
+- `~/.config/blip/allowlist.json` is now a toast *policy*, not a required
+  gate. Missing file = notify everyone. `{ "mode": "off" }` is silence.
+  A populated `{ "allow": ["+1…"] }` still filters to those senders.
+
+**Upgrade note.** If you liked the old quiet default (badge only, no
+toasts until you wrote an allowlist), write:
+
+```json
+{ "mode": "off" }
+```
+
+A legacy empty `{ "allow": [] }` or `[]` still means off. A missing file
+does not.
+
+**Fixed / hardened**
+- Allowlist matching folds US numbers (`+1555…` / `(555) …`) and emails
+  (case-insensitive). Hex group ids are never digit-folded into a phone.
+- The conversation you have open is not toasted — you did not miss it.
+- The self-thread is not toasted.
+- A catch-up after sleep emits at most 20 newest toasts, oldest of that
+  batch first.
+- Attachment-only rows say "New message" instead of the U+FFFC placeholder.
+- Group toasts read `Alice · Family`.
+- Corrupt `allowlist.json` fails closed (off), not open (spam).
+- Toasts stay on screen 15 s (`--urgency=normal`, `--category=im.received`).
+
 ## 2.0.0 — 2026-08-31
 
 The "complete for Fred" release: everything on the roadmap that makes Blip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,15 @@ what it is handed. Keep it that way.
 - **`PanelKeyCatcher` eats keys before focused children.** Any editor that
   should receive typing must be covered by its `blocked:` binding.
 - **Pass `--` before message text** to both `imsg-send` and `notify-send`.
+- **Toasts are a policy, not an allowlist-only gate.** Missing
+  `allowlist.json` notifies every new inbound (`mode=all`). `{ "mode": "off" }`
+  is silence; `{ "mode": "allow", "allow": [...] }` is the old filter; a
+  legacy empty `{ "allow": [] }` stays off. Never toast the conversation
+  currently being read (`--read`), the self-thread, outbound, or the
+  first-run backlog. Cap a batch at `TOAST_BATCH_CAP` (20) newest.
+  Preview text is sanitized in TS (`toastPreview`) before QML interpolates
+  it after `--`. `notifySendArgv()` is the flag contract; `ui.test.ts`
+  fails if BarWidget.qml drifts.
 - **No message content in state.json.** `~/.local/state/blip/state.json` holds
   timestamps, counts, opaque SHA-256 toast keys, self-chat ids, and group
   metadata. It is atomic and `0600`; no message bodies are allowed. EXCEPTION

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <img alt="Omarchy" src="https://img.shields.io/badge/Omarchy-plugin-5fd7ff?style=flat-square">
   <img alt="QuickShell" src="https://img.shields.io/badge/QuickShell-QML-0a84ff?style=flat-square">
   <img alt="bun" src="https://img.shields.io/badge/bun-TypeScript-f9f1e1?style=flat-square">
-  <img alt="tests" src="https://img.shields.io/badge/tests-177%20passing-2ea043?style=flat-square">
+  <img alt="tests" src="https://img.shields.io/badge/tests-206%20passing-2ea043?style=flat-square">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-lightgrey?style=flat-square">
 </p>
 
@@ -98,8 +98,9 @@ Linux side. If the Mac is asleep, the widget dims and says so.
 - compose box at the bottom, Enter sends — **DMs and groups**
 
 **Toasts**
-- desktop notification only for senders on your allowlist
-- everything else still counts and still shows; it just doesn't interrupt you
+- every new inbound fires a **system notification** (Omarchy's notification daemon via `notify-send`) — sender, preview, 15 s, click opens that thread
+- the conversation you have open is not toasted; neither is the self-thread
+- optional allowlist / `{ "mode": "off" }` if you want the old quiet default; everything else still counts on the badge
 
 **Toast actions**
 - click a toast and the panel opens ON that conversation with the compose
@@ -232,10 +233,26 @@ bubble is in your bar.
 
 **Toasts**
 
+New inbound messages fire a desktop notification by default — the same
+system notifications as everything else on Omarchy, not a tiny in-bar
+flash. Click the card to open that conversation with compose focused.
+
+`~/.config/blip/allowlist.json` is re-read every poll (no restart):
+
 ```jsonc
-// ~/.config/blip/allowlist.json — re-read every poll, no restart
-{ "allow": ["+15551234567", "them@icloud.com"] }
+// missing file          → notify everyone (the default)
+// { "mode": "all" }     → same, explicit
+{ "mode": "off" }        // badge only — never interrupt
+{ "mode": "allow", "allow": ["+15551234567", "them@icloud.com"] }
+
+// legacy, still honoured:
+{ "allow": ["+15551234567"] }   // populated → allow those senders
+{ "allow": [] }                 // empty → off (the old quiet default)
 ```
+
+Phone entries match across formatting (`+15551234567`, `(555) 123-4567`).
+Emails match case-insensitively. A hex group id is never mistaken for a
+phone. After a long sleep, at most the 20 newest messages toast.
 
 ## Keyboard
 
@@ -274,6 +291,13 @@ it has *seen* — drives toasts) separate from `readMark` and per-thread
 `readMarks` (highest timestamp *you* have looked at — drives the badge and the
 dots). Fold them together and the badge flashes to 1 and resets on the next
 poll. Yes, that shipped once.
+
+**Toasts are a policy.** Missing `allowlist.json` notifies every new inbound
+as a system notification. `{ "mode": "off" }` is the old quiet default. The
+open conversation, the self-thread, outbound, and the first-run backlog
+never toast. A catch-up after sleep is capped at 20. Preview text is
+sanitized in TypeScript (`toastPreview`) before QML interpolates it after
+`--` on `notify-send`.
 
 **Unread is a ledger, not a window.** The latest 150 rows are enough for normal
 previews, but unread counts and oldest-unread timestamps live in a metadata-only
@@ -319,7 +343,7 @@ The 273,000-message history stays on the Mac where it lives.
 ## Development
 
 ```sh
-bun test                                     # 177 tests, ~70 ms
+bun test                                     # 206 tests, ~70 ms
 bun collector.ts --deep | jq '.unread, (.threads|length)'
 bun thread.ts +15551234567 40 | jq '.bubbles[-1]'
 ```

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -15,14 +15,27 @@ import {
   displayName,
   fetchMessages,
   loadAllowlist,
+  loadToastPolicy,
+  parseToastPolicy,
   loadState,
   maxTs,
   saveState,
   selectToasts,
   toastKey,
+  toastPreview,
+  toastName,
+  foldHandle,
+  allowlisted,
+  notifySendArgv,
+  TOAST_ALL,
+  TOAST_OFF,
+  TOAST_BATCH_CAP,
+  TOAST_BODY_MAX,
+  TOAST_EXPIRE_MS,
   unreadCounts,
   unreadOldest,
   type ImsgMessage,
+  type ToastPolicy,
 } from "./collector";
 
 const tmp = () => mkdtempSync(join(tmpdir(), "blip-test-"));
@@ -253,7 +266,7 @@ describe("displayName", () => {
 });
 
 describe("selectToasts", () => {
-  const allow = ["+15550100002"];
+  const allow: ToastPolicy = { mode: "allow", allow: ["+15550100002"] };
 
   test("a null-chat toast carries the handle, never the string null", () => {
     const out = selectToasts(
@@ -311,7 +324,12 @@ describe("selectToasts", () => {
     // In the self-thread, the user's sent replies come back as from_me=false.
     // Without this dedupe the loop would notify on its own output forever.
     const m = msg({ chat: "+15550100001", handle: "+15550100001", ts: "2026-08-30 11:00:00", text: "echo" });
-    const out = selectToasts([m], "2026-08-30 10:00:00", ["+15550100001"], [toastKey(m)]);
+    const out = selectToasts(
+      [m],
+      "2026-08-30 10:00:00",
+      { mode: "allow", allow: ["+15550100001"] },
+      [toastKey(m)],
+    );
     expect(out).toEqual([]);
   });
 
@@ -333,20 +351,232 @@ describe("selectToasts", () => {
     const out = selectToasts(
       [msg({ chat: "053856bb0d9a40e392db59eace1c56d1", handle: "+15550100004", ts: "2026-08-30 11:00:00" })],
       "2026-08-30 10:00:00",
-      ["+15550100004"],
+      { mode: "allow", allow: ["+15550100004"] },
       [],
     );
     expect(out).toHaveLength(1);
   });
 
-  test("an empty allowlist toasts nothing", () => {
+  test("mode=all toasts every inbound, including short codes", () => {
     const out = selectToasts(
-      [msg({ ts: "2026-08-30 11:00:00" })],
+      [msg({ chat: "878478", handle: "878478", name: "Bank", ts: "2026-08-30 11:00:00", text: "code" })],
       "2026-08-30 10:00:00",
+      TOAST_ALL,
       [],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.name).toBe("Bank");
+    expect(out[0]!.text).toBe("code");
+  });
+
+  test("mode=all still skips outbound and the backlog", () => {
+    const inboundOld = msg({ ts: "2026-08-30 09:00:00" });
+    const outbound = msg({ from_me: true, ts: "2026-08-30 11:00:00" });
+    expect(selectToasts([inboundOld, outbound], "2026-08-30 10:00:00", TOAST_ALL, [])).toEqual([]);
+  });
+
+  test("mode=off toasts nothing, even allowlisted senders", () => {
+    const out = selectToasts(
+      [msg({ chat: "+15550100002", handle: "+15550100002", ts: "2026-08-30 11:00:00" })],
+      "2026-08-30 10:00:00",
+      TOAST_OFF,
       [],
     );
     expect(out).toEqual([]);
+  });
+
+  test("mode=allow with an empty list toasts nobody", () => {
+    const out = selectToasts(
+      [msg({ ts: "2026-08-30 11:00:00" })],
+      "2026-08-30 10:00:00",
+      { mode: "allow", allow: [] },
+      [],
+    );
+    expect(out).toEqual([]);
+  });
+
+  test("does not toast the conversation the user is currently reading", () => {
+    const open = msg({ chat: "+15550100002", handle: "+15550100002", ts: "2026-08-30 11:00:00" });
+    const other = msg({ chat: "+15550100009", handle: "+15550100009", ts: "2026-08-30 11:00:01" });
+    const out = selectToasts([open, other], "2026-08-30 10:00:00", TOAST_ALL, [], {
+      skipChats: ["+15550100002"],
+    });
+    expect(out.map((t) => t.chat)).toEqual(["+15550100009"]);
+  });
+
+  test("does not toast the self-thread", () => {
+    const mine = msg({ chat: "+15550100001", handle: "+15550100001", ts: "2026-08-30 11:00:00" });
+    const out = selectToasts([mine], "2026-08-30 10:00:00", TOAST_ALL, [], {
+      selfChats: ["+15550100001"],
+    });
+    expect(out).toEqual([]);
+  });
+
+  test("a catch-up batch keeps the newest TOAST_BATCH_CAP and drops older ones", () => {
+    const msgs = Array.from({ length: TOAST_BATCH_CAP + 7 }, (_, i) =>
+      msg({
+        chat: `+15550100${String(100 + i).slice(-3)}`,
+        handle: `+15550100${String(100 + i).slice(-3)}`,
+        ts: `2026-08-30 11:${String(i).padStart(2, "0")}:00`,
+        text: `n${i}`,
+      }),
+    );
+    const out = selectToasts(msgs, "2026-08-30 10:00:00", TOAST_ALL, []);
+    expect(out).toHaveLength(TOAST_BATCH_CAP);
+    expect(out[0]!.text).toBe("n7");
+    expect(out[out.length - 1]!.text).toBe(`n${TOAST_BATCH_CAP + 6}`);
+  });
+
+  test("phone formatting variants match an E.164 allowlist entry", () => {
+    const out = selectToasts(
+      [msg({ chat: "5550100002", handle: "(555) 010-0002", ts: "2026-08-30 11:00:00" })],
+      "2026-08-30 10:00:00",
+      { mode: "allow", allow: ["+1 555 010 0002"] },
+      [],
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  test("email allowlist entries match case-insensitively", () => {
+    const out = selectToasts(
+      [msg({ chat: "them@icloud.com", handle: "Them@iCloud.com", ts: "2026-08-30 11:00:00" })],
+      "2026-08-30 10:00:00",
+      { mode: "allow", allow: ["THEM@icloud.com"] },
+      [],
+    );
+    expect(out).toHaveLength(1);
+  });
+
+  test("a hex group id is not folded into a phone number", () => {
+    // 32 hex chars contain plenty of digits; extracting them must not
+    // satisfy an allowlist entry for a real person.
+    const guid = "a5550100002aaaaaaaaaaaaaaaaaaaaa";
+    const out = selectToasts(
+      [msg({ chat: guid, handle: "ALICE", ts: "2026-08-30 11:00:00" })],
+      "2026-08-30 10:00:00",
+      { mode: "allow", allow: ["+15550100002"] },
+      [],
+    );
+    expect(out).toEqual([]);
+  });
+
+  test("group toasts name the sender and the group", () => {
+    const guid = "053856bb0d9a40e392db59eace1c56d1";
+    const out = selectToasts(
+      [msg({ chat: guid, handle: "ALICE", name: "Alice", ts: "2026-08-30 11:00:00", text: "hi" })],
+      "2026-08-30 10:00:00",
+      TOAST_ALL,
+      [],
+      { groups: { [guid]: { name: "Family", guid: "any;+;" + guid, participants: ["ALICE"] } } },
+    );
+    expect(out[0]!.name).toBe("Alice · Family");
+  });
+
+  test("emits a sanitized preview, not the raw attachment placeholder", () => {
+    const out = selectToasts(
+      [msg({ ts: "2026-08-30 11:00:00", text: "\uFFFC" })],
+      "2026-08-30 10:00:00",
+      TOAST_ALL,
+      [],
+    );
+    expect(out[0]!.text).toBe("New message");
+  });
+});
+
+describe("toast preview and notify-send argv", () => {
+  test("blank and attachment-only bodies become 'New message'", () => {
+    expect(toastPreview("")).toBe("New message");
+    expect(toastPreview("   ")).toBe("New message");
+    expect(toastPreview("\uFFFC")).toBe("New message");
+    expect(toastPreview("\uFFFC photo")).toBe("photo");
+  });
+
+  test("long bodies are capped and end with an ellipsis", () => {
+    const long = "x".repeat(TOAST_BODY_MAX + 40);
+    const preview = toastPreview(long);
+    expect(preview.length).toBe(TOAST_BODY_MAX);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  test("a name starting with a dash is still positional after --", () => {
+    const argv = notifySendArgv({ chat: "x", name: "-rf", text: "--hint=evil" });
+    const cut = argv.indexOf("--");
+    expect(cut).toBeGreaterThan(0);
+    expect(argv[cut + 1]).toBe("-rf");
+    expect(argv[cut + 2]).toBe("--hint=evil");
+    expect(argv.slice(0, cut)).not.toContain("-rf");
+  });
+
+  test("the canonical argv carries Blip identity, urgency, category, and wait", () => {
+    const argv = notifySendArgv({ chat: "+1", name: "Ada", text: "hi" });
+    expect(argv[0]).toBe("notify-send");
+    expect(argv).toContain("--app-name=Blip");
+    expect(argv).toContain("--urgency=normal");
+    expect(argv).toContain("--category=im.received");
+    expect(argv).toContain(`--expire-time=${TOAST_EXPIRE_MS}`);
+    expect(argv).toContain("--wait");
+    expect(argv).toContain("--action=default=Open");
+  });
+
+  test("toastName falls back to the handle, never the string null", () => {
+    expect(toastName(msg({ name: null as unknown as string, handle: "+1555", chat: null as unknown as string }))).toBe("+1555");
+  });
+});
+
+describe("foldHandle / allowlisted", () => {
+  test("US numbers with punctuation fold to the last ten digits", () => {
+    expect(foldHandle("+1 (555) 010-0002")).toBe("5550100002");
+    expect(foldHandle("5550100002")).toBe("5550100002");
+    expect(foldHandle("+15550100002")).toBe("5550100002");
+  });
+
+  test("emails fold case-insensitively and short codes stay exact", () => {
+    expect(foldHandle("Them@iCloud.com")).toBe("them@icloud.com");
+    expect(foldHandle("878478")).toBe("878478");
+  });
+
+  test("a hex chat id does not fold to a phone", () => {
+    expect(foldHandle("a5550100002aaaaaaaaaaaaaaaaaaaaa")).not.toBe("5550100002");
+  });
+
+  test("allowlisted matches chat or handle, including folded phones", () => {
+    expect(allowlisted("+15550100002", "+15550100002", ["+1 555 010 0002"])).toBe(true);
+    expect(allowlisted("053856bb0d9a40e392db59eace1c56d1", "+15550100004", ["+15550100004"])).toBe(true);
+    expect(allowlisted("878478", "878478", ["+15550100002"])).toBe(false);
+    expect(allowlisted("x", "y", [])).toBe(false);
+  });
+});
+
+describe("parseToastPolicy", () => {
+  test("null/undefined is all — the unconfigured default", () => {
+    expect(parseToastPolicy(null)).toEqual(TOAST_ALL);
+    expect(parseToastPolicy(undefined)).toEqual(TOAST_ALL);
+  });
+
+  test("legacy populated array is allow; empty array is off", () => {
+    expect(parseToastPolicy(["+15551234567"])).toEqual({ mode: "allow", allow: ["+15551234567"] });
+    expect(parseToastPolicy([])).toEqual(TOAST_OFF);
+  });
+
+  test("legacy {allow:[...]} populated is allow; empty is off", () => {
+    expect(parseToastPolicy({ allow: ["+15551234567"] })).toEqual({ mode: "allow", allow: ["+15551234567"] });
+    expect(parseToastPolicy({ allow: [] })).toEqual(TOAST_OFF);
+  });
+
+  test("explicit mode wins, and allow entries are trimmed", () => {
+    expect(parseToastPolicy({ mode: "OFF" })).toEqual({ mode: "off", allow: [] });
+    expect(parseToastPolicy({ mode: "all", allow: [" leftover "] })).toEqual({
+      mode: "all",
+      allow: ["leftover"],
+    });
+    expect(parseToastPolicy({ mode: "allow", allow: ["  +1  ", "", 42] })).toEqual({
+      mode: "allow",
+      allow: ["+1"],
+    });
+  });
+
+  test("whitespace-only legacy entries collapse to off, not a broken allow mode", () => {
+    expect(parseToastPolicy({ allow: ["  ", ""] })).toEqual(TOAST_OFF);
   });
 });
 
@@ -470,6 +700,22 @@ describe("state and allowlist I/O", () => {
 
   test("a missing allowlist is empty, not an error", () => {
     expect(loadAllowlist(join(tmp(), "none.json"))).toEqual([]);
+  });
+
+  test("a missing allowlist.json is toast-all, not silence", () => {
+    expect(loadToastPolicy(join(tmp(), "none.json"))).toEqual(TOAST_ALL);
+  });
+
+  test("corrupt allowlist.json fails closed to off", () => {
+    const p = join(tmp(), "bad.json");
+    writeFileSync(p, "{not json");
+    expect(loadToastPolicy(p)).toEqual(TOAST_OFF);
+  });
+
+  test("reads an explicit mode file", () => {
+    const p = join(tmp(), "mode.json");
+    writeFileSync(p, JSON.stringify({ mode: "off" }));
+    expect(loadToastPolicy(p)).toEqual(TOAST_OFF);
   });
 
   test("non-string entries are filtered out", () => {

--- a/collector.ts
+++ b/collector.ts
@@ -14,7 +14,8 @@
  *   bun collector.ts            # poll: shallow window, badge + toasts
  *   bun collector.ts --deep     # panel open: wider window, full thread list
  *   bun collector.ts --mark-read        # clear every dot (right-click)
- *   bun collector.ts --read <chat>      # clear one thread's dot (opened it)
+ *   bun collector.ts --read <chat>      # clear one thread's dot (opened it);
+ *                                       # that chat is also skipped for toasts
  */
 
 import { homedir } from "node:os";
@@ -27,7 +28,7 @@ const HOME = process.env.HOME ?? homedir();
 
 /** Watermark + toast dedupe. ~/.local/state is deliberate: never inside a repo. */
 export const STATE_PATH = `${HOME}/.local/state/blip/state.json`;
-/** Handles whose inbound messages are allowed to raise a desktop toast. */
+/** Optional. When set, only these handles raise a desktop toast; empty/missing = every inbound. */
 export const ALLOWLIST_PATH = `${HOME}/.config/blip/allowlist.json`;
 
 /**
@@ -109,6 +110,30 @@ export interface Toast {
   /** Opaque digest persisted for dedupe; never contains message text. */
   key: string;
 }
+
+/**
+ * Who gets a desktop notification.
+ *
+ *   all    — every new inbound (the default when allowlist.json is missing)
+ *   allow  — only listed chats/handles; empty list = nobody
+ *   off    — never interrupt (badge still counts)
+ */
+export type ToastMode = "all" | "allow" | "off";
+
+export interface ToastPolicy {
+  mode: ToastMode;
+  allow: string[];
+}
+
+export const TOAST_ALL: ToastPolicy = { mode: "all", allow: [] };
+export const TOAST_OFF: ToastPolicy = { mode: "off", allow: [] };
+
+/** Newest toasts kept from one collector run; matches the QML queue cap. */
+export const TOAST_BATCH_CAP = 20;
+/** notify-send body cap, including the ellipsis. */
+export const TOAST_BODY_MAX = 220;
+/** How long the daemon should show a Blip toast, in milliseconds. */
+export const TOAST_EXPIRE_MS = 15000;
 
 /**
  * Two marks, deliberately. Collapsing them into one is a bug: the poll
@@ -222,12 +247,55 @@ export function saveState(state: BlipState, path = STATE_PATH): boolean {
 }
 
 export function loadAllowlist(path = ALLOWLIST_PATH): string[] {
+  return loadToastPolicy(path).allow;
+}
+
+function cleanAllow(list: unknown): string[] {
+  if (!Array.isArray(list)) return [];
+  return list
+    .filter((h): h is string => typeof h === "string")
+    .map((h) => h.trim())
+    .filter((h) => h.length > 0);
+}
+
+/**
+ * Parse ~/.config/blip/allowlist.json.
+ *
+ *   missing file                         → all (new default: don't miss people)
+ *   { "mode": "off" }                    → silence
+ *   { "mode": "all" }                    → every inbound
+ *   { "mode": "allow", "allow": [...] }  → those senders only (empty = nobody)
+ *   { "allow": ["+1…"] } / ["+1…"]       → legacy populated list = allow
+ *   { "allow": [] } / []                 → legacy empty list = off
+ *   corrupt JSON                         → off (fail closed, don't spam)
+ */
+export function parseToastPolicy(raw: unknown): ToastPolicy {
+  if (raw == null) return { ...TOAST_ALL };
+  if (Array.isArray(raw)) {
+    const allow = cleanAllow(raw);
+    return allow.length > 0 ? { mode: "allow", allow } : { ...TOAST_OFF };
+  }
+  if (typeof raw !== "object") return { ...TOAST_ALL };
+  const obj = raw as Record<string, unknown>;
+  const allow = cleanAllow(obj.allow);
+  const mode = typeof obj.mode === "string" ? obj.mode.trim().toLowerCase() : "";
+  if (mode === "off") return { mode: "off", allow };
+  if (mode === "all") return { mode: "all", allow };
+  if (mode === "allow") return { mode: "allow", allow };
+  if (Array.isArray(obj.allow)) {
+    return allow.length > 0 ? { mode: "allow", allow } : { ...TOAST_OFF };
+  }
+  return { ...TOAST_ALL };
+}
+
+export function loadToastPolicy(path = ALLOWLIST_PATH): ToastPolicy {
   try {
-    const raw = JSON.parse(readFileSync(path, "utf8"));
-    const list = Array.isArray(raw) ? raw : raw?.allow;
-    return Array.isArray(list) ? list.filter((h: unknown) => typeof h === "string") : [];
-  } catch {
-    return [];
+    return parseToastPolicy(JSON.parse(readFileSync(path, "utf8")));
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    // Missing = never configured → notify everyone. Anything else (corrupt,
+    // EACCES) fails closed so a half-written file cannot spam or go silent-all.
+    return code === "ENOENT" ? { ...TOAST_ALL } : { ...TOAST_OFF };
   }
 }
 
@@ -409,35 +477,130 @@ export function toastKey(m: ImsgMessage): string {
 }
 
 /**
+ * Fold a handle for allowlist comparison.
+ *
+ * Emails are case-insensitive. Phone-shaped values compare on the last
+ * 10 digits so "+15551234567", "5551234567", and "(555) 123-4567" agree.
+ * Group ids and short codes are exact (after trim/casefold) — extracting
+ * digits from a hex GUID would false-match a phone (audit #8 territory).
+ */
+export function foldHandle(s: string): string {
+  const t = String(s || "").trim();
+  if (!t) return "";
+  if (t.includes("@")) return t.toLowerCase();
+  if (/^\+?[0-9\s().-]+$/.test(t)) {
+    const digits = t.replace(/\D/g, "");
+    if (digits.length >= 10) return digits.slice(-10);
+    return digits;
+  }
+  return t.toLowerCase();
+}
+
+/** True when `chat` or `handle` is on the allowlist. */
+export function allowlisted(chat: string, handle: string, allow: string[]): boolean {
+  if (allow.length === 0) return false;
+  const hay = [chat, handle].map((s) => String(s || "").trim()).filter((s) => s.length > 0);
+  for (const entry of allow) {
+    const e = entry.trim();
+    if (!e) continue;
+    const folded = foldHandle(e);
+    for (const h of hay) {
+      if (h === e) return true;
+      if (folded !== "" && foldHandle(h) === folded) return true;
+    }
+  }
+  return false;
+}
+
+/** Preview shown on the toast. Never empty; attachment-only rows say "New message". */
+export function toastPreview(text: string | null | undefined): string {
+  const raw = String(text ?? "").replace(/\uFFFC/g, "").replace(/\s+/g, " ").trim();
+  if (!raw) return "New message";
+  if (raw.length > TOAST_BODY_MAX) return raw.slice(0, TOAST_BODY_MAX - 1) + "…";
+  return raw;
+}
+
+export function toastName(m: ImsgMessage, groups?: Record<string, GroupInfo>): string {
+  const who = (m.name && String(m.name).trim()) || m.handle || chatKey(m) || "iMessage";
+  const chat = chatKey(m);
+  const group = groups && isGroupChat(chat) ? groups[chat] : undefined;
+  if (group?.name) return `${who} · ${group.name}`;
+  return who;
+}
+
+/**
+ * Canonical notify-send argv. QML renders this same flag set; ui.test.ts
+ * locks the two together. `--` is required: a name or body starting with
+ * `-` is data, not a flag (CLAUDE.md invariant).
+ */
+export function notifySendArgv(t: Pick<Toast, "chat" | "name" | "text">): string[] {
+  return [
+    "notify-send",
+    "--app-name=Blip",
+    "--icon=mail-message-new",
+    "--urgency=normal",
+    "--category=im.received",
+    `--expire-time=${TOAST_EXPIRE_MS}`,
+    "--wait",
+    "--action=default=Open",
+    "--",
+    t.name || t.chat || "iMessage",
+    toastPreview(t.text),
+  ];
+}
+
+export interface SelectToastsOpts {
+  /** Conversation the user is looking at right now — they did not miss it. */
+  skipChats?: Iterable<string>;
+  /** Self-thread ids; the from_me=false twin must not raise a toast. */
+  selfChats?: Iterable<string>;
+  groups?: Record<string, GroupInfo>;
+}
+
+/**
  * Pick the messages that earn a desktop notification.
  *
- * Gated three ways, because chat.db is mostly bank alerts and 2FA codes:
- *   1. inbound only, and strictly newer than the watermark
- *   2. sender (chat OR handle) is on the allowlist
- *   3. not already toasted — this is what stops the self-thread echo storm,
- *      where the user's own sent replies come back as from_me=false
+ *   1. policy.mode is not off
+ *   2. inbound only, strictly newer than the watermark (never the first-run backlog)
+ *   3. not the open conversation, not the self-thread
+ *   4. if mode=allow, sender (chat OR handle) matches the allowlist
+ *   5. not already toasted — stops the self-thread echo storm
+ *   6. newest TOAST_BATCH_CAP only — a catch-up after sleep must not dump 150 cards
  */
 export function selectToasts(
   msgs: ImsgMessage[],
   watermark: string,
-  allow: string[],
+  policy: ToastPolicy,
   toasted: string[],
+  opts: SelectToastsOpts = {},
 ): Toast[] {
   if (!watermark) return [];          // never toast the backlog on first run
-  const allowed = new Set(allow);
+  if (policy.mode === "off") return [];
+  const skip = new Set(opts.skipChats ?? []);
+  const self = new Set(opts.selfChats ?? []);
   const seen = new Set(toasted);
   const out: Toast[] = [];
 
   for (const m of msgs) {
     if (m.from_me) continue;
     if (m.ts <= watermark) continue;
-    if (!allowed.has(chatKey(m)) && !allowed.has(m.handle)) continue;
+    const chat = chatKey(m);
+    if (skip.has(chat) || self.has(chat)) continue;
+    if (policy.mode === "allow" && !allowlisted(chat, m.handle, policy.allow)) continue;
     const key = toastKey(m);
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push({ chat: chatKey(m), name: m.name ?? m.handle, text: m.text, ts: m.ts, key });
+    out.push({
+      chat,
+      name: toastName(m, opts.groups),
+      text: toastPreview(m.text),
+      ts: m.ts,
+      key,
+    });
   }
-  return out;
+
+  out.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  return out.length > TOAST_BATCH_CAP ? out.slice(-TOAST_BATCH_CAP) : out;
 }
 
 /** How far back a delivery failure is still worth interrupting for. */
@@ -827,7 +990,11 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
   // complete list in memory (it skips identical assignments anyway).
   const chats = deep ? fetchChats() : null;
   const threads = chats ? mergeChats(windowThreads, chats, groups, exactCounts) : windowThreads;
-  const toast = selectToasts(msgs, state.watermark, loadAllowlist(), state.toasted);
+  const toast = selectToasts(msgs, state.watermark, loadToastPolicy(), state.toasted, {
+    skipChats: readChat ? [readChat] : [],
+    selfChats,
+    groups,
+  });
   const failures = selectFailures(fetched.msgs, state.toasted, nowTs);
   const unread = Object.values(exactCounts).reduce((n, count) => n + count, 0);
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -10,7 +10,7 @@ inventory of what lands on disk.
 |---|---|---|
 | `~/.config/blip/bridge.conf` (0600) | Mac ssh target, remote tool dir, path of Blip's key, `automation=` switch | credentials |
 | `~/.ssh/blip_ed25519` | Blip's dedicated ssh key — confined on the Mac to the bridge tools | — |
-| `~/.config/blip/allowlist.json` | handles allowed to raise desktop toasts | message text |
+| `~/.config/blip/allowlist.json` | toast policy (`mode` all/allow/off) and optional handles; missing = notify every inbound | message text |
 | `~/.local/state/blip/state.json` (0600, atomic) | poll watermark, read marks, per-chat unread counts and oldest-unread timestamps, self-chat ids, group names/members, opaque SHA-256 toast keys | **message bodies — ever** |
 | `~/.local/state/blip/window.json` | whether the app window was open, its size | anything else |
 | `~/.cache/blip/att/` (0700, files 0600, 500 MB LRU, no expiry) | attachments you viewed (photos, PDFs…), fetched on demand; HEIC arrives converted to JPEG. File names carry the Mac's attachment row id and the sanitized original name | attachments you did not open |
@@ -19,9 +19,9 @@ inventory of what lands on disk.
 | `~/bin/imsg`, `~/bin/imsg-send`, `~/bin/contacts` | the bridge shim (a bash script) | — |
 
 Message text lives only in memory while the panel or window is open. Desktop
-toasts show a sender name and a preview through your notification daemon,
-gated by the allowlist — and your notification daemon may keep its own
-history. Blip itself logs nothing; the shell's stderr (journald) sees
+toasts show a sender name and a truncated preview through your notification
+daemon (every new inbound by default; `{ "mode": "off" }` or an allowlist
+restricts that) — and your notification daemon may keep its own history. Blip itself logs nothing; the shell's stderr (journald) sees
 recipients and exit codes, never bodies (`imsg-send` prints a byte count).
 Message bodies do pass through process arguments on both machines, visible
 to other processes running as you.

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "id": "nixfred.blip",
   "name": "Blip",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "Larry & Fred",
   "license": "MIT",
-  "description": "iMessage in the Omarchy bar. Reads and sends through a Mac you own over a multiplexed SSH socket — iMessage is macOS-only, so this machine is a thin client and the Mac is the gateway. Bar badge counts every unread; desktop toasts fire only for handles on your allowlist, because chat.db is mostly bank alerts and 2FA codes. Left-click = panel (thread list, history, compose). Middle-click = refresh. Right-click = mark all read.",
+  "description": "iMessage in the Omarchy bar. Reads and sends through a Mac you own over a multiplexed SSH socket — iMessage is macOS-only, so this machine is a thin client and the Mac is the gateway. Bar badge counts every unread; new inbound messages fire a system notification (optional allowlist if you want to quiet bank alerts and 2FA). Left-click = panel (thread list, history, compose). Middle-click = refresh. Right-click = mark all read.",
   "kinds": [
     "bar-widget"
   ],

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { notifySendArgv } from "./collector";
 
 // The renderer moved from Panel.qml into BlipView.qml in 1.8.0 (shared with the app window).
 const panel = readFileSync(new URL("./BlipView.qml", import.meta.url), "utf8");
@@ -40,5 +41,16 @@ describe("QML safety invariants", () => {
     const mark = panel.indexOf("markThreadRead(root.threadRunningChat)");
     expect(success).toBeGreaterThan(-1);
     expect(mark).toBeGreaterThan(success);
+  });
+
+  test("notify-send is the system-notification path and matches the canonical argv", () => {
+    // Logic lives in collector.notifySendArgv; QML must not drift off it.
+    const argv = notifySendArgv({ chat: "+1555", name: "Ada", text: "hi" });
+    for (const flag of argv) {
+      if (flag === "notify-send" || flag === "--" || flag === "Ada" || flag === "hi") continue;
+      expect(widget).toContain(flag);
+    }
+    expect(widget).toContain('"--"');
+    expect(widget).toContain("notify-send");
   });
 });


### PR DESCRIPTION
## What

New inbound iMessages fire a **system notification** (Omarchy's notification daemon via `notify-send`) instead of only lighting the tiny bar badge.

`~/.config/blip/allowlist.json` is now a toast *policy*, not a required gate:

- missing file → notify everyone (new default)
- `{ "mode": "off" }` → badge only
- `{ "mode": "allow", "allow": ["+1…"] }` → those senders
- legacy `{ "allow": ["+1…"] }` still filters; legacy `{ "allow": [] }` still means off

Also hardened: phone/email matching, skip the open conversation and the self-thread, cap a catch-up at 20, attachment-only rows say "New message", group toasts read `Alice · Family`, corrupt policy file fails closed.

## Why

The bar badge is easy to miss. Toasts were allowlist-gated, and an empty/missing file meant silence, so most installs never interrupted. Clicking the toast still opens that conversation with compose focused.

If you liked the old quiet default:

```json
{ "mode": "off" }
```

## How it was verified

- [x] `bun test` is green (CI will check) — **206 pass**, 0 fail
- [x] Any send/receive behavior was exercised against **my own number only** — never a contact or a group
  - this change does not send; collector logic is unit-tested without `imsg-send`
  - `notify-send --app-name=Blip` was exercised locally against Omarchy's daemon
- [ ] UI change → screenshot attached
  - notifications are the system daemon's card, not a Blip layout change
- [x] Touches an invariant in `CLAUDE.md` → named below, and the doc updated if it changed

Invariants touched:
- **Pass `--` before message text** on `notify-send` (`notifySendArgv` + `ui.test.ts` contract)
- **Two read marks** — toasts still keyed off `watermark`, not `readMark`
- **No message content in state.json** — still opaque SHA-256 toast keys only
- **Toasts are a policy** — new invariant documenting mode=all/allow/off, open-chat skip, batch cap, `toastPreview`