### PR TITLE
fix(ui): square the bubble corner with a per-corner radius, not a stacked tail

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1789,14 +1789,12 @@ FocusScope {
 
                     // iMessage squares off the corner nearest the sender on the
                     // last bubble of a run — the "tail" without drawing a tail.
-                    Rectangle {
-                      visible: modelData.groupEnd === true
-                      width: Style.space(16); height: Style.space(16)
-                      color: bubble.color
-                      anchors.bottom: parent.bottom
-                      anchors.right: bubbleRow.mine ? parent.right : undefined
-                      anchors.left: bubbleRow.mine ? undefined : parent.left
-                    }
+                    // Per-corner radius (Qt 6.7+), NOT a second Rectangle over
+                    // the corner: theirsFill is translucent, and stacking two
+                    // copies of it double-alphas the overlap into a visibly
+                    // lighter square (seen on every received run-ending bubble).
+                    bottomLeftRadius: modelData.groupEnd === true && !bubbleRow.mine ? 0 : radius
+                    bottomRightRadius: modelData.groupEnd === true && bubbleRow.mine ? 0 : radius
 
                     // TextEdit, not Text: read-only but selectable, so a message
                     // can be highlighted and Ctrl+C'd like any other text.


### PR DESCRIPTION
## Problem

Every received bubble that ends a run shows a lighter grey square in its bottom-left corner, where the "tail" is.

`theirsFill` is translucent (`foreground` at 14% alpha). The tail was a second `Rectangle` in `bubble.color` drawn over the corner, so the overlap composites the same translucent colour twice and reads as a lighter block. Sent bubbles never showed it because the accent fill is opaque.

## Fix

Square off the real corner with Qt 6.7+ per-corner radii on the bubble (`bottomLeftRadius` / `bottomRightRadius` to 0 on the sender's side when `groupEnd`) and drop the stacked rectangle. No overlap, so it holds for any fill alpha. One file, 6 insertions, 8 deletions.

Confirmed on screen with Quickshell 0.3.1 / Qt 6.11.2. Happy to add a changelog if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5w1SF7gHaXPrUnoG4BCWN
