### PR TITLE
Fill the app window like other Omarchy windows

### DIFF
--- a/BlipWindow.qml
+++ b/BlipWindow.qml
@@ -21,10 +21,9 @@ FloatingWindow {
   property var hostWidget: null
   // "Blip (3)" while unread exists — selectors match the "Blip" PREFIX.
   title: "Blip" + (hostWidget && hostWidget.unread > 0 ? " (" + hostWidget.unread + ")" : "")
-  // Translucent like the rest of Omarchy: Hyprland blurs what shows through
-  // (decoration.blur is on; no no_blur rule for org.quickshell). Fred, 2.0.2.
-  readonly property real backdropAlpha: 0.70
-  color: Qt.rgba(Color.background.r, Color.background.g, Color.background.b, backdropAlpha)
+  // Same fill as Omarchy's other FloatingWindow (dev gallery). A 0.70
+  // alpha assumed Hyprland blur, which Omarchy 4.x ships off.
+  color: Color.background
   implicitWidth: 1040
   implicitHeight: 720
   minimumSize: Qt.size(720, 480)


### PR DESCRIPTION
Omarchy 4.x turned off Hyprland `decoration.blur` in
[`935283c8`](https://github.com/omacom/omarchy/commit/935283c8492c0e83a58775bc1d83e4ba6bd420eb)
("Simplify rendering"). A later revert
([#7409](https://github.com/omacom/omarchy/pull/7409)) restated that
windows already sit at 0.985/0.96 opacity, so blur was GPU work for
almost nothing.

`BlipWindow` still mixed `Color.background` with `backdropAlpha: 0.70`
on the assumption that blur was on. Without blur, the wallpaper shows
through the Super+M window.

The shell's other `FloatingWindow` (dev gallery) sets `color:
Color.background` and lets Hyprland's default-opacity rule do the rest.
This does the same and drops `backdropAlpha`.

Tested on Omarchy 4.0.2 with blur off.