### PR TITLE
fix: bar double-click + Android SMS/RCS

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -138,7 +138,12 @@ BarWidget {
   // Single click = panel (opens immediately — no double-click lag); a second
   // click within the double-click window = close the panel and open the APP.
   Timer { id: dblClick; interval: 320 }
+  property bool suppressNextLeftClick: false
   function leftClick() {
+    if (suppressNextLeftClick) {
+      suppressNextLeftClick = false
+      return
+    }
     if (dblClick.running) {
       dblClick.stop()
       root.close()
@@ -568,6 +573,14 @@ BarWidget {
       if (code === Qt.MiddleButton) root.refresh(false, false)
       else if (code === Qt.RightButton) root.markAllRead()
       else root.leftClick()
+    }
+    onDoublePressed: function(code) {
+      if (code === Qt.LeftButton) {
+        suppressNextLeftClick = true
+        dblClick.stop()
+        root.close()
+        root.showApp()
+      }
     }
 
     Row {

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -598,7 +598,9 @@ FocusScope {
       // send-file.ts owns target resolution (group guid or DM handle).
       sendDraftPath = draftPath
       // caption on stdin — never in this process's argv (audit #4, war room #1/#13)
-      fileSendProc.command = ["bun", root.sendFileScript, sendChat, draftPath, "--caption-stdin"]
+      var svc2 = String(root.active.service || "iMessage")
+      if (svc2 !== "iMessage" && svc2 !== "SMS" && svc2 !== "RCS") svc2 = "iMessage"
+      fileSendProc.command = ["bun", root.sendFileScript, sendChat, draftPath, "--service", svc2, "--caption-stdin"]
       fileSendProc.stdinEnabled = true
       fileSendProc.running = true
       fileSendProc.write(trimmed !== "" ? text : "")
@@ -608,10 +610,13 @@ FocusScope {
 
     // Body on STDIN (--text-stdin), never argv: argv is readable by every
     // process on this machine and travels through ssh into the Mac's ps.
+    // SMS/RCS vs iMessage: active.service travels from chat.db (collector.ts:386)
+    var svc = String(root.active.service || "iMessage")
+    if (svc !== "iMessage" && svc !== "SMS" && svc !== "RCS") svc = "iMessage"
     var target = root.activeIsGroup
       ? ["--chat-id", String(root.active.guid)]
       : ["--to", sendChat]
-    sendProc.command = [root.home + "/bin/imsg-send"].concat(target).concat(["--yes", "--text-stdin", "--keep-dashes"])
+    sendProc.command = [root.home + "/bin/imsg-send"].concat(target).concat(["--service", svc, "--yes", "--text-stdin", "--keep-dashes"])
     sendProc.stdinEnabled = true
     sendProc.running = true
     sendProc.write(text)

--- a/send-file.ts
+++ b/send-file.ts
@@ -45,6 +45,7 @@ export function sendFile(
   path: string,
   caption: string,
   runner = spawnSync,
+  service = "iMessage",
 ): SendFileResult {
   const fail = (error: string, online = true): SendFileResult => ({ ok: false, online, error });
 
@@ -81,8 +82,10 @@ export function sendFile(
   // Caption rides on stdin ahead of the file bytes (--text-stdin-bytes N), so
   // message text never appears in any process's argv on either machine.
   const cap = Buffer.from(caption.trim(), "utf8");
+  const svc = service === "SMS" || service === "RCS" ? service : "iMessage";
   const args = [
     ...target.args,
+    "--service", svc,
     "--file-stdin",
     "--name", basename(path),
     "--yes",
@@ -102,12 +105,21 @@ export function sendFile(
 if (import.meta.main) {
   const chat = process.argv[2] ?? "";
   const path = process.argv[3] ?? "";
+  // Optional --service flag may appear before --caption-stdin; allow both orders.
+  let svc = "iMessage";
+  let captionIdx = 4;
+  if (process.argv[4] === "--service" && process.argv[5]) {
+    svc = String(process.argv[5]);
+    captionIdx = 6;
+  } else if (process.argv[4] === "--service") {
+    captionIdx = 5;
+  }
   // Caption arrives on stdin (--caption-stdin) so it never sits in this process's argv.
-  const caption = process.argv[4] === "--caption-stdin"
+  const caption = process.argv[captionIdx] === "--caption-stdin"
     ? readFileSync(0, "utf8")
-    : process.argv.slice(4).join(" ");
+    : process.argv.slice(captionIdx).join(" ");
   try {
-    console.log(JSON.stringify(sendFile(chat, path, caption)));
+    console.log(JSON.stringify(sendFile(chat, path, caption, undefined, svc)));
   } catch (e) {
     console.log(JSON.stringify({ ok: false, online: true, error: String(e) }));
   }


### PR DESCRIPTION
Fixes two user-facing bugs found after Tailscale setup

**Bar double-click opening app**
- `BarWidget.qml` handled double-click via a Timer on `onClicked` (`dblClick 320ms`). Omarchy's `Bar.qml:1477` `CenterGestureArea.onDoubleClicked` toggles `transparent` on empty-space double-click. `WidgetButton` only emitted `pressed` on `onClicked`, never `onDoubleClicked`, and `ModuleSlot.modulePointer` (which sits atop the widget) only handled `onClicked` via `pressModuleClickTarget`. Double-clicks fell through to the bar background → bar flashed transparent instead of opening the app.
- Fix: `Ui/WidgetButton.qml` adds `signal doublePressed` and `onDoubleClicked: {accept; doublePressed}`, `Bar.qml` `modulePointer.onDoubleClicked` forwards to `target.doublePressed` and always `accept`s to block `CenterGestureArea`, `BarWidget.qml` adds `suppressNextLeftClick` to swallow the pending second `leftClick` after the native double.

**Android SMS/RCS not sending**
- `BlipView.qml:611` always called `imsg-send --to <handle> --yes` defaulting to `iMessage` (`imsg-send:434`). Threads from `collector.ts:386` carry `service` (`SMS`/`RCS`/`iMessage`), `chats` shows duplicate ids per service (e.g. `+16789671419` has `RCS 1240` and `SMS 8102`). Android contacts on `SMS`/`RCS` failed silently (`error` → `selectFailures`).
- Fix: `BlipView.qml` honors `active.service` → `--service SMS/RCS/iMessage` for both text and file sends; `send-file.ts` adds `--service` param and threads it to `imsg-send`.

**Also:** `BlipView.qml:288` `openLink` jq filter fix is already upstream (`$2` argv) - included.

Test: `bun test --cwd . ./collector.test.ts` 90 pass, `thread.test.ts` 54 pass, `tier2.test.ts` 36 pass, `ui.test.ts` 6 pass; `qs ipc call nixfred.blip app` → `org.quickshell|Blip` mapped.

System patches (`Ui/WidgetButton.qml`, `Bar.qml:modulePointer`) belong in `basecamp/omarchy` - this PR is the Blip side. Happy to split if preferred.

Closes: bar double-click transparency, Android send via correct service.