### PR TITLE
fix(bridge): keep one chat row per group so sends stop failing with -1728

### DIFF
--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -637,10 +637,24 @@ def cmd_groups(con, args):
                  WHERE cmj.chat_id = c.ROWID) AS last_date
         FROM chat c
         WHERE c.style = 43
-        ORDER BY last_date DESC
-        LIMIT ?""",
-        (args.n,),
+        ORDER BY last_date DESC""",
     ).fetchall()
+    # macOS keeps one `chat` row per service, so one conversation that moved
+    # from iMessage to SMS to RCS leaves several rows sharing a chat_identifier.
+    # The rows it no longer uses hold zero messages, and AppleScript cannot
+    # resolve one of those: `send ... to chat id "SMS;+;chat<digits>"`
+    # fails with -1728, "Can't get chat id". Callers key on chat_identifier and
+    # let the last row win, so an empty row can replace the live one.
+    # Rows arrive newest first and SQLite sorts a NULL last_date last, so the
+    # first row for an identifier is the live one. Keep it and drop the rest.
+    seen = set()
+    live = []
+    for r in rows:
+        if r["chat_identifier"] in seen:
+            continue
+        seen.add(r["chat_identifier"])
+        live.append(r)
+    rows = live[: args.n]
     if args.json:
         print(
             json.dumps(


### PR DESCRIPTION
## The bug

Sending to a group chat can fail with:

```
send failed: text (26:293: execution error: Messages got an error:
Can't get chat id "SMS;+;chat<digits>". (-1728))
```

Messages is right. That chat does not exist.

macOS keeps a separate `chat` row for every service. A group that moved between
iMessage, SMS and RCS leaves several rows that share one `chat_identifier` and
differ only by guid. Only one row holds messages. The others are empty shells,
and AppleScript cannot resolve an empty one.

## Why Blip picks the wrong one

`imsg groups` returned every row. `fetchGroups()` in `collector.ts` builds
`out[r.chat] = {...}` keyed on the bare identifier, so the last row wins.

The query ends `ORDER BY last_date DESC`, and SQLite sorts NULL **last** for
DESC. An empty row has a NULL `last_date`, so it arrives last and overwrites the
live entry. `BlipView.qml` then sends `--chat-id <that guid>`.

## Scale

This is not a rare edge case. On one Mac with 489 group rows:

- 28 identifiers had more than one row
- 27 of them resolved to a row with zero messages

Every one of those 27 conversations failed to send, in the panel and from the
CLI. Any US user whose group moved to RCS is exposed.

## The fix

Dedupe at the source, in `cmd_groups`. Drop the SQL `LIMIT`, keep the first row
for each `chat_identifier` (rows already arrive newest first, so that is the live
one), then apply the limit. Every caller now gets one row per conversation and
never an empty guid.

I fixed the bridge rather than `fetchGroups()` because `imsg --json groups`
returning two entries with the same `chat` key is the defect. Fixing it here also
covers the CLI and any future caller.

## Verification

Before:

```
rows returned: 489
duplicate identifiers: 28
<the affected group>  ->  SMS;+;chat<digits>   (0 messages)
```

After:

```
rows returned: 461
duplicate identifiers: 0
<the affected group>  ->  RCS;+;chat<digits>   (19 messages, last today)
```

Sends to all 27 conversations work again. Confirmed end to end through the Linux
shim, not only on the Mac.

## Known limit

A conversation whose only row is empty still returns that row. There is no better
guid to offer, and dropping it would hide the chat from the list. One such chat
existed on the test Mac. It was already deleted on the Mac side.

## Notes

- `python3 -m py_compile bridge/mac/imsg` passes, matching CI.
- No behavior change for anyone without duplicate rows.
- Real chat identifiers and phone numbers are redacted throughout.
