### PR TITLE
fix: honour EXIF orientation so iPhone photos stop rendering sideways (inline + viewer)

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1263,6 +1263,7 @@ FocusScope {
                       source: root.avatarFiles[avatarCircle.avatarHandle] || ""
                       asynchronous: true
                       fillMode: Image.PreserveAspectCrop
+                      autoTransform: true
                       sourceSize.width: 96
                       sourceSize.height: 96
                       // a stale/corrupt cache file → initials, and no retry this session
@@ -1620,6 +1621,11 @@ FocusScope {
                       source: chipRow.showImage ? chipRow.fileUrl : ""
                       asynchronous: true
                       fillMode: Image.PreserveAspectFit
+                      // iPhone photos store rotation as an EXIF tag, not in
+                      // the pixels (sips keeps the tag when it converts HEIC);
+                      // Qt ignores it unless asked, so portraits came out on
+                      // their side. implicitWidth/Height follow the transform.
+                      autoTransform: true
                       // bound the DECODE in BOTH axes, not just the paint — a
                       // 12MP photo (or a 100×100000 sliver) must not cost
                       // 50 MB of texture (Codex review points 19 and #3)
@@ -1713,6 +1719,7 @@ FocusScope {
                         source: linkCard.imgUrl
                         asynchronous: true
                         fillMode: Image.PreserveAspectCrop
+                        autoTransform: true
                         sourceSize.width: 800
                         sourceSize.height: 800
                       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
-- **iPhone photos rendered on their side.** A camera photo stores its
-  rotation as an EXIF orientation tag, and `sips` keeps that tag when the
-  bridge converts HEIC to JPEG — so the pixels arrive landscape with a
-  "rotate 90°" note Qt only honours on request. Every `Image` in the
-  conversation (inline attachments, link-card previews, avatars) now sets
-  `autoTransform: true`; `implicitWidth`/`implicitHeight` follow the
-  rotated shape, so the bubble sizes correctly too. (Adam Gamble)
+- **iPhone photos rendered on their side — inline AND in the viewer.** A
+  camera photo stores its rotation as an EXIF orientation tag, and `sips`
+  keeps that tag when the bridge converts HEIC to JPEG — so the pixels
+  arrive landscape with a "rotate 90°" note that Qt only honours on request
+  and imv (Omarchy's default viewer) never does. Two fixes: every `Image` in
+  the conversation sets `autoTransform: true`, and `fetch.ts` now bakes the
+  orientation into the cached JPEG losslessly with `jpegtran` (libjpeg-turbo,
+  already on every Qt box) — colour profile kept, EXIF dropped so nothing
+  double-rotates. Files cached before this release stay as they were; clear
+  `~/.cache/blip/att` to re-fetch them upright. (Adam Gamble)
 
 ## 2.2.2 — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- **iPhone photos rendered on their side.** A camera photo stores its
+  rotation as an EXIF orientation tag, and `sips` keeps that tag when the
+  bridge converts HEIC to JPEG — so the pixels arrive landscape with a
+  "rotate 90°" note Qt only honours on request. Every `Image` in the
+  conversation (inline attachments, link-card previews, avatars) now sets
+  `autoTransform: true`; `implicitWidth`/`implicitHeight` follow the
+  rotated shape, so the bubble sizes correctly too. (Adam Gamble)
+
 ## 2.2.2 — 2026-09-02
 
 - **Group sends failed with -1728 on Macs that keep one chat row per

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,11 +142,16 @@ what it is handed. Keep it that way.
   re-maps one), and focus is fired via `Quickshell.execDetached` — a
   `Process` silently ignores `running=true` on the zombie. Deploy with a
   restart, never rely on hot-reload for anything IPC.
-- **Every `Image` sets `autoTransform: true`.** iPhone photos carry rotation
-  as an EXIF tag; `sips` preserves it when converting HEIC, and Qt ignores it
-  by default — a portrait photo renders on its side (4032×3024 pixels tagged
-  "Rotate 90 CW"). With the flag, implicit size follows the rotation and the
-  `sourceSize` decode bound still applies. Verified on Qt 6.11.
+- **EXIF orientation is baked at fetch time, and every `Image` sets
+  `autoTransform: true`.** iPhone photos carry rotation as an EXIF tag;
+  `sips` preserves it when converting HEIC, Qt ignores it by default, and imv
+  (Omarchy's default viewer, what `xdg-open` launches) ignores it always —
+  a portrait photo rendered on its side in both places (4032×3024 pixels
+  tagged "Rotate 90 CW"). `fetch.ts` rotates the JPEG losslessly with
+  `jpegtran -copy icc` (libjpeg-turbo, a hard dependency of Qt) before
+  caching, dropping the EXIF block so nothing double-rotates; the QML flag
+  covers files cached before that, and the fall-back when jpegtran fails.
+  Never move this to the Mac side: `sips` cannot auto-orient.
 - **Never let one delegate's implicit width exceed the panel.** A single
   RowLayout of N attachment chips summed implicit widths and silently
   stretched the whole conversation column to 2× panel width — every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,11 @@ what it is handed. Keep it that way.
   re-maps one), and focus is fired via `Quickshell.execDetached` — a
   `Process` silently ignores `running=true` on the zombie. Deploy with a
   restart, never rely on hot-reload for anything IPC.
+- **Every `Image` sets `autoTransform: true`.** iPhone photos carry rotation
+  as an EXIF tag; `sips` preserves it when converting HEIC, and Qt ignores it
+  by default — a portrait photo renders on its side (4032×3024 pixels tagged
+  "Rotate 90 CW"). With the flag, implicit size follows the rotation and the
+  `sourceSize` decode bound still applies. Verified on Qt 6.11.
 - **Never let one delegate's implicit width exceed the panel.** A single
   RowLayout of N attachment chips summed implicit widths and silently
   stretched the whole conversation column to 2× panel width — every

--- a/fetch.ts
+++ b/fetch.ts
@@ -98,6 +98,95 @@ function evict(keep: string): void {
   }
 }
 
+/** EXIF orientation (1–8) of a JPEG, or 1 when absent or unparseable. Walks
+ *  the marker chain only as far as the first APP1 Exif segment and never
+ *  decodes pixels. Pure, bounds-checked at every read. */
+export function exifOrientation(b: Buffer): number {
+  if (b.length < 4 || b[0] !== 0xff || b[1] !== 0xd8) return 1;
+  let p = 2;
+  while (p + 4 <= b.length) {
+    if (b[p] !== 0xff) return 1;
+    const marker = b[p + 1];
+    if (marker === 0xff) { p += 1; continue; }                       // fill byte
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) { p += 2; continue; }  // standalone
+    if (marker === 0xda || marker === 0xd9) return 1;                // scan data / EOI: no EXIF ahead
+    const len = b.readUInt16BE(p + 2);
+    if (len < 2 || p + 2 + len > b.length) return 1;
+    if (marker === 0xe1 && len >= 16 && b.toString("latin1", p + 4, p + 10) === "Exif\0\0") {
+      return tiffOrientation(b.subarray(p + 10, p + 2 + len));
+    }
+    p += 2 + len;
+  }
+  return 1;
+}
+
+function tiffOrientation(t: Buffer): number {
+  if (t.length < 8) return 1;
+  const bo = t.toString("latin1", 0, 2);
+  const le = bo === "II";
+  if (!le && bo !== "MM") return 1;
+  const u16 = (o: number) => (le ? t.readUInt16LE(o) : t.readUInt16BE(o));
+  const u32 = (o: number) => (le ? t.readUInt32LE(o) : t.readUInt32BE(o));
+  if (u16(2) !== 0x2a) return 1;
+  const ifd = u32(4);
+  if (ifd + 2 > t.length) return 1;
+  const n = u16(ifd);
+  for (let i = 0; i < n; i++) {
+    const e = ifd + 2 + i * 12;
+    if (e + 12 > t.length) return 1;
+    if (u16(e) === 0x0112) {
+      if (u16(e + 2) !== 3) return 1;   // must be a SHORT
+      const v = u16(e + 8);
+      return v >= 1 && v <= 8 ? v : 1;
+    }
+  }
+  return 1;
+}
+
+/** The lossless jpegtran operation that undoes an EXIF orientation, or null
+ *  when the image is already upright (1) or the tag is nonsense. */
+export function jpegtranArgs(orientation: number): string[] | null {
+  switch (orientation) {
+    case 2: return ["-flip", "horizontal"];
+    case 3: return ["-rotate", "180"];
+    case 4: return ["-flip", "vertical"];
+    case 5: return ["-transpose"];
+    case 6: return ["-rotate", "90"];
+    case 7: return ["-transverse"];
+    case 8: return ["-rotate", "270"];
+    default: return null;
+  }
+}
+
+/** Bake an EXIF orientation into the pixels so the cached file is upright in
+ *  EVERY consumer, not just Qt: a photo taken in portrait arrives from the
+ *  Mac as landscape pixels plus a "rotate 90" tag (sips keeps the tag when
+ *  it converts HEIC), and imv — Omarchy's default viewer — ignores EXIF.
+ *  jpegtran (libjpeg-turbo, a hard dependency of Qt so always installed) does
+ *  the transform losslessly on stdin→stdout; `-copy icc` keeps the colour
+ *  profile (iPhone photos are Display P3) and drops the EXIF block, so no
+ *  stale orientation tag survives to double-rotate in Qt. The same library
+ *  decodes these bytes in the panel anyway, so this adds no attack surface.
+ *  Any failure (no jpegtran, bad stream) keeps the original bytes — the
+ *  panel's autoTransform still shows those upright. */
+export function bakeOrientation(bytes: Buffer, runner = spawnSync): Buffer {
+  const op = jpegtranArgs(exifOrientation(bytes));
+  if (!op) return bytes;
+  let res: { status: number | null; stdout: Buffer | string };
+  try {
+    res = runner("jpegtran", [...op, "-trim", "-copy", "icc"], {
+      input: bytes,
+      timeout: 30000,
+      maxBuffer: FETCH_MAX_BYTES + (1 << 20),
+    });
+  } catch {
+    return bytes;
+  }
+  const out = res.stdout as Buffer;
+  if (res.status !== 0 || !out || out.length < 4 || out[0] !== 0xff || out[1] !== 0xd8) return bytes;
+  return out;
+}
+
 export interface FetchResult {
   ok: boolean;
   online: boolean;
@@ -140,9 +229,10 @@ export function fetchAttachment(
     const err = (res.stderr || "").toString().trim().split("\n")[0] || `imsg exit ${res.status}`;
     return fail(err);
   }
-  const bytes = res.stdout as Buffer;
-  if (!bytes || bytes.length === 0) return fail("empty attachment stream");
-  if (bytes.length > Math.min(maxBytes, FETCH_MAX_BYTES)) return fail("attachment exceeds the fetch ceiling");
+  const raw = res.stdout as Buffer;
+  if (!raw || raw.length === 0) return fail("empty attachment stream");
+  if (raw.length > Math.min(maxBytes, FETCH_MAX_BYTES)) return fail("attachment exceeds the fetch ceiling");
+  const bytes = bakeOrientation(raw, runner);
 
   // tmp + fsync + rename: a killed fetch must never leave a cache hit that
   // looks complete.

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -1,11 +1,46 @@
 import { describe, expect, test } from "bun:test";
 
-import { cacheFileName, fetchAttachment, lruEvictions, sanitizeName, wantsJpeg } from "./fetch";
+import { CACHE_DIR, bakeOrientation, cacheFileName, exifOrientation, fetchAttachment, jpegtranArgs, lruEvictions, sanitizeName, wantsJpeg } from "./fetch";
 import { extFor, pickImageType } from "./paste";
 import { resolveTarget, sendFile } from "./send-file";
 import { linkHost, linkify, normalizeLink, selectThread } from "./thread";
 import { AVATAR_DIR, avatarKey, fetchAvatar } from "./avatar";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+// A real 16×8 baseline JPEG (ImageMagick, -strip): no APP1 at all.
+const TINY_JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABsSFBcUERsXFhceHBsgKEIrKCUlKFE6PTBCYFVlZF9VXVtqeJmBanGQc1tdhbWGkJ6jq62rZ4C8ybqmx5moq6T/2wBDARweHigjKE4rK06kbl1upKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKT/wAARCAAIABADASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAT/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAABAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCAANSP/9k=",
+  "base64",
+);
+
+/** Insert an APP1 Exif segment carrying just an Orientation tag after SOI. */
+function withExif(jpeg: Buffer, orientation: number, littleEndian = true): Buffer {
+  const tiff = Buffer.alloc(8 + 2 + 12 + 4);
+  const w16 = (o: number, v: number) => (littleEndian ? tiff.writeUInt16LE(v, o) : tiff.writeUInt16BE(v, o));
+  const w32 = (o: number, v: number) => (littleEndian ? tiff.writeUInt32LE(v, o) : tiff.writeUInt32BE(v, o));
+  tiff.write(littleEndian ? "II" : "MM", 0, "latin1");
+  w16(2, 0x2a); w32(4, 8);          // IFD0 at offset 8
+  w16(8, 1);                        // one entry
+  w16(10, 0x0112); w16(12, 3); w32(14, 1); w16(18, orientation); w16(20, 0);
+  w32(22, 0);                       // no IFD1
+  const body = Buffer.concat([Buffer.from("Exif\0\0", "latin1"), tiff]);
+  const seg = Buffer.alloc(4);
+  seg[0] = 0xff; seg[1] = 0xe1; seg.writeUInt16BE(body.length + 2, 2);
+  return Buffer.concat([jpeg.subarray(0, 2), seg, body, jpeg.subarray(2)]);
+}
+
+/** Width × height from the SOF0/SOF2 marker. */
+function sofSize(b: Buffer): [number, number] {
+  for (let p = 2; p + 9 < b.length; ) {
+    const m = b[p + 1];
+    const len = b.readUInt16BE(p + 2);
+    if (m === 0xc0 || m === 0xc2) return [b.readUInt16BE(p + 7), b.readUInt16BE(p + 5)];
+    p += 2 + len;
+  }
+  return [0, 0];
+}
 
 describe("fetch cache", () => {
   test("HEIC wants a Mac-side JPEG conversion, others stream raw", () => {
@@ -61,6 +96,67 @@ describe("fetch cache", () => {
     const r = fetchAttachment("123456789012345", "x.png", "image/png", runner);
     expect(r.ok).toBe(false);
     expect(r.online).toBe(false);
+  });
+});
+
+describe("EXIF orientation is baked into cached JPEGs", () => {
+  test("orientation is read from APP1 in either byte order; anything else is 1", () => {
+    expect(exifOrientation(TINY_JPEG)).toBe(1);
+    expect(exifOrientation(withExif(TINY_JPEG, 6))).toBe(6);
+    expect(exifOrientation(withExif(TINY_JPEG, 8, false))).toBe(8);
+    expect(exifOrientation(withExif(TINY_JPEG, 9))).toBe(1);        // out of range
+    expect(exifOrientation(withExif(TINY_JPEG, 6).subarray(0, 20))).toBe(1);  // truncated
+    expect(exifOrientation(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0, 0, 0, 0]))).toBe(1);  // PNG
+    expect(exifOrientation(Buffer.alloc(0))).toBe(1);
+  });
+
+  test("each orientation maps to its lossless jpegtran transform", () => {
+    expect(jpegtranArgs(1)).toBeNull();
+    expect(jpegtranArgs(3)).toEqual(["-rotate", "180"]);
+    expect(jpegtranArgs(6)).toEqual(["-rotate", "90"]);   // iPhone portrait
+    expect(jpegtranArgs(8)).toEqual(["-rotate", "270"]);
+    expect(jpegtranArgs(5)).toEqual(["-transpose"]);
+    expect(jpegtranArgs(0)).toBeNull();
+  });
+
+  test("upright and non-JPEG bytes never spawn jpegtran", () => {
+    let spawned = 0;
+    const runner = (() => { spawned++; return { status: 0, stdout: Buffer.alloc(0) }; }) as never;
+    expect(bakeOrientation(TINY_JPEG, runner)).toBe(TINY_JPEG);
+    expect(bakeOrientation(Buffer.from("not a jpeg"), runner)).toEqual(Buffer.from("not a jpeg"));
+    expect(spawned).toBe(0);
+  });
+
+  test("a fetched portrait photo is cached rotated, ICC kept, EXIF dropped", () => {
+    const tagged = withExif(TINY_JPEG, 6);
+    const rotated = Buffer.concat([Buffer.from([0xff, 0xd8]), Buffer.from("ROTATED")]);
+    let seen: { args: string[]; input: Buffer } | null = null;
+    const runner = ((cmd: string, args: string[], opts: { input?: Buffer }) => {
+      if (cmd === "jpegtran") { seen = { args, input: opts.input! }; return { status: 0, stdout: rotated, stderr: "" }; }
+      return { status: 0, stdout: tagged, stderr: "" };
+    }) as never;
+    const r = fetchAttachment("123456789012347", "IMG_1.heic", "image/heic", runner);
+    expect(r.ok).toBe(true);
+    expect(seen!.args).toEqual(["-rotate", "90", "-trim", "-copy", "icc"]);
+    expect(seen!.input.equals(tagged)).toBe(true);           // bytes on stdin, never argv
+    expect(readFileSync(join(CACHE_DIR, cacheFileName("123456789012347", "IMG_1.heic", "image/heic"))).equals(rotated)).toBe(true);
+  });
+
+  test("when jpegtran is missing or fails, the original bytes are cached", () => {
+    const tagged = withExif(TINY_JPEG, 6);
+    const runner = ((cmd: string) =>
+      cmd === "jpegtran" ? { status: null, stdout: null, error: new Error("ENOENT") } : { status: 0, stdout: tagged, stderr: "" }) as never;
+    const r = fetchAttachment("123456789012348", "IMG_2.heic", "image/heic", runner);
+    expect(r.ok).toBe(true);
+    expect(readFileSync(r.path).equals(tagged)).toBe(true);
+  });
+
+  const haveJpegtran = spawnSync("jpegtran", ["-help"]).status !== null;
+  test.skipIf(!haveJpegtran)("real jpegtran turns a tagged 16×8 into an upright 8×16", () => {
+    const out = bakeOrientation(withExif(TINY_JPEG, 6));
+    expect(sofSize(withExif(TINY_JPEG, 6))).toEqual([16, 8]);
+    expect(sofSize(out)).toEqual([8, 16]);
+    expect(exifOrientation(out)).toBe(1);                    // tag gone: no double rotation in Qt
   });
 });
 


### PR DESCRIPTION
## Problem

Photos taken on an iPhone render on their side, both inline in the conversation and in the viewer that opens on click. A camera photo stores its rotation as an EXIF orientation tag rather than in the pixels, and `sips` keeps that tag when the bridge converts HEIC to JPEG. The file that lands in `~/.cache/blip/att` is 4032×3024 landscape pixels tagged "Rotate 90 CW". Qt's `Image` ignores that tag unless asked, and imv (Omarchy's default image viewer, what `xdg-open` launches) has no EXIF support at all.

## Fix, in two commits

**1. `autoTransform: true`** on the three `Image` elements in `BlipView.qml`: the inline attachment, the link-card preview, and the avatar. Qt applies the EXIF transform at decode time, and `implicitWidth`/`implicitHeight` follow the rotated shape, so the bubble sizes correctly too.

Verified on Qt 6.11.2 (what Quickshell links against here) with a cached photo:

| | implicit size |
|---|---|
| `autoTransform: false` | 800 × 600 |
| `autoTransform: true` | 600 × 800 |

Same result on the `asynchronous: true` path, and the 800 px `sourceSize` decode bound still applies.

**2. Bake the orientation into the cached file** in `fetch.ts`, so every consumer is upright, not just Qt. A pure, bounds-checked walk of the JPEG markers reads the orientation (no pixel decode); when it isn't 1, the bytes go through `jpegtran <op> -trim -copy icc` on stdin/stdout before caching.

- Lossless, ~50 ms on a 12 MP photo.
- `-copy icc` keeps the colour profile (iPhone photos are Display P3) and drops the EXIF block, so no stale tag survives to double-rotate in Qt.
- `jpegtran` ships with libjpeg-turbo, which Qt itself links, so it is on every Quickshell box. The same library already decodes these bytes in the panel, so no new parser meets untrusted input.
- Any failure (binary missing, bad stream) keeps the original bytes; commit 1 still shows those upright inline.

Six tests: the parser in both byte orders plus truncated / out-of-range / PNG inputs, the op mapping, no spawn for upright or non-JPEG bytes, the injected-runner fetch path (args, stdin transport, cached bytes), the failure fall-back, and a real `jpegtran` run (skipped where the binary is absent) proving a tagged 16×8 becomes an upright 8×16 with no tag left.

Verified live: the same photo re-fetched as 3024×4032, no Orientation tag, Display P3 retained, 0600.

Files cached before this change keep their tag; they render upright inline (commit 1) but open sideways in imv until evicted or `~/.cache/blip/att` is cleared. Noted in the changelog entry.

Also adds an Unreleased changelog entry and an invariant note in `CLAUDE.md` so neither half gets "simplified" away later. Feel free to drop either if you'd rather own those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5w1SF7gHaXPrUnoG4BCWN
