### PR TITLE
bridge: ignore Family Sharing child-delegate Contacts stores when resolving names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Your kids' contact lists no longer rename your contacts.** Family
+  Sharing's "Manage Contacts" (Screen Time) mirrors each child's address book
+  onto the parent's Mac as a separate Contacts store. Contacts.app keeps those
+  out of All Contacts, but the bridge read every store on disk and let them
+  vote on names — so with two sons, the number saved as "Monica Gamble" in
+  your own contacts showed as "Mom" in every Blip thread, tile and group
+  name, two votes to one. `imsg`, `contacts` and `blip-check` now skip stores
+  whose account is flagged `isChildDelegate` in the Accounts database; a Mac
+  where that database cannot be read behaves exactly as before. `blip-check`
+  says how many child lists it ignored. Mac side: re-run the install
+  one-liner. Names and photos that exist ONLY in a child's list fall back to
+  the bare number, which is what Contacts.app shows you too.
 - **Location-sharing notices no longer show up as empty unread messages.**
   Messages.app writes its own announcements — someone joined or left, a
   rename, location sharing started or stopped — into the message table with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,12 @@ what it is handed. Keep it that way.
   (`name_for`) and photos (`cmd_avatar`) treat a collision only WITHIN one
   source as ambiguous; across sources the most common spelling wins. Got
   this wrong twice (2.0.0 photos, 1.9.4 names → "Rob T shows as a number").
+  EXCEPTION: a Family Sharing child's address book (Screen Time ▸ Manage
+  Contacts) is mirrored to the parent's Mac as its OWN CardDAV store under
+  `AddressBook/Sources/<id>/`, flagged `isChildDelegate` in
+  `~/Library/Accounts/Accounts4.sqlite`. Contacts.app hides those from All
+  Contacts; `_ab_sources()` drops them before the vote, or two sons' "Mom"
+  cards outvote your own "Monica Gamble" for the same number.
 - **`chat:null` exists.** Use `chatKey()`; never `String(m.chat)`.
 - **Group ids come in two shapes**: 32 hex, or `chat<digits>`. `isGroupChat()` is
   "not a phone/email" — never a positive regex on one shape.

--- a/bridge/mac/blip-check
+++ b/bridge/mac/blip-check
@@ -15,6 +15,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import plistlib
 import sqlite3
 import subprocess
 import sys
@@ -63,10 +64,47 @@ def check_automation() -> tuple[bool, str]:
     return False, err[:200]
 
 
+ACCOUNTS_DB = os.path.expanduser("~/Library/Accounts/Accounts4.sqlite")
+
+
+def _archived_bool(blob) -> bool:
+    """True when an NSKeyedArchiver plist archives the single value YES."""
+    try:
+        p = plistlib.loads(blob)
+        root = p["$top"]["root"]
+        v = p["$objects"][root.data] if isinstance(root, plistlib.UID) else root
+        return v is True
+    except Exception:
+        return False
+
+
+def _child_delegate_sources() -> set[str]:
+    """Account ids of Family Sharing child-delegate Contacts stores (Screen
+    Time -> Manage Contacts). Same rule as imsg/contacts: those .abcddb files
+    are a child's address book, not the user's, and are skipped for names and
+    photos. Unreadable Accounts db -> empty set."""
+    out: set[str] = set()
+    try:
+        con = sqlite3.connect(f"file:{ACCOUNTS_DB}?mode=ro", uri=True)
+        rows = con.execute(
+            "SELECT a.ZIDENTIFIER, p.ZVALUE FROM ZACCOUNTPROPERTY p "
+            "JOIN ZACCOUNT a ON a.Z_PK = p.ZOWNER WHERE p.ZKEY = 'isChildDelegate'"
+        ).fetchall()
+        con.close()
+    except sqlite3.DatabaseError:
+        return out
+    for ident, blob in rows:
+        if ident and _archived_bool(blob):
+            out.add(str(ident))
+    return out
+
+
 def _addressbook_dbs() -> list[str]:
     """One .abcddb per Contacts source/account, plus the root db, like the
     `contacts` tool. Order is stable so the check is deterministic."""
-    paths = sorted(glob.glob(AB_GLOB))
+    skip = _child_delegate_sources()
+    paths = [p for p in sorted(glob.glob(AB_GLOB))
+             if os.path.basename(os.path.dirname(p)) not in skip]
     root = os.path.join(AB_DIR, "AddressBook-v22.abcddb")
     if os.path.exists(root):
         paths.append(root)
@@ -96,6 +134,9 @@ def check_contacts() -> tuple[bool, str]:
     if readable:
         skipped = len(paths) - readable
         tail = f", {skipped} stale source(s) skipped" if skipped else ""
+        kids = len(_child_delegate_sources())
+        if kids:
+            tail += f", {kids} Family Sharing child list(s) ignored"
         return True, f"{total} contacts readable ({readable}/{len(paths)} sources{tail})"
     return False, last_err or "no AddressBook source could be opened"
 

--- a/bridge/mac/contacts
+++ b/bridge/mac/contacts
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import plistlib
 import re
 import sqlite3
 import sys
@@ -41,12 +42,58 @@ ADDRESSBOOK_DIR = os.path.expanduser(
 )
 APPLE_EPOCH = 978307200  # 2001-01-01 UTC
 
+_ACCOUNTS_DB = os.path.expanduser("~/Library/Accounts/Accounts4.sqlite")
+
+
+def _archived_bool(blob) -> bool:
+    """True when an NSKeyedArchiver plist archives the single value YES."""
+    try:
+        p = plistlib.loads(blob)
+        root = p["$top"]["root"]
+        v = p["$objects"][root.data] if isinstance(root, plistlib.UID) else root
+        return v is True
+    except Exception:
+        return False
+
+
+def _child_delegate_sources() -> set[str]:
+    """Identifiers of Contacts stores that mirror a Family Sharing child's
+    address book (Screen Time -> Manage Contacts). Each child gets its own
+    CardDAV store under AddressBook/Sources/<id>/, and the Accounts database
+    flags that account with isChildDelegate = YES. Contacts.app keeps them out
+    of All Contacts; the bridge must too, or a child's "Mom" card outvotes your
+    own spelling of the same number (two sons, two "Mom"s, one "Monica").
+    Any failure -> empty set, i.e. the old read-every-source behavior."""
+    out: set[str] = set()
+    try:
+        con = sqlite3.connect(f"file:{_ACCOUNTS_DB}?mode=ro", uri=True)
+        rows = con.execute(
+            "SELECT a.ZIDENTIFIER, p.ZVALUE FROM ZACCOUNTPROPERTY p "
+            "JOIN ZACCOUNT a ON a.Z_PK = p.ZOWNER WHERE p.ZKEY = 'isChildDelegate'"
+        ).fetchall()
+        con.close()
+    except sqlite3.DatabaseError:
+        return out
+    for ident, blob in rows:
+        if ident and _archived_bool(blob):
+            out.add(str(ident))
+    return out
+
+
+def _ab_sources() -> list[str]:
+    """Every AddressBook source db that belongs to the user, sorted, minus the
+    child-delegate mirrors. The Sources/<id>/ folder name IS the account id."""
+    skip = _child_delegate_sources()
+    return [
+        p for p in sorted(glob(os.path.join(ADDRESSBOOK_DIR, "Sources", "*", "AddressBook-v22.abcddb")))
+        if os.path.basename(os.path.dirname(p)) not in skip
+    ]
+
 
 def source_dbs() -> list[str]:
-    """All AddressBook-v22.abcddb files (one per source/account)."""
-    paths = sorted(
-        glob(os.path.join(ADDRESSBOOK_DIR, "Sources", "*", "AddressBook-v22.abcddb"))
-    )
+    """All AddressBook-v22.abcddb files (one per source/account), minus
+    Family Sharing child-delegate mirrors (see _child_delegate_sources)."""
+    paths = _ab_sources()
     # Also include the root db if non-trivial
     root = os.path.join(ADDRESSBOOK_DIR, "AddressBook-v22.abcddb")
     if os.path.exists(root):

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -48,6 +48,53 @@ _AB_GLOB = os.path.expanduser(
     "~/Library/Application Support/AddressBook/Sources/*/AddressBook-v22.abcddb"
 )
 
+_ACCOUNTS_DB = os.path.expanduser("~/Library/Accounts/Accounts4.sqlite")
+
+
+def _archived_bool(blob) -> bool:
+    """True when an NSKeyedArchiver plist archives the single value YES."""
+    try:
+        p = plistlib.loads(blob)
+        root = p["$top"]["root"]
+        v = p["$objects"][root.data] if isinstance(root, plistlib.UID) else root
+        return v is True
+    except Exception:
+        return False
+
+
+def _child_delegate_sources() -> set[str]:
+    """Identifiers of Contacts stores that mirror a Family Sharing child's
+    address book (Screen Time -> Manage Contacts). Each child gets its own
+    CardDAV store under AddressBook/Sources/<id>/, and the Accounts database
+    flags that account with isChildDelegate = YES. Contacts.app keeps them out
+    of All Contacts; the bridge must too, or a child's "Mom" card outvotes your
+    own spelling of the same number (two sons, two "Mom"s, one "Monica").
+    Any failure -> empty set, i.e. the old read-every-source behavior."""
+    out: set[str] = set()
+    try:
+        con = sqlite3.connect(f"file:{_ACCOUNTS_DB}?mode=ro", uri=True)
+        rows = con.execute(
+            "SELECT a.ZIDENTIFIER, p.ZVALUE FROM ZACCOUNTPROPERTY p "
+            "JOIN ZACCOUNT a ON a.Z_PK = p.ZOWNER WHERE p.ZKEY = 'isChildDelegate'"
+        ).fetchall()
+        con.close()
+    except sqlite3.DatabaseError:
+        return out
+    for ident, blob in rows:
+        if ident and _archived_bool(blob):
+            out.add(str(ident))
+    return out
+
+
+def _ab_sources() -> list[str]:
+    """Every AddressBook source db that belongs to the user, sorted, minus the
+    child-delegate mirrors. The Sources/<id>/ folder name IS the account id."""
+    skip = _child_delegate_sources()
+    return [
+        p for p in sorted(glob(_AB_GLOB))
+        if os.path.basename(os.path.dirname(p)) not in skip
+    ]
+
 
 def _normalize_phone(s: str) -> str:
     digits = re.sub(r"\D", "", s or "")
@@ -97,12 +144,13 @@ def name_for(handle: str | None) -> str | None:
         return None
     if _NAME_INDEX is None:
         # One person usually exists in SEVERAL sources (iCloud, Exchange, On My
-        # Mac) under slightly different spellings ("Rob" vs "Robert"). That is
+        # Mac) under slightly different spellings; a Family Sharing child's
+        # mirrored address book is NOT one of yours (_ab_sources drops it) ("Rob" vs "Robert"). That is
         # not ambiguity. Ambiguity is two DIFFERENT records inside ONE source
         # sharing the key — that source is skipped for that key. Across
         # sources the most common spelling wins; ties go to the first source.
         votes: dict[str, dict[str, int]] = {}   # key -> name -> count
-        for path in sorted(glob(_AB_GLOB)):
+        for path in _ab_sources():
             try:
                 con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
                 con.row_factory = sqlite3.Row
@@ -1110,7 +1158,7 @@ def cmd_avatar(con, args):
     if not key:
         sys.exit(1)
     candidates: list[tuple[str, int]] = []
-    for path in glob(_AB_GLOB):
+    for path in _ab_sources():
         try:
             con2 = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
             q = ("SELECT ZOWNER AS pk, ZADDRESS AS v FROM ZABCDEMAILADDRESS" if want_email


### PR DESCRIPTION
## Problem

With Family Sharing's **Manage Contacts** (Screen Time), each child's address book is mirrored onto the parent's Mac as its own CardDAV store under `~/Library/Application Support/AddressBook/Sources/<id>/`. Contacts.app hides those stores from *All Contacts*, but the bridge globbed every `.abcddb` on disk and let each one vote on a name. With two sons, the number saved as **Monica Gamble** in my own contacts rendered as **Mom** in every Blip thread, pinned tile, and group name — two votes to one.

## Fix

The Accounts database (`~/Library/Accounts/Accounts4.sqlite`, readable under the same Full Disk Access grant as `chat.db`) flags those accounts with the property `isChildDelegate = YES`, and the `Sources/<id>/` folder name is the account identifier. `imsg`, `contacts`, and `blip-check` now read that flag and drop those folders before building the name index, looking up avatars, or merging contacts.

- Unreadable Accounts database → empty skip set → exactly the previous behavior.
- `blip-check` reports `N Family Sharing child list(s) ignored`.
- CLAUDE.md gains the exception under the cross-source invariant; CHANGELOG has the user-facing note (Mac side needs the install one-liner re-run).

## Verified

macOS 26.6, live bridge:

```
skip: ['84009003', 'B8EBFFFC']
sources used: ['50B7BBAE']
+12707845266 -> Monica Gamble
  ✅  contacts   326 contacts readable (2/2 sources, 2 Family Sharing child list(s) ignored)
```

`bun collector.ts --deep` now names the DM and both groups "Monica Gamble, …". `bun test`: 279 pass. CI's `py_compile` covers the three edited tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRNWkDqR4hUHUPs1DJ8mp7
