### PR TITLE
Clock and dates follow Qt format strings on the widget entry

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -24,6 +24,18 @@ BarWidget {
   readonly property string collectorPath:
     decodeURIComponent(Qt.resolvedUrl("collector.ts").toString().replace(/^file:\/\//, ""))
 
+  // Clock and date patterns from this widget's shell.json entry — Qt format
+  // strings, exactly as Omarchy's clock takes `format`. Qt formats the list
+  // with them and thread.ts formats the bubbles with the same strings, so the
+  // two never disagree. Unset, the time follows the locale (an AM/PM marker
+  // means 12-hour) and dates read the way Messages writes them.
+  readonly property string localeTimeFormat:
+    /ap/i.test(Qt.locale().timeFormat(Locale.ShortFormat)) ? "h:mm AP" : "HH:mm"
+  readonly property string timeFormat: formatSetting("timeFormat", localeTimeFormat)
+  readonly property string dateFormat: formatSetting("dateFormat", "MMM d")
+  readonly property string dateFormatWithYear: formatSetting("dateFormatWithYear", "MMM d, yyyy")
+  function formatSetting(name, fallback) { var v = String(setting(name, "")); return v === "" ? fallback : v }
+
   // ---- collector state
   property var threads: []           // [{chat,name,handle,service,last_ts,last_text,last_from_me,count,unread,pinned,pin_order}]
   property string threadsJson: ""    // last assigned list, for no-op detection

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -22,6 +22,11 @@ FocusScope {
 
   // ---- host contract (docs/app-design-review.md) ----------------------
   property var hostWidget: null
+  /** Qt format strings, owned by the host widget (see BarWidget). Empty when no host is
+   *  attached or the host has none, which thread.ts and Qt both read as "use the defaults". */
+  readonly property string timeFormat: (hostWidget && hostWidget.timeFormat) || ""
+  readonly property string dateFormat: (hostWidget && hostWidget.dateFormat) || ""
+  readonly property string dateFormatWithYear: (hostWidget && hostWidget.dateFormatWithYear) || ""
   /** The surface hosting this view is showing (popout: opened; window:
    *  visible). Gates reads, reloads, and autofocus — a hidden surface must
    *  never mark anything read. */
@@ -324,7 +329,10 @@ FocusScope {
     if (threadProc.running || pendingThreadChat === "") return
     threadRunningChat = pendingThreadChat
     pendingThreadChat = ""
-    threadProc.command = ["bun", root.threadScript, threadRunningChat, "80"]
+    threadProc.command = ["bun", root.threadScript, threadRunningChat, "80",
+                          "--time-format", root.timeFormat,
+                          "--date-format", root.dateFormat,
+                          "--date-format-with-year", root.dateFormatWithYear]
     threadProc.running = true
   }
 
@@ -759,11 +767,18 @@ FocusScope {
   }
   Timer { id: noteTimer; interval: 1500; onTriggered: if (root.note === "copied" || root.note === "sent to LocalSend") root.note = "" }
 
+  // The same patterns as the bubbles: today the time, older rows the date and
+  // the time, with the year once it is not this year.
   function fmtTime(ts) {
     var s = String(ts || "")
     if (s.length < 16) return s
-    var today = Qt.formatDateTime(new Date(), "yyyy-MM-dd")
-    return s.substring(0, 10) === today ? s.substring(11, 16) : s.substring(5, 16)
+    var now = new Date()
+    var at = new Date(+s.substring(0, 4), +s.substring(5, 7) - 1, +s.substring(8, 10),
+                      +s.substring(11, 13), +s.substring(14, 16))
+    var clock = Qt.formatTime(at, root.timeFormat)
+    if (s.substring(0, 10) === Qt.formatDate(now, "yyyy-MM-dd")) return clock
+    var date = at.getFullYear() === now.getFullYear() ? root.dateFormat : root.dateFormatWithYear
+    return Qt.formatDate(at, date) + " " + clock
   }
 
   // ------------------------------------------------------------ processes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Clock and dates are yours to set.** Bubble times and read receipts were
+  hardcoded 12-hour while the conversation list showed 24-hour — two clocks
+  in one window, and no setting for either. Both now follow three Qt format
+  strings on the widget's shell.json entry, the way Omarchy's clock takes its
+  `format`: `timeFormat`, `dateFormat` (day dividers this year) and
+  `dateFormatWithYear`. Unset, the time follows your locale and dates read as
+  before, so nothing changes until you ask.
 - **Reads now reach the Mac, and your phone.** Blip's "mark all read" cleared
   the badge on Linux and nothing else; the iPhone kept its red dots. The old
   note called this impossible because `open imessage://<handle>` does not flip

--- a/README.md
+++ b/README.md
@@ -301,6 +301,15 @@ cloned by hand: `omarchy plugin enable nixfred.blip --section right`, or add
 `~/.config/omarchy/shell.json`. Then `omarchy-restart-shell` — the speech
 bubble is in your bar.
 
+**Clock and dates.** Out of the box the time follows your locale — `9:08 PM`
+or `21:08` — and dates read the way Messages writes them: `Aug 28`, or
+`Aug 28, 2025` for another year. To change either, put Qt format strings on
+the same entry, exactly as Omarchy's clock takes its `format`:
+
+```jsonc
+{ "id": "nixfred.blip", "timeFormat": "HH:mm", "dateFormat": "dd.MM", "dateFormatWithYear": "dd.MM.yyyy" }
+```
+
 **5. (Optional) `SUPER+M` for the app window** — the Lua snippet under
 "The app" above.
 

--- a/scripts/demo/DemoShell.qml
+++ b/scripts/demo/DemoShell.qml
@@ -6,8 +6,8 @@ import qs.Commons
 // Screenshot harness. Renders the REAL BlipView against the fake bridge, in a
 // plain window, with no bar and no second Omarchy shell fighting the live one.
 //
-// It stands in for BarWidget: BlipView asks its host for nine things, and this
-// supplies all nine — `threads` from a genuine `bun collector.ts --deep` run,
+// It stands in for BarWidget: BlipView asks its host for twelve things, and this
+// supplies all twelve — `threads` from a genuine `bun collector.ts --deep` run,
 // which in the sandbox reaches scripts/demo/fake-imsg instead of a Mac. So the
 // list, the avatars, the bubbles, the link card and the share sheet are all
 // produced by the shipping code paths.
@@ -24,6 +24,11 @@ ShellRoot {
     property int unread: 0
     property bool healthy: true
     property string lastError: ""
+    // Clock and date patterns, as BarWidget would supply them (README defaults);
+    // BLIP_DEMO_TIME_FORMAT etc. override, so a shot can show them configured.
+    property string timeFormat: Quickshell.env("BLIP_DEMO_TIME_FORMAT") || "h:mm AP"
+    property string dateFormat: Quickshell.env("BLIP_DEMO_DATE_FORMAT") || "MMM d"
+    property string dateFormatWithYear: Quickshell.env("BLIP_DEMO_DATE_FORMAT_WITH_YEAR") || "MMM d, yyyy"
     function refresh(deep, markRead, readChat, seen) { collector.reload() }
     function markAllRead() { }
     function markThreadRead(chat) { }

--- a/thread.test.ts
+++ b/thread.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ImsgMessage } from "./collector";
+import type { Formats } from "./thread";
 import {
   clockLabel,
   dayLabel,
   decorate,
   dedupeSelfEcho,
+  DEFAULT_FORMATS,
+  formatStamp,
+  formatsFromArgv,
   loadThread,
   localToday,
   minutesBetween,
@@ -27,6 +31,61 @@ function msg(over: Partial<ImsgMessage> = {}): ImsgMessage {
   };
 }
 
+const DOTTED: Formats = { time: "HH:mm", date: "dd.MM", dateWithYear: "dd.MM.yyyy" };
+
+describe("formatStamp", () => {
+  const ts = "2026-08-30 21:08:22"; // a Sunday
+
+  test.each([
+    ["HH:mm", "21:08"],
+    ["h:mm AP", "9:08 PM"],
+    ["hh:mm ap", "09:08 pm"],
+    ["h:mm A", "9:08 PM"],
+    ["h", "21"],                       // no AM/PM token → h is 24-hour, as in Qt
+    ["H:m:s", "21:8:22"],
+    ["dd.MM", "30.08"],
+    ["dd.MM.yyyy", "30.08.2026"],
+    ["d/M/yy", "30/8/26"],
+    ["MMM d, yyyy", "Aug 30, 2026"],
+    ["d MMMM yyyy", "30 August 2026"],
+    ["ddd d MMM", "Sun 30 Aug"],
+    ["dddd", "Sunday"],
+    ["h 'o''clock'", "21 o'clock"],    // quoted literals, '' is a quote
+    ["'at' h:mm ap", "at 9:08 pm"],    // an 'a' inside quotes is not a token
+    ["yyyy-MM-dd'T'HH:mm", "2026-08-30T21:08"],
+    ["ww", "ww"],                      // unknown letters pass through
+  ])("%s → %s", (pattern, expected) => {
+    expect(formatStamp(ts, pattern)).toBe(expected);
+  });
+
+  test("midnight and noon on a 12-hour clock", () => {
+    expect(formatStamp("2026-08-30 00:30:00", "h:mm AP")).toBe("12:30 AM");
+    expect(formatStamp("2026-08-30 12:00:00", "h:mm AP")).toBe("12:00 PM");
+  });
+
+  test("a date-only stamp formats at midnight", () => {
+    expect(formatStamp("2026-08-30", "dd.MM HH:mm")).toBe("30.08 00:00");
+  });
+
+  test("malformed input formats to nothing, not a crash", () => {
+    expect(formatStamp("nonsense", "HH:mm")).toBe("");
+    expect(formatStamp("", "HH:mm")).toBe("");
+  });
+});
+
+describe("formatsFromArgv", () => {
+  test("reads the three flags", () => {
+    const f = formatsFromArgv(["bun", "thread.ts", "+15550100002", "80",
+      "--time-format", "HH:mm", "--date-format", "dd.MM", "--date-format-with-year", "dd.MM.yyyy"]);
+    expect(f).toEqual(DOTTED);
+  });
+
+  test("unset or empty keeps the default", () => {
+    expect(formatsFromArgv(["bun", "thread.ts", "+15550100002", "80"])).toEqual(DEFAULT_FORMATS);
+    expect(formatsFromArgv(["--time-format", "", "--date-format"])).toEqual(DEFAULT_FORMATS);
+  });
+});
+
 describe("clockLabel", () => {
   test("formats afternoon as 12-hour with PM", () => {
     expect(clockLabel("2026-08-30 21:08:22")).toBe("9:08 PM");
@@ -42,6 +101,10 @@ describe("clockLabel", () => {
 
   test("noon is 12 PM, not 0 PM", () => {
     expect(clockLabel("2026-08-30 12:00:00")).toBe("12:00 PM");
+  });
+
+  test("follows the time pattern it is given", () => {
+    expect(clockLabel("2026-08-30 21:08:22", "HH:mm")).toBe("21:08");
   });
 
   test("garbage in yields an empty label, not a crash", () => {
@@ -66,6 +129,13 @@ describe("dayLabel", () => {
 
   test("a previous year includes it", () => {
     expect(dayLabel("2025-12-24 09:00:00", today)).toBe("Dec 24, 2025");
+  });
+
+  test("dates follow the patterns, Today and Yesterday stay words", () => {
+    expect(dayLabel("2026-08-30 09:00:00", today, DOTTED)).toBe("Today");
+    expect(dayLabel("2026-08-29 09:00:00", today, DOTTED)).toBe("Yesterday");
+    expect(dayLabel("2026-08-28 09:00:00", today, DOTTED)).toBe("28.08");
+    expect(dayLabel("2025-12-24 09:00:00", today, DOTTED)).toBe("24.12.2025");
   });
 
   test("crossing a month boundary still resolves Yesterday", () => {
@@ -99,6 +169,17 @@ describe("decorate", () => {
     expect(b[0]!.groupStart).toBe(true);
     expect(b[0]!.groupEnd).toBe(true);
     expect(b[0]!.time).toBe("12:00 PM");
+  });
+
+  test("the patterns reach the divider, the timestamp and the read receipt", () => {
+    const b = decorate(
+      [msg({ ts: "2026-08-28 16:42:00", from_me: true, read_at: "2026-08-28 16:45:00" })],
+      today,
+      DOTTED,
+    );
+    expect(b[0]!.day).toBe("28.08");
+    expect(b[0]!.time).toBe("16:42");
+    expect(b[0]!.receipt).toBe("Read 28.08 16:45");
   });
 
   test("consecutive messages from one sender form a single group", () => {
@@ -271,6 +352,7 @@ describe("loadThread", () => {
       "+15551234567",
       10,
       "2026-08-30",
+      DEFAULT_FORMATS,
       fake({ status: 0, stdout: JSON.stringify([msg({ ts: "2026-08-30 12:00:00" })]) }),
     );
     expect(r.ok).toBe(true);
@@ -279,20 +361,20 @@ describe("loadThread", () => {
   });
 
   test("exit 69 reports the bridge offline", () => {
-    const r = loadThread("+1", 10, "2026-08-30", fake({ status: 69 }));
+    const r = loadThread("+1", 10, "2026-08-30", DEFAULT_FORMATS, fake({ status: 69 }));
     expect(r.ok).toBe(false);
     expect(r.online).toBe(false);
     expect(r.error).toBe("Mac unreachable");
   });
 
   test("malformed stdout is reported, not thrown", () => {
-    const r = loadThread("+1", 10, "2026-08-30", fake({ status: 0, stdout: "junk" }));
+    const r = loadThread("+1", 10, "2026-08-30", DEFAULT_FORMATS, fake({ status: 0, stdout: "junk" }));
     expect(r.ok).toBe(false);
     expect(r.error).toContain("bad JSON");
   });
 
   test("a non-zero exit surfaces the first stderr line", () => {
-    const r = loadThread("+1", 10, "2026-08-30", fake({ status: 2, stderr: "nope\nmore" }));
+    const r = loadThread("+1", 10, "2026-08-30", DEFAULT_FORMATS, fake({ status: 2, stderr: "nope\nmore" }));
     expect(r.ok).toBe(false);
     expect(r.error).toBe("nope");
   });
@@ -349,7 +431,7 @@ describe("selectThread", () => {
   test("loadThread loads a group by EXACT chat id via thread --chat", () => {
     let seen: string[] = [];
     const runner = ((_: string, args: string[]) => { seen = args; return { status: 0, stdout: "[]", stderr: "" }; }) as never;
-    loadThread(guid, 80, "2026-08-30", runner);
+    loadThread(guid, 80, "2026-08-30", DEFAULT_FORMATS, runner);
     expect(seen).toContain("--rich");
     expect(seen).toContain("--chat");
     expect(seen[seen.indexOf("--chat") + 1]).toBe(guid);

--- a/thread.ts
+++ b/thread.ts
@@ -62,7 +62,7 @@ export interface Bubble {
   groupStart: boolean;
   /** Last bubble of a run — carries the timestamp, like iMessage. */
   groupEnd: boolean;
-  /** "9:41 PM", shown only on groupEnd. */
+  /** "9:41 PM" (or whatever `timeFormat` says), shown only on groupEnd. */
   time: string;
   /** "Read 4:42 PM" — only on the NEWEST read from-me bubble, like iMessage. */
   receipt: string;
@@ -98,22 +98,89 @@ export interface ThreadOutput {
 
 // ---------------------------------------------------------------- formatting
 
-/** "2026-08-30 21:08:22" → "9:08 PM". Avoids Date parsing and its TZ surprises. */
-export function clockLabel(ts: string): string {
-  const m = /^\d{4}-\d{2}-\d{2} (\d{2}):(\d{2})/.exec(ts);
-  if (!m) return "";
-  let h = Number(m[1]);
-  const min = m[2];
-  const suffix = h >= 12 ? "PM" : "AM";
-  h = h % 12;
-  if (h === 0) h = 12;
-  return `${h}:${min} ${suffix}`;
+/**
+ * How times and dates read. Qt format strings, set on the widget's shell.json
+ * entry exactly the way Omarchy's clock takes its `format` — the same string
+ * drives Qt in QML and formatStamp() here, so the list and the bubbles agree.
+ * Defaults are what Messages shows on a US Mac; BarWidget swaps the time for
+ * "HH:mm" when the locale has no AM/PM.
+ */
+export interface Formats {
+  time: string;
+  date: string;
+  dateWithYear: string;
 }
 
-const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+export const DEFAULT_FORMATS: Formats = { time: "h:mm AP", date: "MMM d", dateWithYear: "MMM d, yyyy" };
 
-/** "Today" / "Yesterday" / "Aug 28" / "Aug 28, 2025" for an older year. */
-export function dayLabel(ts: string, today: string): string {
+/** `--time-format`, `--date-format`, `--date-format-with-year` from argv; unset keeps the default. */
+export function formatsFromArgv(argv: readonly string[], defaults = DEFAULT_FORMATS): Formats {
+  const flag = (name: string, fallback: string) => {
+    const i = argv.indexOf(name);
+    return i >= 0 && argv[i + 1] ? argv[i + 1]! : fallback;
+  };
+  return {
+    time: flag("--time-format", defaults.time),
+    date: flag("--date-format", defaults.date),
+    dateWithYear: flag("--date-format-with-year", defaults.dateWithYear),
+  };
+}
+
+const MONTHS = ["January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"];
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+/**
+ * Qt's QDateTime::toString() for a "YYYY-MM-DD HH:MM:SS" stamp, the tokens
+ * Blip needs: d dd ddd dddd · M MM MMM MMMM · yy yyyy · h hh H HH · m mm · s ss ·
+ * AP ap A a, and 'quoted literals' with '' as an apostrophe. h/hh are 12-hour
+ * when an AM/PM token is present, 24-hour otherwise, as in Qt. Works on the
+ * string so a Mac-local stamp never meets the Linux time zone. Malformed
+ * input formats to "".
+ */
+export function formatStamp(ts: string, pattern: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})(?: (\d{2}):(\d{2})(?::(\d{2}))?)?/.exec(ts);
+  if (!m) return "";
+  const [year, month, day, hour = "00", minute = "00", second = "00"] =
+    m.slice(1) as [string, string, string, string?, string?, string?];
+  const h24 = Number(hour);
+  const h12 = h24 % 12 || 12;                                   // 0 and 12 read as 12
+  const ampm = h24 < 12 ? "am" : "pm";
+  const twelveHour = /[Aa]/.test(pattern.replace(/'(?:[^']|'')*'/g, ""));
+  const weekday = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day))).getUTCDay();
+
+  const field = (v: string, n: number) => (n === 1 ? String(Number(v)) : v);          // "08" → "8" | "08"
+  const clock = (h: number, n: number) => (n === 1 ? String(h) : String(h).padStart(2, "0"));
+  const name = (names: string[], i: number, n: number) => (n === 3 ? names[i]!.slice(0, 3) : names[i]!);
+
+  // One pass: '' · 'literal' · an unterminated quote runs to the end · AP/ap · a run of one letter.
+  return pattern.replace(/''|'((?:[^']|'')*)'|'(.*)$|AP|ap|([A-Za-z])\3*/g, (tok, quoted, tail, letter) => {
+    if (tok === "''") return "'";
+    if (quoted !== undefined) return quoted.replace(/''/g, "'");
+    if (tail !== undefined) return tail;
+    if (tok === "AP" || tok === "A") return ampm.toUpperCase();
+    if (tok === "ap" || tok === "a") return ampm;
+    const n = tok.length;
+    switch (letter) {
+      case "y": return n >= 4 ? year : n === 2 ? year.slice(2) : tok;
+      case "M": return n >= 3 ? name(MONTHS, Number(month) - 1, n) : field(month, n);
+      case "d": return n >= 3 ? name(DAYS, weekday, n) : field(day, n);
+      case "H": return clock(h24, n);
+      case "h": return clock(twelveHour ? h12 : h24, n);
+      case "m": return field(minute, n);
+      case "s": return field(second, n);
+      default: return tok;                                       // unknown letters pass through, as in Qt
+    }
+  });
+}
+
+/** "2026-08-30 21:08:22" → "9:08 PM" by default; "21:08" with timeFormat "HH:mm". */
+export function clockLabel(ts: string, time = DEFAULT_FORMATS.time): string {
+  return formatStamp(ts, time);
+}
+
+/** "Today" / "Yesterday", else the date — with the year when it is not this year. */
+export function dayLabel(ts: string, today: string, formats = DEFAULT_FORMATS): string {
   const date = ts.slice(0, 10);
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return "";
   if (date === today) return "Today";
@@ -123,10 +190,7 @@ export function dayLabel(ts: string, today: string): string {
   const diffDays = Math.round((t.getTime() - d.getTime()) / 86400000);
   if (diffDays === 1) return "Yesterday";
 
-  const month = MONTHS[Number(date.slice(5, 7)) - 1] ?? "";
-  const dayNum = Number(date.slice(8, 10));
-  const year = date.slice(0, 4);
-  return year === today.slice(0, 4) ? `${month} ${dayNum}` : `${month} ${dayNum}, ${year}`;
+  return formatStamp(ts, date.slice(0, 4) === today.slice(0, 4) ? formats.date : formats.dateWithYear);
 }
 
 /** Minutes between two "YYYY-MM-DD HH:MM:SS" stamps. */
@@ -147,7 +211,7 @@ export function minutesBetween(a: string, b: string): number {
  * timestamp — that is what keeps a long back-and-forth readable instead of
  * stamping every single line.
  */
-export function decorate(msgs: ImsgMessage[], today: string): Bubble[] {
+export function decorate(msgs: ImsgMessage[], today: string, formats = DEFAULT_FORMATS): Bubble[] {
   const out: Bubble[] = [];
 
   // iMessage shows "Read" under only the newest read message you sent.
@@ -185,11 +249,11 @@ export function decorate(msgs: ImsgMessage[], today: string): Bubble[] {
       // U+FFFC is the object-replacement placeholder Messages leaves where an
       // attachment sat; the chip row carries that information instead.
       text: (m.text ?? "").replace(/￼/g, "").trim(),
-      day: newDay ? dayLabel(m.ts, today) : "",
+      day: newDay ? dayLabel(m.ts, today, formats) : "",
       groupStart,
       groupEnd,
-      time: groupEnd ? clockLabel(m.ts) : "",
-      receipt: i === receiptIdx ? receiptLabel(m.read_at!, today) : "",
+      time: groupEnd ? clockLabel(m.ts, formats.time) : "",
+      receipt: i === receiptIdx ? receiptLabel(m.read_at!, today, formats) : "",
       tapbacks: m.tapbacks ?? [],
       // Belt to imsg 1.5.1's suspenders: link-preview payloads are not files.
       attachments: (m.attachments ?? []).filter(
@@ -251,10 +315,10 @@ export function linkify(text: string): string {
 }
 
 /** "Read 4:42 PM" today, "Read Yesterday 9:03 AM" otherwise. */
-export function receiptLabel(readAt: string, today: string): string {
-  const clock = clockLabel(readAt);
+export function receiptLabel(readAt: string, today: string, formats = DEFAULT_FORMATS): string {
+  const clock = clockLabel(readAt, formats.time);
   if (!clock) return "Read";
-  const day = dayLabel(readAt, today);
+  const day = dayLabel(readAt, today, formats);
   return day === "Today" ? `Read ${clock}` : `Read ${day} ${clock}`;
 }
 
@@ -298,6 +362,7 @@ export function loadThread(
   chat: string,
   limit: number,
   today: string,
+  formats = DEFAULT_FORMATS,
   runner = spawnSync,
 ): ThreadOutput {
   // Groups load by EXACT chat id (imsg ≥1.8.0 `thread --chat`). The old
@@ -324,7 +389,7 @@ export function loadThread(
     const parsed = JSON.parse(res.stdout as string);
     if (!Array.isArray(parsed)) throw new Error("not an array");
     const msgs = selectThread(parsed as ImsgMessage[], chat, group, limit, loadState().selfChats);
-    return { ok: true, online: true, error: "", bubbles: decorate(msgs, today) };
+    return { ok: true, online: true, error: "", bubbles: decorate(msgs, today, formats) };
   } catch (e) {
     return { ok: false, online: true, error: `bad JSON from imsg: ${e}`, bubbles: [] };
   }
@@ -347,7 +412,7 @@ if (import.meta.main) {
   const limit = Number(process.argv[3] ?? 80) || 80;
   const today = localToday();
   try {
-    console.log(JSON.stringify(loadThread(chat, limit, today)));
+    console.log(JSON.stringify(loadThread(chat, limit, today, formatsFromArgv(process.argv))));
   } catch (e) {
     console.log(JSON.stringify({ ok: false, online: false, error: String(e), bubbles: [] }));
   }


### PR DESCRIPTION
## What

Bubble timestamps, read receipts, day dividers and the conversation list now follow three Qt format strings on the widget's shell.json entry — the same inline-settings shape Omarchy's clock uses for its `format`:

```jsonc
{ "id": "nixfred.blip", "timeFormat": "HH:mm", "dateFormat": "dd.MM", "dateFormatWithYear": "dd.MM.yyyy" }
```

Unset, `timeFormat` follows the locale (`h:mm AP` when the locale's short time has an AM/PM marker, else `HH:mm`) and the date patterns stay what Blip shows today (`MMM d`, `MMM d, yyyy`). A US install keeps its bubbles as they were; the one visible change there is the list, where an older row now reads `Sep 2 11:59 PM` instead of the raw `09-02 23:59` slice.

| defaults (US locale) | `HH:mm` · `dd.MM` · `dd.MM.yyyy` |
|---|---|
| ![defaults](https://raw.githubusercontent.com/Fileri/blip/pr-assets/time-format/app-default.png) | ![configured](https://raw.githubusercontent.com/Fileri/blip/pr-assets/time-format/app.png) |

Both rendered by `scripts/demo/blip-shots` against the fake bridge — invented people, real code paths.

## Why

Two clocks in one window, and no setting for either. `thread.ts` hardcoded 12-hour for bubbles and receipts; `BlipView.fmtTime` showed the list in 24-hour by slicing the raw stamp. Next to an Omarchy bar clock set to `dddd HH:mm`, a European install read 21:08 in the bar and the list, and 9:08 PM in the conversation.

Omarchy already settled how a widget takes this kind of preference: a Qt format string inline on the entry, read with `setting()`. Copying that is smaller and more predictable than a Blip-only 12h/24h switch, and it covers dates in the same stroke.

## How

- **`thread.ts`** — `Formats { time, date, dateWithYear }` with the Messages-style defaults. `formatsFromArgv()` reads `--time-format`, `--date-format`, `--date-format-with-year`; an empty value means the default. `formatStamp(ts, pattern)` implements the Qt tokens Blip needs (`d dd ddd dddd · M MM MMM MMMM · yy yyyy · h hh H HH · m mm · s ss · AP ap A a`, quoted literals, `''` as an apostrophe); `h` is 12-hour only when an AM/PM token is present, as in Qt. It works on the string, never a `Date`, so a Mac-local stamp still never meets the Linux time zone. The hand-rolled 12-hour conversion and the month table are gone. `clockLabel`, `dayLabel`, `receiptLabel`, `decorate` and `loadThread` take the formats, defaulting to today's behaviour.
- **`BarWidget.qml`** — three `readonly` properties via `setting()`; `localeTimeFormat` is the locale-derived default.
- **`BlipView.qml`** — takes the strings from the host, passes the three flags to `thread.ts`, and formats the list with `Qt.formatTime` / `Qt.formatDate`. No arithmetic in QML.
- **`scripts/demo/DemoShell.qml`** — the screenshot harness's stand-in host supplies the three too (env-overridable), which is how the shots above were made.
- **README** (install step 4) and **CHANGELOG** (Unreleased).

`Today` and `Yesterday` stay words, as in Messages. Names and markers are English in both formatters — the same choice Omarchy's calendar makes by pinning its labels to `en_US`.

## How it was verified

- [x] `bun test` is green (CI will check) — 259 pass; 21 new tests, including a 17-row pattern table for `formatStamp`
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send; `thread.ts` was run against my own thread through the live bridge, with the flags, with empty flags, and without
- [x] UI change → screenshots above (harness, invented people). On a live Omarchy shell: restart clean, no QML warnings, list and thread agree
- [ ] Touches an invariant in `CLAUDE.md` → none touched

Cross-checks on a live Omarchy box:
- `formatStamp` vs `Qt.formatDateTime` on 23 patterns (including `h 'o''clock'`, `'at' h:mm ap`, `ddd d MMM`): identical
- Locale default under 12 locales (`en_US en_GB en_AU nb_NO de_DE fr_FR es_MX hi_IN ko_KR ja_JP ar_EG C`), each in its own Qt process: `h:mm AP` for the AM/PM locales, `HH:mm` for the rest — including `ko_KR`'s `Ap h:mm` and `ja_JP`'s `H:mm`. With an explicit pattern Qt keeps English names and markers in every one of them, so the list and the bubbles never diverge.
