### PR TITLE
Mirror pinned conversations in Blip

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -25,7 +25,7 @@ BarWidget {
     decodeURIComponent(Qt.resolvedUrl("collector.ts").toString().replace(/^file:\/\//, ""))
 
   // ---- collector state
-  property var threads: []           // [{chat,name,handle,service,last_ts,last_text,last_from_me,count,unread}]
+  property var threads: []           // [{chat,name,handle,service,last_ts,last_text,last_from_me,count,unread,pinned,pin_order}]
   property string threadsJson: ""    // last assigned list, for no-op detection
   property int unread: 0
   property bool online: false        // the Mac is reachable

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -104,6 +104,8 @@ FocusScope {
   property string pasteChat: ""
 
   readonly property var threads: hostWidget ? hostWidget.threads : []
+  readonly property var pinnedThreads: root.threads.filter(function(t) { return t.pinned === true })
+  readonly property var unpinnedThreads: root.threads.filter(function(t) { return t.pinned !== true })
   readonly property bool online: hostWidget ? hostWidget.online : false
   readonly property int unread: hostWidget ? hostWidget.unread : 0
 
@@ -122,6 +124,21 @@ FocusScope {
   property string sendChat: ""          // immutable context for the current send
   property string sendText: ""
   property string reloadChat: ""
+
+  function threadIndex(thread) {
+    for (var i = 0; i < root.threads.length; i++) {
+      if (String(root.threads[i].chat) === String(thread.chat)) return i
+    }
+    return -1
+  }
+
+  function avatarInitials(thread) {
+    var n = String(thread.name || "")
+    if (/^[+0-9]/.test(n) || n === "") return "#"
+    var parts = n.trim().split(/\s+/).filter(function(p) { return p.length > 0 })
+    if (parts.length === 0) return "#"
+    return (parts[0][0] + (parts.length > 1 ? parts[parts.length - 1][0] : "")).toUpperCase()
+  }
 
   readonly property bool inThread: active !== null
   // last_ts of the open conversation as of its last load — the push watcher
@@ -1140,6 +1157,107 @@ FocusScope {
               Keys.onEscapePressed: root.exitSearch()
             }
 
+            // Read-only mirror of Messages' pinned section. These tiles have
+            // no preview: the Mac owns pinning, while Blip only renders the
+            // ordered avatars and names above the ordinary conversation rows.
+            GridLayout {
+              id: pinnedGrid
+              Layout.fillWidth: true
+              visible: root.online && root.listShowing && !root.searchShowing && !root.newMode
+                       && root.pinnedThreads.length > 0
+              columns: 3
+              columnSpacing: Style.space(8)
+              rowSpacing: Style.space(10)
+              Layout.topMargin: Style.space(8)
+              Layout.bottomMargin: Style.space(8)
+
+              Repeater {
+                model: pinnedGrid.visible ? root.pinnedThreads : []
+                delegate: Rectangle {
+                  required property var modelData
+                  Layout.fillWidth: true
+                  Layout.preferredWidth: Math.max(1, (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3)
+                  implicitHeight: pinnedColumn.implicitHeight + Style.space(4)
+                  radius: Style.cornerRadius
+                  color: pinnedHover.hovered
+                    ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+                    : "transparent"
+
+                  HoverHandler { id: pinnedHover }
+                  TapHandler { onTapped: root.openThread(modelData) }
+
+                  ColumnLayout {
+                    id: pinnedColumn
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    spacing: Style.space(4)
+
+                    Rectangle {
+                      id: pinnedAvatar
+                      Layout.alignment: Qt.AlignHCenter
+                      width: Math.min(88, Math.max(56,
+                        (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3 * 0.62))
+                      height: width
+                      radius: width / 2
+                      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+                      readonly property string avatarHandle: String(modelData.handle || modelData.chat || "")
+                      Component.onCompleted: if (!root.isGroupId(String(modelData.chat || ""))) root.requestAvatar(avatarHandle)
+
+                      Image {
+                        id: pinnedAvatarImg
+                        anchors.fill: parent
+                        visible: false
+                        source: root.avatarFiles[pinnedAvatar.avatarHandle] || ""
+                        asynchronous: true
+                        fillMode: Image.PreserveAspectCrop
+                        sourceSize.width: 192
+                        sourceSize.height: 192
+                        onStatusChanged: if (status === Image.Error && pinnedAvatar.avatarHandle !== "") {
+                          var m = Object.assign({}, root.avatarFiles); m[pinnedAvatar.avatarHandle] = ""; root.avatarFiles = m
+                        }
+                      }
+                      Item {
+                        id: pinnedAvatarMask
+                        anchors.fill: parent
+                        visible: false
+                        layer.enabled: true
+                        Rectangle { anchors.fill: parent; radius: width / 2 }
+                      }
+                      MultiEffect {
+                        anchors.fill: parent
+                        source: pinnedAvatarImg
+                        visible: pinnedAvatarImg.status === Image.Ready
+                        maskEnabled: true
+                        maskSource: pinnedAvatarMask
+                      }
+                      Text {
+                        anchors.centerIn: parent
+                        visible: pinnedAvatarImg.status !== Image.Ready
+                        text: root.avatarInitials(modelData)
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.body
+                        font.bold: true
+                      }
+                    }
+
+                    Text {
+                      Layout.fillWidth: true
+                      text: String(modelData.name || modelData.chat)
+                      textFormat: Text.PlainText
+                      horizontalAlignment: Text.AlignHCenter
+                      elide: Text.ElideRight
+                      color: root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.bold: modelData.unread > 0
+                    }
+                  }
+                }
+              }
+            }
+
             Text {
               Layout.fillWidth: true
               visible: root.searching && root.searchNote !== ""
@@ -1219,7 +1337,7 @@ FocusScope {
             }
 
             Repeater {
-              model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.threads : []
+              model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.unpinnedThreads : []
               delegate: Rectangle {
                 required property var modelData
                 required property int index
@@ -1227,7 +1345,7 @@ FocusScope {
                 Layout.fillWidth: true
                 implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 20 : 12)
                 radius: Style.cornerRadius
-                color: rowHover.hovered || root.cursor === index
+                color: rowHover.hovered || root.cursor === root.threadIndex(modelData)
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
 
@@ -1287,13 +1405,7 @@ FocusScope {
                     Text {
                       anchors.centerIn: parent
                       visible: avatarImg.status !== Image.Ready
-                      text: {
-                        var n = String(modelData.name || "")
-                        if (/^[+0-9]/.test(n) || n === "") return "#"
-                        var parts = n.trim().split(/\s+/).filter(function(p) { return p.length > 0 })
-                        if (parts.length === 0) return "#"
-                        return (parts[0][0] + (parts.length > 1 ? parts[parts.length - 1][0] : "")).toUpperCase()
-                      }
+                      text: root.avatarInitials(modelData)
                       color: root.foreground
                       font.family: root.fontFamily
                       font.pixelSize: Style.font.caption

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Linux side. If the Mac is asleep, the widget dims and says so.
 
 **Thread list**
 - contact photo (from the Mac's Contacts) or initials, name, preview, time
+- **pinned conversations mirrored from Messages on the Mac**, kept in the same order at the top (read-only)
 - **blue dot** that stays until you open *that* conversation — iMessage semantics, not "I glanced at the list"
 - groups titled the way Messages.app titles them: the group's name, else its members
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,9 @@ changes to the Mac beyond claude-on-mac updates.
   `.pluginPayloadAttachment` link-preview blobs filtered (imsg 1.5.1).
 - [x] **Send-effect labels** — shipped 0.8.0: "· sent with confetti" in the
   time row.
+- [x] **Pinned conversation mirror** — reads the Mac's ordered Messages pin
+  metadata and keeps those conversations at the top of Blip's list; Blip has
+  no pin or unpin control and writes nothing back.
 
 ## Tier 2 — attachments both directions (SHIPPED 0.9.0, 2026-08-31)
 

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -13,7 +13,7 @@ Subcommands:
   search <text> [N], full-text-ish LIKE search across messages
   thread <handle> [N], same as `from`, oldest→newest
   contacts, list known handles with message counts
-  chats, list chats (group + 1:1) with last activity
+  chats, list chats (group + 1:1) with last activity and pin metadata
   groups [N], group chats with the AppleScript GUID needed to send to them
 
 All output is `ts | who | text` (or JSON with --json).
@@ -25,6 +25,7 @@ import argparse
 import datetime as dt
 import json
 import os
+import plistlib
 import re
 import sqlite3
 import struct
@@ -32,6 +33,13 @@ import sys
 from glob import glob
 
 DB_PATH = os.path.expanduser("~/Library/Messages/chat.db")
+PINNING_PLIST_PATHS = (
+    os.path.expanduser("~/Library/Preferences/com.apple.messages.pinning.plist"),
+    os.path.expanduser(
+        "~/Library/Containers/com.apple.MobileSMS/Data/Library/Preferences/"
+        "com.apple.messages.pinning.plist"
+    ),
+)
 APPLE_EPOCH = 978307200  # 2001-01-01 UTC
 
 # ---------- Contacts name resolution (built-in, no external deps) ----------
@@ -170,6 +178,67 @@ def fmt_ts(apple_ns: int | None) -> str:
 
 def message_text(row: sqlite3.Row) -> str:
     return row["text"] or decode_attributed_body(row["attributedBody"]) or ""
+
+
+def pinned_chat_identifiers() -> list[str]:
+    """Read the ordered chat identifiers from Messages' pinning preferences.
+
+    The plist is an undocumented, version-dependent preference, so keep this
+    deliberately tolerant: recursively collect strings and let
+    ``pin_order_for`` decide which ones identify a chat. A missing or
+    unreadable plist simply means that no chats are pinned.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+
+    def visit(item) -> None:
+        if isinstance(item, str):
+            item = item.strip()
+            if item and item not in seen:
+                seen.add(item)
+                out.append(item)
+        elif isinstance(item, dict):
+            for child in item.values():
+                visit(child)
+        elif isinstance(item, (list, tuple)):
+            for child in item:
+                visit(child)
+
+    for path in PINNING_PLIST_PATHS:
+        try:
+            with open(path, "rb") as f:
+                visit(plistlib.load(f))
+        except (OSError, plistlib.InvalidFileException, ValueError, TypeError):
+            continue
+    return out
+
+
+def _pin_id(value: str) -> str:
+    """Reduce an Apple chat id (or service-qualified id) to its chat id."""
+    value = str(value or "").strip().lower()
+    for separator in (";+;", ";-;"):
+        if separator in value:
+            value = value.rsplit(separator, 1)[1]
+    return value
+
+
+def _same_chat_id(left: str, right: str) -> bool:
+    left = _pin_id(left)
+    right = _pin_id(right)
+    if left == right:
+        return True
+    # Some preference/database versions omit the plus on phone identifiers.
+    if re.fullmatch(r"\+?[0-9]{5,}", left) and re.fullmatch(r"\+?[0-9]{5,}", right):
+        return left.lstrip("+") == right.lstrip("+")
+    return False
+
+
+def pin_order_for(pin_ids: list[str], chat_identifier: str, guid: str | None) -> int | None:
+    """Return the Messages pin position for one chat, or None."""
+    for index, pin_id in enumerate(pin_ids):
+        if _same_chat_id(pin_id, chat_identifier) or (guid and _same_chat_id(pin_id, guid)):
+            return index
+    return None
 
 
 # ---------- --rich enrichment (tapbacks, read receipts, replies, attachments) ----------
@@ -569,7 +638,7 @@ def cmd_chats(con, args):
     # the latest visible message so the list needs no second query.
     rows = con.execute(
         f"""
-        SELECT c.ROWID AS cid, c.chat_identifier, c.display_name, c.room_name,
+        SELECT c.ROWID AS cid, c.chat_identifier, c.guid, c.display_name, c.room_name,
                c.service_name, MAX(m.date) AS last_date,
                COUNT(m.ROWID) AS n
         FROM chat c
@@ -582,8 +651,10 @@ def cmd_chats(con, args):
         (args.n,),
     ).fetchall()
     if args.json:
+        pin_ids = pinned_chat_identifiers()
         out = []
         for r in rows:
+            pin_order = pin_order_for(pin_ids, r["chat_identifier"], r["guid"])
             last = con.execute(
                 f"""SELECT m.text, m.attributedBody, m.is_from_me, h.id AS handle
                     FROM chat_message_join cmj
@@ -603,6 +674,8 @@ def cmd_chats(con, args):
                 "last_from_me": bool(last["is_from_me"]) if last else False,
                 "last_handle": (last["handle"] if last else None) or "",
                 "last_name": (name_for(last["handle"]) if last and last["handle"] and not args.no_names else None),
+                "pinned": pin_order is not None,
+                "pin_order": pin_order,
             })
         print(json.dumps(out, indent=2, ensure_ascii=False))
         return

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -8,6 +8,7 @@ import {
   detectSelfChats,
   fetchMessagesAfter,
   CATCHUP_MAX_ROWS,
+  fetchChats,
   fetchGroups,
   groupName,
   dedupeSelfEcho,
@@ -723,14 +724,15 @@ describe("complete conversation list (mergeChats)", () => {
   const windowThread = {
     chat: "+15551234567", guid: "", name: "Pat", handle: "+15551234567", service: "iMessage",
     last_ts: "2026-08-31 20:00:00", last_text: "hi", last_from_me: false, count: 3, unread: 1,
+    pinned: false, pin_order: null,
   };
   const chats = [
     { id: "+15551234567", name: null, service: "iMessage", last: "2026-08-31 20:00:00",
-      last_text: "hi", last_from_me: false, last_handle: "+15551234567", last_name: "Pat" },
+      last_text: "hi", last_from_me: false, last_handle: "+15551234567", last_name: "Pat", pinned: false, pin_order: null },
     { id: "ce5a593a78af408282d61461ade89135", name: "Lunch Crew", service: "iMessage", last: "2026-08-31 19:00:00",
-      last_text: "Nice", last_from_me: false, last_handle: "+15550001111", last_name: "Sam" },
+      last_text: "Nice", last_from_me: false, last_handle: "+15550001111", last_name: "Sam", pinned: false, pin_order: null },
     { id: "+15559990000", name: null, service: "SMS", last: "2026-08-20 09:00:00",
-      last_text: "old news", last_from_me: true, last_handle: "+15559990000", last_name: "Quiet Q" },
+      last_text: "old news", last_from_me: true, last_handle: "+15559990000", last_name: "Quiet Q", pinned: false, pin_order: null },
   ];
 
   test("quiet conversations outside the window appear, newest first", () => {
@@ -752,6 +754,53 @@ describe("complete conversation list (mergeChats)", () => {
     const out = mergeChats([], chats, {}, {});
     expect(out.find((t) => t.chat === "+15559990000")!.name).toBe("Quiet Q");
     expect(out.find((t) => t.chat === "ce5a593a78af408282d61461ade89135")!.name).toBe("Lunch Crew");
+  });
+
+  test("mirrored pins sort first in Messages pin order, ahead of activity", () => {
+    const out = mergeChats(
+      [
+        { ...windowThread, last_ts: "2026-08-31 22:00:00" },
+        { ...windowThread, chat: "+15557770000", last_ts: "2026-08-31 21:00:00", pinned: false, pin_order: null },
+      ],
+      [
+        { ...chats[0]!, pinned: false, pin_order: null },
+        { ...chats[1]!, pinned: true, pin_order: 1 },
+      ],
+      {},
+      {},
+    );
+    expect(out.map((t) => t.chat)).toEqual([
+      "ce5a593a78af408282d61461ade89135",
+      "+15551234567",
+      "+15557770000",
+    ]);
+    expect(out[0]!.pinned).toBe(true);
+    expect(out[0]!.pin_order).toBe(1);
+  });
+});
+
+describe("pinned conversation metadata", () => {
+  test("fetchChats preserves pin state and tolerates an older bridge", () => {
+    const runner = ((_: string, __: string[]) => ({
+      status: 0,
+      stdout: JSON.stringify([
+        {
+          id: "+15551234567", name: "Pat", service: "iMessage", last: "2026-08-31 20:00:00",
+          last_text: "hi", last_from_me: false, last_handle: "+15551234567", last_name: "Pat",
+          pinned: true, pin_order: 0,
+        },
+        {
+          id: "+15550001111", name: null, service: "SMS", last: "2026-08-31 19:00:00",
+          last_text: "old", last_from_me: true, last_handle: "+15550001111", last_name: null,
+        },
+      ]),
+      stderr: "",
+    })) as never;
+    const out = fetchChats(runner)!;
+    expect(out[0]!.pinned).toBe(true);
+    expect(out[0]!.pin_order).toBe(0);
+    expect(out[1]!.pinned).toBe(false);
+    expect(out[1]!.pin_order).toBe(null);
   });
 });
 

--- a/collector.ts
+++ b/collector.ts
@@ -100,6 +100,10 @@ export interface Thread {
   last_from_me: boolean;
   count: number;       // messages for this chat inside the fetched window
   unread: number;      // inbound newer than the global/per-thread read mark
+  /** Mirrored from Messages' pinning preferences; Blip never changes it. */
+  pinned: boolean;
+  /** Position in Messages' pinned section, when pinned. */
+  pin_order: number | null;
 }
 
 export interface Toast {
@@ -398,11 +402,26 @@ export function buildThreads(
       last_from_me: last.from_me,
       count: sorted.length,
       unread,
+      pinned: false,
+      pin_order: null,
     });
   }
 
-  threads.sort((a, b) => (a.last_ts < b.last_ts ? 1 : a.last_ts > b.last_ts ? -1 : 0));
+  threads.sort(compareThreads);
   return threads;
+}
+
+/** Messages keeps pinned conversations ahead of the activity-sorted list. */
+export function compareThreads(a: Thread, b: Thread): number {
+  if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+  if (a.pinned && b.pinned) {
+    if (a.pin_order !== null && b.pin_order !== null && a.pin_order !== b.pin_order) {
+      return a.pin_order - b.pin_order;
+    }
+    if (a.pin_order !== null && b.pin_order === null) return -1;
+    if (a.pin_order === null && b.pin_order !== null) return 1;
+  }
+  return a.last_ts < b.last_ts ? 1 : a.last_ts > b.last_ts ? -1 : 0;
 }
 
 function digest(value: string): string {
@@ -655,7 +674,7 @@ export function unreadOldest(
 }
 
 /** `imsg --json groups` — claude-on-mac ≥ 1.4.0. */
-/** One row of `imsg --json chats`: a conversation with its latest preview. */
+/** One row of `imsg --json chats`: a conversation with preview + pin metadata. */
 export interface ChatInfo {
   id: string;
   name: string | null;
@@ -665,15 +684,19 @@ export interface ChatInfo {
   last_from_me: boolean;
   last_handle: string;
   last_name: string | null;
+  /** Mirrored from Messages' pinning preferences; absent on old bridges. */
+  pinned: boolean;
+  pin_order: number | null;
 }
 
 /** How many conversations the sidebar lists (chat.db has hundreds). */
 export const CHAT_LIST_LIMIT = 300;
 
 /**
- * The COMPLETE conversation list (imsg ≥1.11.0 `chats` with previews). The
- * message window only ever covers the busiest few days — deriving the list
- * from it lost every quiet conversation ("where is my quiet group?").
+ * The COMPLETE conversation list (imsg ≥1.11.0 `chats` with previews and pin
+ * metadata). The message window only ever covers the busiest few days —
+ * deriving the list from it lost every quiet conversation ("where is my quiet
+ * group?").
  * Fetched on deep runs only; the shallow poll keeps the last list in the
  * widget's memory. Previews are never persisted (no content on disk).
  */
@@ -697,6 +720,8 @@ export function fetchChats(runner = spawnSync): ChatInfo[] | null {
         last_from_me: r.last_from_me === true,
         last_handle: String(r.last_handle ?? ""),
         last_name: typeof r.last_name === "string" ? r.last_name : null,
+        pinned: r.pinned === true,
+        pin_order: Number.isInteger(r.pin_order) ? Number(r.pin_order) : null,
       }));
   } catch {
     return null;
@@ -715,8 +740,18 @@ export function mergeChats(
   groups: Record<string, GroupInfo>,
   unreadCounts: Record<string, number>,
 ): Thread[] {
+  const infoByChat = new Map(chats.map((c) => [c.id, c]));
+  const applyPin = (thread: Thread): Thread => {
+    const info = infoByChat.get(thread.chat);
+    if (!info) return thread;
+    const pinned = info.pinned === true;
+    const pin_order = Number.isInteger(info.pin_order) ? Number(info.pin_order) : null;
+    return thread.pinned === pinned && thread.pin_order === pin_order
+      ? thread
+      : { ...thread, pinned, pin_order };
+  };
   const have = new Set(threads.map((t) => t.chat));
-  const out = [...threads];
+  const out = threads.map(applyPin);
   for (const c of chats) {
     if (have.has(c.id)) continue;
     have.add(c.id);
@@ -735,9 +770,11 @@ export function mergeChats(
       last_from_me: c.last_from_me,
       count: 0,
       unread: unreadCounts[c.id] ?? 0,
+      pinned: c.pinned === true,
+      pin_order: Number.isInteger(c.pin_order) ? Number(c.pin_order) : null,
     });
   }
-  return out.sort((a, b) => (a.last_ts < b.last_ts ? 1 : a.last_ts > b.last_ts ? -1 : 0));
+  return out.sort(compareThreads);
 }
 
 export function fetchGroups(runner = spawnSync): Record<string, GroupInfo> | null {

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -37,10 +37,10 @@ Threat model and the audit findings behind these notes: [SECURITY.md](SECURITY.m
 | `~/Pictures/.blip-outbox/<id>/` | a file you are sending, for the seconds until Messages copies it into its own store; then moved to `~/.blip/sent` (leftovers older than an hour are swept) |
 | `~/.blip/sent/<id>/` (200 MB LRU) | files Blip sent — kept because Messages often leaves the attachment record pointing at the staging path instead of copying it, and Blip would otherwise never be able to show your own photo again |
 
-The tools read `~/Library/Messages/chat.db` and the AddressBook database
-read-only, and drive Messages.app through AppleScript. They write nothing
-else. Messages.app itself keeps your conversation history exactly as it
-always has.
+The tools read `~/Library/Messages/chat.db`, the AddressBook database, and
+Messages' pinning preferences read-only, and drive Messages.app through
+AppleScript. They write nothing else. Messages.app itself keeps your
+conversation history exactly as it always has.
 
 ## Permissions the Mac asks for
 
@@ -53,8 +53,9 @@ missing. Blip never asks for Contacts, Camera, Microphone, or Location.
 
 ## What crosses the network
 
-Only ssh between the two machines: message queries and previews, attachment
-bytes you request, and files you send. Push notifications use a
+Only ssh between the two machines: message queries and previews, ordered
+conversation-pin metadata, attachment bytes you request, and files you send.
+Push notifications use a
 content-free "something changed" ping — a watcher on the Mac emits a
 timestamp when `chat.db` changes; the client then fetches privately.
 


### PR DESCRIPTION
## Summary

- Mirror ordered pinned-conversation metadata from Messages.
- Render pinned conversations as read-only avatar/name tiles in three-column rows above ordinary conversation rows.
- Preserve existing unread behavior and activity ordering for unpinned conversations.

## Implementation

- Extend the Mac bridge chats JSON with tolerant pin-preference parsing and stable pin ordering.
- Merge pin metadata into the complete collector thread model with backward-compatible defaults and test coverage.
- Split the QML list into pinned and unpinned sections, preserving keyboard selection by chat identity.
- Document the feature and its read-only privacy behavior.

## Verification

- `bun test`: 197 passed, 0 failed.
- UI spacing and the normal Omarchy window were deployed and visually verified.