### PR TITLE
imsg: hide announcement rows, they are not messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Location-sharing notices no longer show up as empty unread messages.**
+  Messages.app writes its own announcements — someone joined or left, a
+  rename, location sharing started or stopped — into the message table with
+  `item_type != 0`, and never marks them read. The bridge passed them through,
+  so each one became an empty bubble that counted as unread forever and pulled
+  its conversation to the top; an iCloud re-sync after a restart lands several
+  at once. `imsg` now hides them at the source, next to Recently Deleted, so
+  every query agrees. Group names are unaffected: rename rows are still read
+  for that. Mac side: re-run the install one-liner so `~/.blip/bin/imsg` picks
+  it up.
 - **Reads now reach the Mac, and your phone.** Blip's "mark all read" cleared
   the badge on Linux and nothing else; the iPhone kept its red dots. The old
   note called this impossible because `open imessage://<handle>` does not flip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,11 @@ what it is handed. Keep it that way.
   "not a phone/email" — never a positive regex on one shape.
 - **Deleted messages stay in chat.db for 30 days** (`chat_recoverable_message_join`).
   claude-on-mac's `imsg` hides them (1.4.0+); Blip assumes that.
+- **Announcements are not messages.** Joins, leaves, renames and location-sharing
+  notices share the message table with `item_type != 0`, and Apple never marks
+  them read. `imsg` hides them at the source; let one through and it is an
+  empty bubble that counts as unread forever. Group names still come from
+  rename rows (`cmd_groups` reads the raw table).
 - **The conversation Flickable is `interactive: false`.** An interactive
   Flickable grabs every drag, and drag IS text selection in a bubble; a
   slightly-moving click on a link became a flick. Wheel scrolling never

--- a/README.md
+++ b/README.md
@@ -388,6 +388,11 @@ Deleted" bin that is still in `chat.db`. claude-on-mac's `imsg` hides those rows
 a conversation you delete on the phone disappears from Blip within one poll of
 the iCloud sync. `IMSG_INCLUDE_DELETED=1` shows them again.
 
+**Notices are not messages.** Messages.app writes its grey centered notices —
+someone joined, a group was renamed, location sharing started — into the same
+table as messages, and never marks them read. `imsg` hides them, or every one
+would be an empty bubble that counts as unread until the end of time.
+
 **No message bodies are stored on Linux.** `~/.local/state/blip/state.json`
 holds timestamps, unread counts, SHA-256 toast-dedupe keys, inferred self-chat
 ids, and group metadata. It is written atomically with mode `0600`; legacy

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -129,13 +129,13 @@ def open_db() -> sqlite3.Connection:
         sys.exit(f"chat.db not found at {DB_PATH}")
     # mode=ro alone (without immutable=1) so we still see uncommitted WAL writes
     con = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
-    # macOS 12 and earlier have no Recently Deleted table: read the plain message
-    # table instead of dying with a traceback on every command.
+    # macOS 12 and earlier have no Recently Deleted table: filter without it
+    # instead of dying with a traceback on every command.
     global MESSAGE_SRC
-    if "chat_recoverable_message_join" in MESSAGE_SRC and not con.execute(
+    if not con.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chat_recoverable_message_join'"
     ).fetchone():
-        MESSAGE_SRC = "message"
+        MESSAGE_SRC = message_src(has_recently_deleted=False)
     con.row_factory = sqlite3.Row
     return con
 
@@ -534,14 +534,29 @@ def render(rows, as_json: bool, with_names: bool = True, con=None, rich: bool = 
         print(f"{fmt_ts(r['date'])}  {who:>30}{chat_tag}: {text}")
 
 
-# Recently Deleted (the 30-day bin, synced from iPhone via Messages in iCloud)
-# keeps its rows in chat.db. Hide them by default, or a conversation deleted on
-# the phone lingers in every client for a month. IMSG_INCLUDE_DELETED=1 shows them.
-MESSAGE_SRC = (
-    "message"
-    if os.environ.get("IMSG_INCLUDE_DELETED") == "1"
-    else "(SELECT * FROM message WHERE ROWID NOT IN (SELECT message_id FROM chat_recoverable_message_join))"
-)
+# Two kinds of rows live in the message table without being messages. Both are
+# hidden at the source, so every query — recent, thread, chats, unread — agrees.
+#
+#   Recently Deleted: the 30-day bin, synced from the iPhone via Messages in
+#   iCloud. Left in, a conversation deleted on the phone lingers in every client
+#   for a month. IMSG_INCLUDE_DELETED=1 shows them.
+#
+#   Announcements (item_type != 0): someone joined or left, a rename, location
+#   sharing started or stopped. Messages.app draws them as grey centered text
+#   and never marks them read, so left in they surface as empty bubbles that
+#   count as unread forever. Group names are still recovered from rename rows;
+#   cmd_groups reads the raw table for that.
+HIDE_DELETED = os.environ.get("IMSG_INCLUDE_DELETED") != "1"
+
+
+def message_src(has_recently_deleted: bool) -> str:
+    where = ["item_type = 0"]
+    if HIDE_DELETED and has_recently_deleted:
+        where.append("ROWID NOT IN (SELECT message_id FROM chat_recoverable_message_join)")
+    return f"(SELECT * FROM message WHERE {' AND '.join(where)})"
+
+
+MESSAGE_SRC = message_src(has_recently_deleted=True)
 
 _BASE_SELECT_CACHE: str | None = None
 


### PR DESCRIPTION
## What

`imsg` no longer returns Messages.app's own announcement rows — someone joined or left a group, a rename, location sharing started or stopped (`item_type != 0`). They are hidden at the source, next to Recently Deleted, so every query agrees: `recent`, `thread`, `chats`, `groups`, and the unread ledger the collector builds from them.

User-visible effect: no more empty bubbles that count as unread forever and pull a conversation to the top. Mac side needs the install one-liner re-run so `~/.blip/bin/imsg` picks it up (noted in CHANGELOG).

## Why

Apple writes these notices into the message table with an empty body and never marks them read. The bridge passed them through, so Blip treated each one as an unread inbound message. An iCloud re-sync after a restart lands several at once: on my Mac, five location-sharing notices arrived in the same second and lit two family threads with "two new messages" that did not exist. The database had 42 such rows sitting at `is_read = 0`, some from 2025.

Rendering notices the way Messages does, as grey centered text, would be a follow-up: the bridge would emit them tagged, and the collector would keep them out of the unread ledger and toasts. Out of scope here.

## How it was verified

- [x] `bun test` is green (CI will check) — 234 pass, plus `py_compile` on every Mac tool
- [x] Any send/receive behavior was exercised against **my own number only** — never a contact or a group
  - this change does not send; it only filters reads
- [ ] UI change → screenshot attached
  - no UI change; the bubbles simply stop appearing
- [x] Touches an invariant in `CLAUDE.md` → named below, and the doc updated if it changed

Against a live `chat.db`, old tool vs new, compared by row id and counts only:

- `recent 60`: exactly the five `item_type = 4` rows left the window; five older real messages took their place
- no `item_type != 0` row remains in the newest 500
- `chats`: 30 before, 30 after · `groups`: 149 before and after, 4 named before and after (rename-row name recovery reads the raw table and is unaffected)
- unread inbound rows in the newest 500: 12 → 2
- `IMSG_INCLUDE_DELETED=1` still works; the macOS 12 fallback (no Recently Deleted table) now filters announcements too instead of reading the raw table

Invariants touched:
- **Deleted messages stay in chat.db for 30 days** — same mechanism, unchanged behaviour; the filter moved into `message_src()`
- **New: Announcements are not messages** — added to CLAUDE.md, with a matching design note in README next to "Deleted means deleted"
