### PR TITLE
Contact management: review, compare, edit, merge, and clean up Mac contacts from Blip

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -24,14 +24,22 @@ BarWidget {
   readonly property string collectorPath:
     decodeURIComponent(Qt.resolvedUrl("collector.ts").toString().replace(/^file:\/\//, ""))
 
+  // One validated preference source for both render surfaces. The popout and
+  // app update together, and external dotfile restores are picked up live.
+  BlipPreferences { id: preferences }
+
   // Clock and date patterns from this widget's shell.json entry — Qt format
   // strings, exactly as Omarchy's clock takes `format`. Qt formats the list
   // with them and thread.ts formats the bubbles with the same strings, so the
-  // two never disagree. Unset, the time follows the locale (an AM/PM marker
-  // means 12-hour) and dates read the way Messages writes them.
+  // two never disagree. An explicit shell.json format wins; otherwise the
+  // portable Blip preference decides 12- vs 24-hour, and an unloaded
+  // preference file falls back to the locale (an AM/PM marker = 12-hour).
   readonly property string localeTimeFormat:
     /ap/i.test(Qt.locale().timeFormat(Locale.ShortFormat)) ? "h:mm AP" : "HH:mm"
-  readonly property string timeFormat: formatSetting("timeFormat", localeTimeFormat)
+  readonly property string preferredTimeFormat: preferences.loaded
+    ? (preferences.use12HourConversationTimes ? "h:mm AP" : "HH:mm")
+    : localeTimeFormat
+  readonly property string timeFormat: formatSetting("timeFormat", preferredTimeFormat)
   readonly property string dateFormat: formatSetting("dateFormat", "MMM d")
   readonly property string dateFormatWithYear: formatSetting("dateFormatWithYear", "MMM d, yyyy")
   function formatSetting(name, fallback) { var v = String(setting(name, "")); return v === "" ? fallback : v }
@@ -112,6 +120,7 @@ BarWidget {
     target.bar = root.bar
     target.anchorItem = button
     target.hostWidget = root
+    target.preferences = preferences
   }
   onBarChanged: injectPanel()
 
@@ -137,7 +146,10 @@ BarWidget {
     id: windowLoader
     active: root.leader                // created at start so it can self-restore
     source: Qt.resolvedUrl("BlipWindow.qml")
-    onLoaded: item.hostWidget = root
+    onLoaded: {
+      item.hostWidget = root
+      item.preferences = preferences
+    }
   }
   readonly property bool windowVisible: windowLoader.item ? windowLoader.item.visible === true : false
   function hideWindow() {
@@ -175,6 +187,14 @@ BarWidget {
       'for i in 1 2 3 4 5 6 7 8; do a=$(hyprctl clients -j | jq -r \'.[] | select(.title | startswith("Blip")) | .address\' | head -1); [ -n "$a" ] && break; sleep 0.15; done; ' +
       '[ -n "$a" ] && hyprctl dispatch "hl.dsp.focus({ window = \\"address:$a\\" })" >/dev/null'])
   }
+  function showSettings(page) {
+    showApp()
+    Qt.callLater(function() {
+      if (!windowLoader.item) return
+      windowLoader.item.visible = true
+      windowLoader.item.openSettings(page)
+    })
+  }
   /** Either surface open → keep the deep (complete) thread list. */
   function anySurfaceOpen() {
     return (panelLoader.item && panelLoader.item.opened === true)
@@ -209,9 +229,21 @@ BarWidget {
   property var refreshQueue: []        // stateful requests are never overwritten
   property bool collectorReserved: false // a queued run owns the next event-loop turn
 
-  function refresh(deep, markRead, readChat, seen) {
+  function normalizedReadAliases(readChat, values) {
+    var chat = String(readChat || "")
+    var source = Array.isArray(values) ? values : []
+    var out = []
+    for (var i = 0; i < source.length && out.length < 15; i++) {
+      var alias = String(source[i] || "")
+      if (alias !== "" && alias !== chat && out.indexOf(alias) < 0) out.push(alias)
+    }
+    return out
+  }
+
+  function refresh(deep, markRead, readChat, seen, readAliases) {
     var req = { deep: deep === true, markRead: markRead === true,
-                readChat: String(readChat || ""), seen: String(seen || "") }
+                readChat: String(readChat || ""), seen: String(seen || ""),
+                readAliases: normalizedReadAliases(readChat, readAliases) }
     if (collector.running || collectorReserved) { enqueueRefresh(req); return }
     runRefresh(req)
   }
@@ -223,9 +255,11 @@ BarWidget {
     // entry per ping). mark-all stays FIFO and is never overwritten.
     if (!req.markRead) {
       for (var i = 0; i < q.length; i++) {
-        if (!q[i].markRead && q[i].readChat === req.readChat) {
+        if (!q[i].markRead && q[i].readChat === req.readChat
+            && JSON.stringify(q[i].readAliases || []) === JSON.stringify(req.readAliases)) {
           q[i] = { deep: q[i].deep || req.deep, markRead: false, readChat: req.readChat,
-                   seen: req.seen > q[i].seen ? req.seen : q[i].seen }
+                   seen: req.seen > q[i].seen ? req.seen : q[i].seen,
+                   readAliases: req.readAliases }
           refreshQueue = q
           return
         }
@@ -240,6 +274,8 @@ BarWidget {
     if (req.markRead) args.push("--mark-read")
     if (req.readChat !== "") {
       args.push("--read", req.readChat)
+      for (var i = 0; i < req.readAliases.length; i++)
+        args.push("--read-alias", req.readAliases[i])
       if (req.seen !== "") args.push("--seen", req.seen)
     }
     collector.command = args
@@ -284,7 +320,7 @@ BarWidget {
     return out
   }
 
-  function markThreadRead(chat) {
+  function markThreadRead(chat, aliases) {
     var c = String(chat)
     var lastTs = ""
     var list = threads.map(function(t) {
@@ -295,7 +331,7 @@ BarWidget {
     noteLocalRead(c, lastTs)
     threads = list
     unread = list.reduce(function(n, t) { return n + (Number(t.unread) || 0) }, 0)
-    refresh(true, false, c, lastTs)
+    refresh(true, false, c, lastTs, aliases)
   }
 
   function markAllRead() {
@@ -333,6 +369,10 @@ BarWidget {
   function activeSeenTs() {
     var s = readingSurface()
     return s ? String(s.activeLastTs || "") : ""
+  }
+  function activeReadAliases() {
+    var s = readingSurface()
+    return s && s.active ? s.active.aliases || [] : []
   }
 
   Process {
@@ -425,7 +465,7 @@ BarWidget {
     // While the panel is open keep the wide window, or the list would shrink
     // from 40 threads to 14 on the next tick.
     onTriggered: root.refresh(root.anySurfaceOpen(), false,
-                              root.activeReadChat(), root.activeSeenTs())
+                              root.activeReadChat(), root.activeSeenTs(), root.activeReadAliases())
   }
 
   // ------------------------------------------------- real-time push
@@ -477,7 +517,8 @@ BarWidget {
       // Carrying the open thread's chat means a message landing in the
       // conversation the user is READING is counted read in this same run —
       // no badge flash, no second round-trip.
-      root.refresh(root.anySurfaceOpen(), false, root.activeReadChat(), root.activeSeenTs())
+      root.refresh(root.anySurfaceOpen(), false, root.activeReadChat(), root.activeSeenTs(),
+                   root.activeReadAliases())
       // Reload the OPEN conversation in parallel — waiting for the collector
       // and then reloading serially added a visible second of latency.
       // Both surfaces: each gates itself on its own surfaceOpen.
@@ -569,7 +610,7 @@ BarWidget {
   // ------------------------------------------------------------ IPC
   // IPC that sends or reads message content is a deputy for any local
   // process (Codex audit #3). It is opt-in: automation=on in bridge.conf.
-  // status/open/close/toggle/window/app stay available — they expose nothing.
+  // status/open/close/toggle/window/app/settings stay available — they expose nothing.
   property bool automationOn: false
   readonly property string automationOff: "blip: automation=off — set automation=on in ~/.config/blip/bridge.conf to allow ipc send/read"
   FileView {
@@ -606,6 +647,8 @@ BarWidget {
     function newchat(query: string): string { if (!root.automationOn) return root.automationOff; return panelLoader.item ? panelLoader.item.newChatFor(query) : "no panel" }
     function window(): string { root.toggleWindow(); return root.windowVisible ? "window shown" : "window hidden" }
     function app(): string { root.showApp(); return "app shown + focused" }
+    function settings(): string { root.showSettings(); return "settings shown" }
+    function appearance(): string { root.showSettings("appearance"); return "appearance settings shown" }
     function windowgoto(chat: string): string {
       if (!root.automationOn) return root.automationOff
       root.ensureWindow()

--- a/BlipIdentities.qml
+++ b/BlipIdentities.qml
@@ -1,0 +1,1089 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Short-lived, bounded bridge between the settings UI and identities.ts.
+// No writable contact/config file is parsed inside the shell process.
+Item {
+  id: root
+  visible: false
+  implicitWidth: 0
+  implicitHeight: 0
+
+  readonly property string home: Quickshell.env("HOME")
+  readonly property string configPath: home + "/.config/blip/identities.json"
+  readonly property string runtimeDirectory: Quickshell.env("XDG_RUNTIME_DIR")
+  readonly property string vcardUriPrefix: "file://" + runtimeDirectory + "/blip/vcards/"
+  readonly property string helperPath:
+    decodeURIComponent(Qt.resolvedUrl("identities.ts").toString().replace(/^file:\/\//, ""))
+
+  property var identities: []
+  property var candidates: []
+  property var audit: null
+  property var repairPreview: null
+  property var comparison: null
+  property var linkPreview: null
+  property var mutationPreview: null
+  property var mutationRequest: null
+  property string comparisonOwnerToken: ""
+  // Set only for an explicit cross-name merge (two candidates the user
+  // identified as the same person); "" for the normal single-person scope.
+  property string comparisonOtherOwnerToken: ""
+  property string activeHandle: ""
+  property bool contactWrites: false
+  property string pendingRepairToken: ""
+  property string pendingOwnerToken: ""
+  property string undoToken: ""
+  property string undoHandle: ""
+  property string undoName: ""
+  property int undoFieldCount: 0
+  property string undoAction: ""
+  property int undoCardCount: 0
+  property bool loaded: false
+  property bool loading: false
+  property string error: ""
+  property string notice: "Loading contact choices…"
+  property string currentOperation: ""
+  property bool reloadAfterExit: false
+  property bool readSilently: false
+  property string identitiesJson: ""
+  property string pendingReviewHandle: ""
+  property bool refreshCandidatesAfterExit: false
+  property int pendingAuditCount: 0
+  property bool quietAudit: false
+  // The cleanup scan runs on its own dedicated process (auditWorker) so a
+  // long scan can start the moment a mutation lands without contending with
+  // navigation, edits, or merges on the interactive worker.
+  property bool auditRunning: false
+  property string pendingAuditFingerprint: ""
+  property string auditFingerprint: ""
+  property bool vcardReported: false
+  property bool vcardClipboardPending: false
+  property string pendingVcardPayload: ""
+  property string pendingVcardFileName: ""
+
+  signal choicesChanged()
+  // Fired after any operation that changed Mac Contacts (edit, delete,
+  // merge, link, field removal, undo) so listeners can refresh derived
+  // views like the cleanup scan.
+  signal contactsMutated()
+  signal vcardFinished(string message, bool success)
+
+  function safeText(value, maximum) {
+    if (typeof value !== "string" || value.length > maximum) return ""
+    return value
+      .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+      .replace(/\s+/g, " ").trim()
+  }
+
+  function safeError(value) {
+    return safeText(String(value || "Contact-name operation failed"), 180)
+      || "Contact-name operation failed"
+  }
+
+  function handleKey(value) {
+    var handle = String(value || "")
+    if (handle.indexOf("@") >= 0) return "email:" + handle.toLowerCase()
+    var digits = handle.replace(/\D/g, "")
+    return "phone:" + (digits.length >= 10 ? digits.slice(-10) : digits)
+  }
+
+  function validToken(value) {
+    return typeof value === "string" && /^sha256:[0-9a-f]{64}$/.test(value)
+  }
+
+  function validRevision(value) {
+    return typeof value === "string" && /^sha256:[0-9a-f]{64}$/.test(value)
+  }
+
+  function safeIdentity(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var source = value.source === "contacts" ? "contacts" : value.source === "custom" ? "custom" : ""
+    if (handle === "" || name === "" || source === "") return null
+    var result = { handle: handle, name: name, source: source, contactToken: "" }
+    if (source === "contacts") {
+      if (!validToken(value.contactToken)) return null
+      result.contactToken = value.contactToken
+    }
+    return result
+  }
+
+  function safeCandidate(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var name = safeText(value.name, 160)
+    var records = Number(value.recordCount)
+    var sources = Number(value.sourceCount)
+    if (name === "" || !validToken(value.token)
+        || !Number.isInteger(records) || records < 1 || records > 64
+        || !Number.isInteger(sources) || sources < 1 || sources > 64) return null
+    if (!Array.isArray(value.cards) || value.cards.length !== records) return null
+    var cards = []
+    var accounts = ({})
+    var tokens = ({})
+    tokens[value.token] = true
+    for (var i = 0; i < value.cards.length; i++) {
+      var rawCard = value.cards[i]
+      if (!rawCard || typeof rawCard !== "object" || Array.isArray(rawCard)
+          || !validToken(rawCard.token) || tokens[rawCard.token]) return null
+      var account = Number(rawCard.accountNumber)
+      var sourceName = safeText(rawCard.sourceName, 120)
+      if (!Number.isInteger(account) || account < 1 || account > 64) return null
+      if (sourceName === "") return null
+      tokens[rawCard.token] = true
+      accounts[account] = true
+      cards.push({
+        token: rawCard.token,
+        accountNumber: account,
+        sourceName: sourceName,
+        hasPhoto: rawCard.hasPhoto === true,
+        matchCount: Number.isInteger(Number(rawCard.matchCount))
+          && Number(rawCard.matchCount) >= 1 && Number(rawCard.matchCount) <= 8
+          ? Number(rawCard.matchCount) : 1
+      })
+    }
+    if (Object.keys(accounts).length !== sources) return null
+    return {
+      token: value.token,
+      name: name,
+      recordCount: records,
+      sourceCount: sources,
+      hasPhoto: value.hasPhoto === true,
+      cards: cards
+    }
+  }
+
+  function safeAudit(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handleCount = Number(value.handleCount)
+    var noMatchCount = Number(value.noMatchCount)
+    if (!Number.isInteger(handleCount) || handleCount < 1 || handleCount > 200
+        || handleCount !== pendingAuditCount
+        || !Number.isInteger(noMatchCount) || noMatchCount < 0 || noMatchCount > handleCount)
+      return null
+    var seen = ({})
+    function entries(raw, kind) {
+      if (!Array.isArray(raw) || raw.length > 200) return null
+      var result = []
+      for (var i = 0; i < raw.length; i++) {
+        var item = raw[i]
+        if (!item || typeof item !== "object" || Array.isArray(item)) return null
+        var handle = root.safeText(item.handle, 320)
+        var key = root.handleKey(handle)
+        var options = root.validatedList(item.candidates, function(candidate) {
+          return root.safeCandidate(candidate)
+        }, 8)
+        if (handle === "" || seen[key] || options === null) return null
+        if (kind === "single" && (options.length !== 1 || options[0].recordCount !== 1)) return null
+        if (kind === "duplicate" && (options.length !== 1 || options[0].recordCount < 2)) return null
+        if (kind === "conflict" && options.length < 2) return null
+        seen[key] = true
+        result.push({ handle: handle, candidates: options })
+      }
+      return result
+    }
+    var singleCards = entries(value.singleCards, "single")
+    var duplicates = entries(value.duplicates, "duplicate")
+    var conflicts = entries(value.conflicts, "conflict")
+    if (singleCards === null || duplicates === null || conflicts === null
+        || noMatchCount + singleCards.length + duplicates.length + conflicts.length !== handleCount)
+      return null
+    return { handleCount: handleCount, noMatchCount: noMatchCount,
+      singleCards: singleCards, duplicates: duplicates, conflicts: conflicts }
+  }
+
+  function safeRepairPreview(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var kind = value.kind === "phone" ? "phone" : value.kind === "email" ? "email" : ""
+    var fieldCount = Number(value.fieldCount)
+    var cardNumber = Number(value.cardNumber)
+    var cardCount = Number(value.cardCount)
+    var accountNumber = Number(value.accountNumber)
+    var sourceName = safeText(value.sourceName, 120)
+    if (handle === "" || name === "" || kind === ""
+        || !Number.isInteger(fieldCount) || fieldCount < 1 || fieldCount > 8
+        || !Number.isInteger(cardNumber) || cardNumber < 1 || cardNumber > 64
+        || !Number.isInteger(cardCount) || cardCount < cardNumber || cardCount > 64
+        || !Number.isInteger(accountNumber) || accountNumber < 1 || accountNumber > 64
+        || sourceName === ""
+        || !Array.isArray(value.labels) || value.labels.length !== fieldCount) return null
+    var labels = []
+    for (var i = 0; i < value.labels.length; i++) {
+      if (typeof value.labels[i] !== "string" || value.labels[i].length > 80) return null
+      labels.push(safeText(value.labels[i], 80))
+    }
+    return {
+      handle: handle, name: name, kind: kind, fieldCount: fieldCount,
+      labels: labels, cardNumber: cardNumber, cardCount: cardCount,
+      accountNumber: accountNumber, sourceName: sourceName,
+      writeEnabled: value.writeEnabled === true,
+      token: pendingRepairToken, ownerToken: pendingOwnerToken
+    }
+  }
+
+  function safeOptionalText(value, maximum) {
+    if (typeof value !== "string" || value.length > maximum) return null
+    return value
+      .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+      .replace(/\s+/g, " ").trim()
+  }
+
+  function safeLabeledValues(value) {
+    if (!Array.isArray(value) || value.length > 16) return null
+    var result = []
+    for (var i = 0; i < value.length; i++) {
+      var item = value[i]
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null
+      var label = safeOptionalText(item.label, 80)
+      var itemValue = safeOptionalText(item.value, 320)
+      if (label === null || itemValue === null || itemValue === "") return null
+      result.push({ label: label, value: itemValue })
+    }
+    return result
+  }
+
+  function safeAddresses(value) {
+    if (!Array.isArray(value) || value.length > 16) return null
+    var result = []
+    var keys = ["label", "street", "city", "state", "postalCode", "country", "countryCode"]
+    var limits = [80, 320, 320, 320, 80, 160, 8]
+    for (var i = 0; i < value.length; i++) {
+      var item = value[i]
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null
+      var address = ({})
+      for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+        var cleaned = safeOptionalText(item[keys[keyIndex]], limits[keyIndex])
+        if (cleaned === null) return null
+        address[keys[keyIndex]] = cleaned
+      }
+      if (address.street === "" && address.city === "" && address.state === ""
+          && address.postalCode === "" && address.country === "") return null
+      result.push(address)
+    }
+    return result
+  }
+
+  function safeComparisonCard(value, expectedNumber, seenTokens) {
+    if (!value || typeof value !== "object" || Array.isArray(value) || !validToken(value.token)
+        || seenTokens[value.token]) return null
+    var cardNumber = Number(value.cardNumber)
+    var accountNumber = Number(value.accountNumber)
+    var sourceName = safeText(value.sourceName, 120)
+    if (!Number.isInteger(cardNumber) || cardNumber !== expectedNumber
+        || !Number.isInteger(accountNumber) || accountNumber < 1 || accountNumber > 64
+        || sourceName === "") return null
+    var scalarKeys = ["displayName", "firstName", "middleName", "lastName", "nickname",
+      "organization", "department", "jobTitle", "birthday", "note"]
+    var scalarLimits = [160, 160, 160, 160, 160, 320, 320, 320, 10, 1000]
+    if (!validRevision(value.revision)) return null
+    var card = ({ token: value.token, revision: value.revision,
+      cardNumber: cardNumber, accountNumber: accountNumber,
+      sourceName: sourceName,
+      hasPhoto: value.hasPhoto === true })
+    seenTokens[value.token] = true
+    for (var i = 0; i < scalarKeys.length; i++) {
+      var text = safeOptionalText(value[scalarKeys[i]], scalarLimits[i])
+      if (text === null) return null
+      card[scalarKeys[i]] = text
+    }
+    if (card.birthday !== "" && !/^(?:[0-9]{4}\-|--)[0-9]{2}\-[0-9]{2}$/.test(card.birthday)) return null
+    card.phones = safeLabeledValues(value.phones)
+    card.emails = safeLabeledValues(value.emails)
+    card.urls = safeLabeledValues(value.urls)
+    card.addresses = safeAddresses(value.addresses)
+    if (card.phones === null || card.emails === null || card.urls === null || card.addresses === null)
+      return null
+    return card
+  }
+
+  function safeComparison(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var cardCount = Number(value.cardCount)
+    var sourceCount = Number(value.sourceCount)
+    if (handle === "" || name === "" || !Number.isInteger(cardCount) || cardCount < 1 || cardCount > 8
+        || !Number.isInteger(sourceCount) || sourceCount < 1 || sourceCount > 8
+        || !Array.isArray(value.cards) || value.cards.length !== cardCount) return null
+    var seen = ({})
+    var accounts = ({})
+    var cards = []
+    for (var i = 0; i < value.cards.length; i++) {
+      var card = safeComparisonCard(value.cards[i], i + 1, seen)
+      if (!card) return null
+      accounts[card.accountNumber] = true
+      cards.push(card)
+    }
+    if (Object.keys(accounts).length !== sourceCount) return null
+    return { handle: handle, name: name, cardCount: cardCount, sourceCount: sourceCount,
+      writeEnabled: value.writeEnabled === true, cards: cards, ownerToken: comparisonOwnerToken,
+      otherOwnerToken: comparisonOtherOwnerToken }
+  }
+
+
+  function safeMutationPreview(value, requireApplied) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var action = ["edit", "delete", "consolidate"].indexOf(value.action) >= 0 ? value.action : ""
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var cardNumber = Number(value.cardNumber)
+    var cardCount = Number(value.cardCount)
+    var accountNumber = Number(value.accountNumber)
+    var sourceName = safeText(value.sourceName, 120)
+    var sourceCardCount = Number(value.sourceCardCount)
+    if (action === "" || handle === "" || name === "" || !validRevision(value.planHash)
+        || !Number.isInteger(cardNumber) || cardNumber < 1 || cardNumber > 8
+        || !Number.isInteger(cardCount) || cardCount < cardNumber || cardCount > 8
+        || !Number.isInteger(accountNumber) || accountNumber < 1 || accountNumber > 64
+        || sourceName === ""
+        || !Number.isInteger(sourceCardCount) || sourceCardCount < 0 || sourceCardCount > 7
+        || !Array.isArray(value.changedFields) || value.changedFields.length < 1
+        || value.changedFields.length > 13) return null
+    var changed = []
+    for (var i = 0; i < value.changedFields.length; i++) {
+      var field = safeText(value.changedFields[i], 40)
+      if (field === "") return null
+      changed.push(field)
+    }
+    if (requireApplied === true && (value.applied !== true
+        || !/^undo:[0-9a-f]{32}$/.test(String(value.undoToken || "")))) return null
+    if (requireApplied === true && action !== "delete"
+        && (!validRevision(value.revision) || safeText(value.displayName, 160) === "")) return null
+    return { action: action, handle: handle, name: name, cardNumber: cardNumber,
+      cardCount: cardCount, accountNumber: accountNumber, sourceCardCount: sourceCardCount,
+      sourceName: sourceName,
+      changedFields: changed, planHash: value.planHash, writeEnabled: value.writeEnabled === true,
+      applied: value.applied === true, undoToken: String(value.undoToken || ""),
+      revision: String(value.revision || ""), displayName: safeText(value.displayName || "", 160) }
+  }
+
+  function safeLinkPreview(value, requireLinked) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var cardCount = Number(value.cardCount)
+    var sourceCount = Number(value.sourceCount)
+    var action = safeText(value.action, 80)
+    if (handle === "" || name === "" || !Number.isInteger(cardCount) || cardCount < 2 || cardCount > 8
+        || !Number.isInteger(sourceCount) || sourceCount < 1 || sourceCount > 8
+        || ["Link Selected Cards", "Merge Selected Cards", "Merge and Link Selected Cards"].indexOf(action) < 0)
+      return null
+    if (requireLinked === true && value.linked !== true) return null
+    if (requireLinked !== true && typeof value.ready !== "boolean") return null
+    return { handle: handle, name: name, cardCount: cardCount, sourceCount: sourceCount,
+      writeEnabled: value.writeEnabled === true, action: action,
+      ready: requireLinked === true ? false : value.ready, linked: value.linked === true }
+  }
+
+  function validatedList(value, validator, maximum) {
+    if (!Array.isArray(value) || value.length > maximum) return null
+    var result = []
+    for (var i = 0; i < value.length; i++) {
+      var item = validator(value[i])
+      if (!item) return null
+      result.push(item)
+    }
+    return result
+  }
+
+  function start(operation, payload, quiet) {
+    if (worker.running) return false
+    error = ""
+    currentOperation = operation
+    if (operation === "vcard") vcardReported = false
+    reloadAfterExit = false
+    refreshCandidatesAfterExit = false
+    // A periodic read is bookkeeping, not a visible operation. Toggling
+    // `loading` here used to disable and repaint every settings row at 5 s.
+    loading = quiet !== true
+    worker.payload = payload === undefined ? "" : JSON.stringify(payload)
+    worker.stdinEnabled = worker.payload !== ""
+    worker.command = ["bun", helperPath, operation]
+    worker.running = true
+    return true
+  }
+
+  function load(silent) {
+    readSilently = silent === true
+    return start("read", undefined, readSilently && loaded)
+  }
+
+  function findCandidates(handle) {
+    var requested = safeText(String(handle || ""), 320)
+    if (requested === "") return false
+    // A click that lands during the tiny local-file refresh window must not
+    // be lost. Finish that read, then begin the user-visible Mac lookup.
+    if (worker.running) {
+      if (currentOperation === "read" && readSilently) {
+        pendingReviewHandle = requested
+        return true
+      }
+      return false
+    }
+    activeHandle = requested
+    candidates = []
+    repairPreview = null
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+    pendingRepairToken = ""
+    pendingOwnerToken = ""
+    notice = "Checking matching cards on the Mac…"
+    return start("candidates", { handle: activeHandle }, false)
+  }
+
+  // quiet = an automatic freshness re-scan after a contact mutation: it must
+  // not clobber the mutation's own success notice. Previous results stay
+  // visible (stale) while the fresh scan runs; auditRunning drives the UI's
+  // in-progress state.
+  function auditContacts(handles, quiet) {
+    if (auditWorker.running) return false
+    if (!Array.isArray(handles) || handles.length < 1 || handles.length > 200) return false
+    var accepted = []
+    var seen = ({})
+    for (var i = 0; i < handles.length; i++) {
+      var handle = safeText(handles[i], 320)
+      var key = handleKey(handle)
+      if (handle === "" || seen[key]) return false
+      seen[key] = true
+      accepted.push(handle)
+    }
+    quietAudit = quiet === true
+    pendingAuditCount = accepted.length
+    pendingAuditFingerprint = JSON.stringify(Object.keys(seen).sort())
+    if (!quietAudit) notice = "Scanning matching Contacts cards; nothing will be changed…"
+    auditWorker.payload = JSON.stringify({ handles: accepted })
+    auditWorker.stdinEnabled = true
+    auditWorker.command = ["bun", helperPath, "audit"]
+    auditRunning = true
+    auditWorker.running = true
+    return true
+  }
+
+  function consumeAudit(text) {
+    auditRunning = false
+    var result = null
+    try { result = JSON.parse(text) } catch (e) { result = null }
+    var audited = result && result.ok === true ? safeAudit(result.audit) : null
+    if (!audited) {
+      if (!quietAudit) error = "Identity helper returned an invalid contact audit"
+      return
+    }
+    audit = audited
+    auditFingerprint = pendingAuditFingerprint
+    if (!quietAudit) notice = result.cached === true
+      ? "Cleanup results are current — Contacts hasn't changed since the last scan"
+      : "Contact cleanup scan finished; nothing was changed"
+  }
+
+  function clearAudit() {
+    if (auditWorker.running) return false
+    audit = null
+    pendingAuditCount = 0
+    pendingAuditFingerprint = ""
+    auditFingerprint = ""
+    return true
+  }
+
+  function dismissReview() {
+    if (worker.running) return false
+    activeHandle = ""
+    candidates = []
+    repairPreview = null
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+    pendingRepairToken = ""
+    pendingOwnerToken = ""
+    error = ""
+    notice = identities.length === 0 ? "No saved contact choices" : "Loaded saved contact choices"
+    return true
+  }
+
+  function choose(handle, name, token) {
+    notice = "Saving an optional display preference in Blip…"
+    return start("choose", { handle: handle, name: name, token: token })
+  }
+
+  function setCustom(handle, name) {
+    notice = "Saving custom name…"
+    return start("custom", { handle: handle, name: name })
+  }
+
+  function clearChoice(handle) {
+    notice = "Removing the portable display preference…"
+    return start("clear", { handle: handle })
+  }
+
+  function openOnMac(handle, token) {
+    notice = "Opening one Contacts card on the Mac; no data will be changed…"
+    return start("open", { handle: handle, token: token })
+  }
+
+  function copyVCard(handle) {
+    notice = "Exporting the contact from the Mac…"
+    return start("vcard", { handle: handle })
+  }
+
+  function reportVCard(message, success) {
+    if (currentOperation !== "vcard" || vcardReported) return
+    vcardReported = true
+    vcardFinished(message, success === true)
+  }
+
+  function startVcardClipboard() {
+    if (pendingVcardPayload === "") return
+    vcardClipboard.payload = pendingVcardPayload
+    vcardClipboard.fileName = pendingVcardFileName
+    vcardClipboardPending = true
+    vcardClipboard.stdinEnabled = true
+    vcardClipboard.running = true
+  }
+
+  function serveVCard(fileUri, fileName) {
+    pendingVcardPayload = "copy\n" + fileUri + "\n"
+    pendingVcardFileName = fileName
+    vcardClipboardPending = true
+    if (vcardClipboard.running) {
+      vcardClipboard.replacing = true
+      vcardClipboard.running = false
+    } else {
+      startVcardClipboard()
+    }
+  }
+
+  function compareCards(handle, ownerToken, otherOwnerToken) {
+    if (!validToken(ownerToken)) return false
+    var cross = otherOwnerToken !== undefined && otherOwnerToken !== null
+      && String(otherOwnerToken) !== ""
+    if (cross && (!validToken(otherOwnerToken) || otherOwnerToken === ownerToken)) return false
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ownerToken
+    comparisonOtherOwnerToken = cross ? String(otherOwnerToken) : ""
+    notice = cross
+      ? "Loading both people's card details from Contacts…"
+      : "Loading the active card details from Contacts…"
+    var payload = ({ handle: handle, ownerToken: ownerToken })
+    if (cross) payload.otherOwnerToken = String(otherOwnerToken)
+    return start("compare", payload)
+  }
+
+  function prepareCardEdit(card, draft) {
+    if (!contactWrites || !comparison || !card || !validToken(card.token)
+        || !validRevision(card.revision) || !validToken(comparison.ownerToken)
+        || String(comparison.otherOwnerToken || "") !== "") return false
+    mutationPreview = null
+    mutationRequest = { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      token: card.token, revision: card.revision, card: draft }
+    notice = "Verifying this contact edit on the Mac…"
+    return start("edit-prepare", mutationRequest)
+  }
+
+  function prepareCardDelete(card) {
+    if (!contactWrites || !comparison || !card || !validToken(card.token)
+        || !validRevision(card.revision) || !validToken(comparison.ownerToken)
+        || String(comparison.otherOwnerToken || "") !== "") return false
+    mutationPreview = null
+    mutationRequest = { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      token: card.token, revision: card.revision }
+    notice = "Verifying this source-card deletion on the Mac…"
+    return start("delete-prepare", mutationRequest)
+  }
+
+  function prepareConsolidation(targetCard, draft) {
+    if (!contactWrites || !comparison || comparison.cards.length < 2 || !targetCard
+        || !validToken(targetCard.token) || !validToken(comparison.ownerToken)) return false
+    var revisions = []
+    for (var i = 0; i < comparison.cards.length; i++) {
+      var card = comparison.cards[i]
+      if (!validToken(card.token) || !validRevision(card.revision)) return false
+      revisions.push({ token: card.token, revision: card.revision })
+    }
+    mutationPreview = null
+    mutationRequest = { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      targetToken: targetCard.token, revisions: revisions, card: draft }
+    if (String(comparison.otherOwnerToken || "") !== "")
+      mutationRequest.otherOwnerToken = comparison.otherOwnerToken
+    notice = "Verifying the merged card and every source card on the Mac…"
+    return start("merge-prepare", mutationRequest)
+  }
+
+  function applyMutation() {
+    if (!contactWrites || !mutationPreview || !mutationPreview.writeEnabled || !mutationRequest
+        || !validRevision(mutationPreview.planHash)) return false
+    var operation = mutationPreview.action === "edit" ? "edit"
+      : mutationPreview.action === "delete" ? "delete" : "merge"
+    var request = ({})
+    var keys = Object.keys(mutationRequest)
+    for (var i = 0; i < keys.length; i++) request[keys[i]] = mutationRequest[keys[i]]
+    request.planHash = mutationPreview.planHash
+    notice = operation === "edit" ? "Saving the verified contact edit…"
+      : operation === "delete" ? "Deleting the verified source card…"
+      : "Consolidating the verified source cards…"
+    return start(operation, request)
+  }
+
+  function cancelMutation() {
+    if (worker.running) return false
+    mutationPreview = null
+    mutationRequest = null
+    notice = "No Contacts data was changed"
+    return true
+  }
+
+  function discardUnsavedContacts() {
+    if (!contactWrites) return false
+    notice = "Closing Contacts on the Mac without saving its pending edit…"
+    return start("discard-unsaved", {})
+  }
+
+  function prepareLink() {
+    if (!contactWrites || !comparison || !comparison.writeEnabled
+        || !validToken(comparison.ownerToken)) return false
+    linkPreview = null
+    notice = "Selecting the exact cards and checking Apple’s link action…"
+    return start("link-prepare", {
+      handle: comparison.handle, ownerToken: comparison.ownerToken
+    })
+  }
+
+  function linkCards() {
+    if (!contactWrites || !comparison || !linkPreview || !linkPreview.ready
+        || !linkPreview.writeEnabled || !validToken(comparison.ownerToken)) return false
+    notice = "Running Contacts’ verified “" + linkPreview.action + "” action…"
+    return start("link", { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      expectedAction: linkPreview.action })
+  }
+
+  function cancelLink() {
+    if (worker.running) return false
+    linkPreview = null
+    notice = "No Contacts data was changed"
+    return true
+  }
+
+  function cancelComparison() {
+    if (worker.running) return false
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+    notice = candidates.length > 1 ? "Contacts has conflicting names" : "Contacts has one matching name"
+    return true
+  }
+
+  function inspectOnMac(handle, token, ownerToken) {
+    if (!contactWrites || !validToken(token) || !validToken(ownerToken) || token === ownerToken)
+      return false
+    pendingRepairToken = token
+    pendingOwnerToken = ownerToken
+    repairPreview = null
+    notice = "Verifying the exact field with Contacts on the Mac…"
+    return start("inspect", { handle: handle, token: token, ownerToken: ownerToken })
+  }
+
+  function cancelRepair() {
+    if (worker.running) return false
+    repairPreview = null
+    pendingRepairToken = ""
+    pendingOwnerToken = ""
+    notice = candidates.length > 1 ? "Contacts has conflicting names" : "Contacts has one matching name"
+    return true
+  }
+
+  function removeOnMac() {
+    if (!contactWrites || !repairPreview || !repairPreview.writeEnabled
+        || !validToken(repairPreview.token)
+        || !validToken(repairPreview.ownerToken)) return false
+    notice = "Removing the verified field from Mac Contacts…"
+    return start("remove", {
+      handle: repairPreview.handle, token: repairPreview.token,
+      ownerToken: repairPreview.ownerToken
+    })
+  }
+
+  function undoOnMac() {
+    if (!contactWrites || !/^undo:[0-9a-f]{32}$/.test(undoToken)) return false
+    notice = "Undoing the last Blip contact change…"
+    return start("undo", { undoToken: undoToken })
+  }
+
+  function consume(raw) {
+    if (raw.length > 49152) {
+      error = "Identity helper returned too much data"
+      reportVCard(error, false)
+      return
+    }
+    var result
+    try { result = JSON.parse(raw.trim()) }
+    catch (e) {
+      error = "Identity helper returned invalid JSON"
+      reportVCard(error, false)
+      return
+    }
+    if (!result || result.ok !== true) {
+      error = safeError(result ? result.error : "Identity helper failed")
+      reportVCard(error, false)
+      return
+    }
+    if (currentOperation === "read") {
+      var saved = validatedList(result.identities, function(value) { return root.safeIdentity(value) }, 64)
+      if (saved === null) { error = "Identity helper returned an invalid saved-choice list"; return }
+      var serialized = JSON.stringify(saved)
+      // A QML array assignment rebuilds every Repeater delegate, even when
+      // the rows are identical. Preserve the existing model on no-op polls.
+      if (serialized !== identitiesJson) {
+        identitiesJson = serialized
+        identities = saved
+      }
+      contactWrites = result.contactWrites === true
+      loaded = true
+      if (!readSilently)
+        notice = saved.length === 0 ? "No saved contact choices" : "Loaded saved contact choices"
+      return
+    }
+    if (currentOperation === "candidates") {
+      var options = validatedList(result.candidates, function(value) { return root.safeCandidate(value) }, 8)
+      var handle = safeText(result.handle, 320)
+      if (options === null || handle === "") {
+        error = "Identity helper returned an invalid candidate list"
+        return
+      }
+      var totalCards = 0
+      var allTokens = ({})
+      for (var candidateIndex = 0; candidateIndex < options.length; candidateIndex++) {
+        var option = options[candidateIndex]
+        if (allTokens[option.token]) { error = "Identity helper returned duplicate contact tokens"; return }
+        allTokens[option.token] = true
+        totalCards += option.cards.length
+        for (var cardIndex = 0; cardIndex < option.cards.length; cardIndex++) {
+          var cardToken = option.cards[cardIndex].token
+          if (allTokens[cardToken]) { error = "Identity helper returned duplicate contact tokens"; return }
+          allTokens[cardToken] = true
+        }
+      }
+      if (totalCards > 64) { error = "Identity helper returned too many contact cards"; return }
+      activeHandle = handle
+      candidates = options
+      notice = options.length === 0
+        ? "No matching contact cards were found"
+        : options.length === 1 ? "Contacts has one matching name" : "Contacts has conflicting names"
+      return
+    }
+    if (currentOperation === "vcard") {
+      var copiedName = safeText(result.name, 160)
+      var copiedHandle = safeText(result.handle, 320)
+      var copiedFileName = safeText(result.fileName, 160)
+      var copiedFileUri = safeText(result.fileUri, 700)
+      var copiedBytes = Number(result.bytes)
+      if (copiedName === "" || copiedHandle === "" || !Number.isInteger(copiedBytes)
+          || copiedBytes < 1 || copiedBytes > 2097152
+          || copiedFileName === "" || !copiedFileName.endsWith(".vcf")
+          || root.runtimeDirectory === ""
+          || !copiedFileUri.startsWith(root.vcardUriPrefix)
+          || copiedFileUri.indexOf("..") >= 0 || !copiedFileUri.endsWith(".vcf")) {
+        error = "Contacts returned an invalid vCard confirmation"
+        reportVCard(error, false)
+        return
+      }
+      // Keep wl-copy alive inside the shell process. A short-lived helper can
+      // write the .vcf, but if it owns the Wayland selection and then exits,
+      // the clipboard immediately becomes empty.
+      serveVCard(copiedFileUri, copiedFileName)
+      return
+    }
+    if (currentOperation === "discard-unsaved") {
+      if (typeof result.discarded !== "boolean") {
+        error = "Contacts returned an invalid unsaved-change confirmation"
+        return
+      }
+      notice = result.discarded
+        ? "Discarded the pending Contacts edit and closed Contacts on the Mac"
+        : "Contacts had no pending edit to discard"
+      return
+    }
+    if (currentOperation === "choose" || currentOperation === "custom") {
+      var identity = safeIdentity(result.identity)
+      if (!identity) { error = "Identity helper returned an invalid saved choice"; return }
+      notice = identity.source === "contacts"
+        ? "Blip will use “" + identity.name + "” from Contacts. The contact was not changed."
+        : "Saved custom Blip-only name “" + identity.name + "”; Mac Contacts was not changed"
+      reloadAfterExit = true
+      choicesChanged()
+      return
+    }
+    if (currentOperation === "clear") {
+      var after = validatedList(result.identities, function(value) { return root.safeIdentity(value) }, 64)
+      if (after === null) { error = "Identity helper returned an invalid saved-choice list"; return }
+      identitiesJson = JSON.stringify(after)
+      identities = after
+      notice = "Removed the name Blip was using"
+      choicesChanged()
+      return
+    }
+    if (currentOperation === "open") {
+      var openedName = safeText(result.name, 160)
+      var openedCard = Number(result.cardNumber)
+      var openedCount = Number(result.cardCount)
+      var openedAccount = Number(result.accountNumber)
+      var openedSource = safeText(result.sourceName, 120)
+      if (result.opened !== true || openedName === ""
+          || !Number.isInteger(openedCard) || openedCard < 1 || openedCard > 64
+          || !Number.isInteger(openedCount) || openedCount < 1 || openedCount > 64
+          || openedCard > openedCount
+          || !Number.isInteger(openedAccount) || openedAccount < 1 || openedAccount > 64
+          || openedSource === "") {
+        error = "Contacts.app did not open the selected card"
+        return
+      }
+      notice = "Opened “" + openedName + "” card " + openedCard + " of " + openedCount
+        + " from " + openedSource + " in Contacts on the Mac. Nothing was changed."
+      return
+    }
+    if (currentOperation === "compare") {
+      var compared = safeComparison(result.comparison)
+      if (!compared || !validToken(compared.ownerToken)) {
+        error = "Contacts returned an invalid card comparison"
+        return
+      }
+      comparison = compared
+      linkPreview = null
+      notice = "Loaded " + compared.cardCount + " active cards for comparison; nothing was changed"
+      return
+    }
+    if (currentOperation === "edit-prepare" || currentOperation === "delete-prepare"
+        || currentOperation === "merge-prepare") {
+      var mutation = safeMutationPreview(result.preview, false)
+      var expectedAction = currentOperation === "edit-prepare" ? "edit"
+        : currentOperation === "delete-prepare" ? "delete" : "consolidate"
+      if (!mutation || mutation.action !== expectedAction || !comparison
+          || mutation.handle !== comparison.handle) {
+        error = "Contacts returned an invalid contact-change preview"
+        return
+      }
+      mutationPreview = mutation
+      notice = "Verified the exact Mac Contacts change; review the confirmation"
+      return
+    }
+    if (currentOperation === "edit" || currentOperation === "delete"
+        || currentOperation === "merge") {
+      var appliedMutation = safeMutationPreview(result, true)
+      var appliedAction = currentOperation === "edit" ? "edit"
+        : currentOperation === "delete" ? "delete" : "consolidate"
+      if (!appliedMutation || appliedMutation.action !== appliedAction) {
+        error = "Contacts did not confirm the contact change"
+        return
+      }
+      undoToken = appliedMutation.undoToken
+      undoHandle = appliedMutation.handle
+      undoName = appliedMutation.name
+      undoFieldCount = appliedMutation.changedFields.length
+      undoAction = appliedMutation.action
+      undoCardCount = appliedMutation.action === "consolidate"
+        ? appliedMutation.sourceCardCount + 1 : 1
+      mutationPreview = null
+      mutationRequest = null
+      comparison = null
+      linkPreview = null
+      comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+      notice = appliedMutation.action === "edit"
+        ? "Saved the contact card in Mac Contacts"
+        : appliedMutation.action === "delete"
+          ? "Deleted the source card from Mac Contacts"
+          : "Consolidated " + undoCardCount + " source cards in Mac Contacts"
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+      return
+    }
+    if (currentOperation === "link-prepare") {
+      var prepared = safeLinkPreview(result.preview, false)
+      if (!prepared || !comparison || prepared.handle !== comparison.handle
+          || prepared.cardCount !== comparison.cardCount) {
+        error = "Contacts returned an invalid link preview"
+        return
+      }
+      linkPreview = prepared
+      notice = prepared.ready
+        ? "Contacts is ready; review the final link confirmation"
+        : "Contacts does not offer a link for this exact selection; the cards may already be linked"
+      return
+    }
+    if (currentOperation === "link") {
+      var linked = safeLinkPreview(result, true)
+      if (!linked || !comparison || linked.handle !== comparison.handle
+          || linked.cardCount !== comparison.cardCount) {
+        error = "Contacts did not confirm the link action"
+        return
+      }
+      notice = "Contacts ran “" + linked.action + "” for the exact " + linked.cardCount + " cards"
+      comparison = null
+      linkPreview = null
+      comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+      return
+    }
+    if (currentOperation === "inspect") {
+      var preview = safeRepairPreview(result.preview)
+      if (!preview || !validToken(preview.token)) {
+        error = "Contacts returned an invalid repair preview"
+        return
+      }
+      repairPreview = preview
+      notice = preview.writeEnabled
+        ? "Verified the exact Mac Contacts field; review the confirmation below"
+        : "The Mac-side contact-writes gate is disabled"
+      return
+    }
+    if (currentOperation === "remove") {
+      var removedPreview = safeRepairPreview(result)
+      var returnedUndo = safeText(result.undoToken, 40)
+      if (!removedPreview || result.removed !== true || !/^undo:[0-9a-f]{32}$/.test(returnedUndo)) {
+        error = "Contacts did not confirm the removal"
+        return
+      }
+      undoToken = returnedUndo
+      undoHandle = removedPreview.handle
+      undoName = removedPreview.name
+      undoFieldCount = removedPreview.fieldCount
+      undoAction = "field-removal"
+      undoCardCount = 1
+      repairPreview = null
+      pendingRepairToken = ""
+      pendingOwnerToken = ""
+      notice = "Removed the verified " + removedPreview.kind + " from “" + removedPreview.name + "” on the Mac"
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+      return
+    }
+    if (currentOperation === "undo") {
+      var restoredHandle = safeText(result.handle, 320)
+      var restoredName = safeText(result.name, 160)
+      var restoredCount = Number(result.fieldCount)
+      var restoredCards = Number(result.cardCount)
+      var restoredAction = ["field-removal", "edit", "delete", "consolidate"].indexOf(result.action) >= 0
+        ? result.action : ""
+      if (result.restored !== true || restoredHandle === "" || restoredName === ""
+          || restoredAction === ""
+          || !Number.isInteger(restoredCards) || restoredCards < 1 || restoredCards > 8
+          || !Number.isInteger(restoredCount) || restoredCount < 1 || restoredCount > 13) {
+        error = "Contacts did not confirm the restore"
+        return
+      }
+      undoToken = ""
+      undoHandle = ""
+      undoName = ""
+      undoFieldCount = 0
+      undoAction = ""
+      undoCardCount = 0
+      notice = result.alreadyPresent === true
+        ? "The field was already present in Mac Contacts"
+        : restoredAction === "delete" ? "Recreated the deleted card for “" + restoredName + "”"
+          : restoredAction === "consolidate" ? "Restored " + restoredCards + " pre-merge cards"
+            : "Undid the contact change for “" + restoredName + "”"
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+    }
+  }
+
+  Process {
+    id: worker
+    property string payload: ""
+    stdout: StdioCollector { onStreamFinished: root.consume(text) }
+    onStarted: {
+      if (payload !== "") write(payload)
+      stdinEnabled = false
+    }
+    onExited: function(code, status) {
+      root.loading = false
+      if (code !== 0 && root.error === "") root.error = "Contact-name operation failed"
+      if (root.currentOperation === "vcard" && !root.vcardReported
+          && !root.vcardClipboardPending)
+        root.reportVCard(root.error || "Could not copy the contact vCard", false)
+      if (root.pendingReviewHandle !== "") {
+        var requested = root.pendingReviewHandle
+        root.pendingReviewHandle = ""
+        Qt.callLater(function() { root.findCandidates(requested) })
+        return
+      }
+      if (root.refreshCandidatesAfterExit) {
+        root.refreshCandidatesAfterExit = false
+        var active = root.activeHandle
+        if (active !== "") Qt.callLater(function() { root.findCandidates(active) })
+        return
+      }
+      if (root.reloadAfterExit) {
+        root.reloadAfterExit = false
+        Qt.callLater(function() { root.load(true) })
+      }
+    }
+  }
+
+  Process {
+    id: auditWorker
+    property string payload: ""
+    stdout: StdioCollector { onStreamFinished: root.consumeAudit(text) }
+    onStarted: {
+      if (payload !== "") write(payload)
+      stdinEnabled = false
+    }
+    onExited: function(code, status) {
+      root.auditRunning = false
+    }
+  }
+
+  Process {
+    id: vcardClipboard
+    property string payload: ""
+    property string fileName: ""
+    property bool replacing: false
+    command: ["wl-copy", "--foreground", "--type", "x-special/gnome-copied-files"]
+    onStarted: {
+      write(payload)
+      stdinEnabled = false
+      root.vcardClipboardPending = false
+      root.pendingVcardPayload = ""
+      root.pendingVcardFileName = ""
+      root.notice = "Copied “" + fileName + "” — paste it as a vCard file"
+      root.reportVCard(root.notice, true)
+    }
+    onExited: function(code, status) {
+      if (replacing) {
+        replacing = false
+        Qt.callLater(root.startVcardClipboard)
+        return
+      }
+      if (root.vcardClipboardPending && !root.vcardReported) {
+        root.vcardClipboardPending = false
+        root.reportVCard("Could not keep the vCard on the clipboard", false)
+      }
+    }
+  }
+
+  Timer {
+    interval: 5000
+    repeat: true
+    running: true
+    // Source repair is deliberate and stable while open. Only poll the local
+    // override file from the overview, and never overlap another operation.
+    onTriggered: if (!worker.running && root.activeHandle === "") root.load(true)
+  }
+
+  Component.onCompleted: load(false)
+}

--- a/BlipPreferences.qml
+++ b/BlipPreferences.qml
@@ -1,0 +1,289 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Live, file-backed appearance preferences shared by the popout and app.
+// preferences.ts is the trust boundary: it caps and validates the writable
+// JSON before this long-lived shell process sees a small normalized object.
+Item {
+  id: root
+  visible: false
+  implicitWidth: 0
+  implicitHeight: 0
+
+  readonly property string home: Quickshell.env("HOME")
+  readonly property string configPath: home + "/.config/blip/preferences.json"
+  readonly property string helperPath:
+    decodeURIComponent(Qt.resolvedUrl("preferences.ts").toString().replace(/^file:\/\//, ""))
+
+  property string outgoingBubbleColor: "theme"
+  property string incomingBubbleColor: "theme"
+  property real backgroundOpacity: 0.70
+  property real fontScale: 1.0
+  property real density: 1.0
+  property int sidebarWidth: 320
+  property int avatarSize: 30
+  property real cornerScale: 1.0
+  property bool hideShortCodeConversations: true
+  property bool use12HourConversationTimes: true
+
+  property bool loaded: false
+  property bool exists: false
+  property bool saving: false
+  property bool dirty: false
+  property string error: ""
+  property string notice: "Loading preferences…"
+  property string lastSerialized: ""
+
+  function defaults() {
+    return {
+      schemaVersion: 1,
+      outgoingBubbleColor: "theme",
+      incomingBubbleColor: "theme",
+      backgroundOpacity: 0.70,
+      fontScale: 1.0,
+      density: 1.0,
+      sidebarWidth: 320,
+      avatarSize: 30,
+      cornerScale: 1.0,
+      hideShortCodeConversations: true,
+      use12HourConversationTimes: true
+    }
+  }
+
+  function snapshot() {
+    return {
+      schemaVersion: 1,
+      outgoingBubbleColor: outgoingBubbleColor,
+      incomingBubbleColor: incomingBubbleColor,
+      backgroundOpacity: Math.round(backgroundOpacity * 100) / 100,
+      fontScale: Math.round(fontScale * 100) / 100,
+      density: Math.round(density * 100) / 100,
+      sidebarWidth: Math.round(sidebarWidth),
+      avatarSize: Math.round(avatarSize),
+      cornerScale: Math.round(cornerScale * 100) / 100,
+      hideShortCodeConversations: hideShortCodeConversations,
+      use12HourConversationTimes: use12HourConversationTimes
+    }
+  }
+
+  function finiteIn(value, low, high) {
+    return typeof value === "number" && isFinite(value) && value >= low && value <= high
+  }
+
+  function validColor(value) {
+    return typeof value === "string" &&
+      (value === "theme" || /^#[0-9a-f]{6}([0-9a-f]{2})?$/.test(value))
+  }
+
+  // Defense in depth: verify the helper's normalized object again before any
+  // value is retained by the shell or used in geometry.
+  function applyPreferences(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value) || value.schemaVersion !== 1)
+      return false
+    if (!validColor(value.outgoingBubbleColor) || !validColor(value.incomingBubbleColor)) return false
+    if (!finiteIn(value.backgroundOpacity, 0.2, 1.0)) return false
+    if (!finiteIn(value.fontScale, 0.75, 1.5)) return false
+    if (!finiteIn(value.density, 0.7, 1.4)) return false
+    if (!finiteIn(value.sidebarWidth, 240, 520)) return false
+    if (!finiteIn(value.avatarSize, 24, 64)) return false
+    if (!finiteIn(value.cornerScale, 0, 2)) return false
+    if (typeof value.hideShortCodeConversations !== "boolean") return false
+    if (typeof value.use12HourConversationTimes !== "boolean") return false
+
+    var normalized = {
+      schemaVersion: 1,
+      outgoingBubbleColor: value.outgoingBubbleColor,
+      incomingBubbleColor: value.incomingBubbleColor,
+      backgroundOpacity: Math.round(value.backgroundOpacity * 100) / 100,
+      fontScale: Math.round(value.fontScale * 100) / 100,
+      density: Math.round(value.density * 100) / 100,
+      sidebarWidth: Math.round(value.sidebarWidth),
+      avatarSize: Math.round(value.avatarSize),
+      cornerScale: Math.round(value.cornerScale * 100) / 100,
+      hideShortCodeConversations: value.hideShortCodeConversations,
+      use12HourConversationTimes: value.use12HourConversationTimes
+    }
+    var serialized = JSON.stringify(normalized)
+    // Keep bindings and slider delegates untouched when the periodic bounded
+    // read returns the same file contents.
+    if (loaded && serialized === lastSerialized) return true
+    outgoingBubbleColor = normalized.outgoingBubbleColor
+    incomingBubbleColor = normalized.incomingBubbleColor
+    backgroundOpacity = normalized.backgroundOpacity
+    fontScale = normalized.fontScale
+    density = normalized.density
+    sidebarWidth = normalized.sidebarWidth
+    avatarSize = normalized.avatarSize
+    cornerScale = normalized.cornerScale
+    hideShortCodeConversations = normalized.hideShortCodeConversations
+    use12HourConversationTimes = normalized.use12HourConversationTimes
+    lastSerialized = serialized
+    return true
+  }
+
+  function safeError(value) {
+    return String(value || "Preference operation failed")
+      .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+      .replace(/\s+/g, " ").trim().slice(0, 180)
+  }
+
+  function consumeRead(raw) {
+    if (raw.length > 4096) {
+      error = "Preference helper returned too much data"
+      return
+    }
+    try {
+      var result = JSON.parse(raw.trim())
+      if (!result || result.ok !== true) {
+        error = safeError(result ? result.error : "Preference helper failed")
+        loaded = true
+        return
+      }
+      if (!applyPreferences(result.preferences)) {
+        error = "Preference helper returned an invalid schema"
+        loaded = true
+        return
+      }
+      exists = result.exists === true
+      error = ""
+      loaded = true
+      notice = exists ? "Loaded preferences.json" : "Using defaults; creating preferences.json…"
+      if (!exists) scheduleSave()
+    } catch (e) {
+      error = "Preference helper returned invalid JSON"
+      loaded = true
+    }
+  }
+
+  function load(force) {
+    if (reader.running || writer.running) return
+    if (!force && dirty) return
+    if (force) {
+      dirty = false
+      saveTimer.stop()
+    }
+    reader.command = ["bun", helperPath, "read"]
+    reader.running = true
+  }
+
+  function scheduleSave() {
+    dirty = true
+    notice = "Unsaved changes…"
+    saveTimer.restart()
+  }
+
+  function writeNow() {
+    if (writer.running) {
+      saveTimer.restart()
+      return
+    }
+    writer.payload = JSON.stringify(snapshot())
+    writer.resultOk = false
+    writer.stdinEnabled = true
+    dirty = false
+    saving = true
+    notice = "Saving…"
+    writer.command = ["bun", helperPath, "write"]
+    writer.running = true
+  }
+
+  function setColor(key, value) {
+    var color = String(value || "").trim().toLowerCase()
+    if (!validColor(color)) return false
+    if (key === "outgoingBubbleColor") outgoingBubbleColor = color
+    else if (key === "incomingBubbleColor") incomingBubbleColor = color
+    else return false
+    scheduleSave()
+    return true
+  }
+
+  function setNumber(key, value) {
+    var number = Number(value)
+    if (key === "backgroundOpacity" && finiteIn(number, 0.2, 1.0)) backgroundOpacity = number
+    else if (key === "fontScale" && finiteIn(number, 0.75, 1.5)) fontScale = number
+    else if (key === "density" && finiteIn(number, 0.7, 1.4)) density = number
+    else if (key === "sidebarWidth" && finiteIn(number, 240, 520)) sidebarWidth = Math.round(number)
+    else if (key === "avatarSize" && finiteIn(number, 24, 64)) avatarSize = Math.round(number)
+    else if (key === "cornerScale" && finiteIn(number, 0, 2)) cornerScale = number
+    else return false
+    scheduleSave()
+    return true
+  }
+
+  function setBoolean(key, value) {
+    if (typeof value !== "boolean") return false
+    if (key === "hideShortCodeConversations") hideShortCodeConversations = value
+    else if (key === "use12HourConversationTimes") use12HourConversationTimes = value
+    else return false
+    scheduleSave()
+    return true
+  }
+
+  function restoreDefaults() {
+    applyPreferences(defaults())
+    scheduleSave()
+  }
+
+  Timer {
+    id: saveTimer
+    interval: 350
+    onTriggered: root.writeNow()
+  }
+
+  // A restored dotfile is picked up without restarting the shell. Polling the
+  // bounded helper avoids feeding the writable file itself into FileView.
+  Timer {
+    interval: 5000
+    repeat: true
+    running: true
+    onTriggered: root.load(false)
+  }
+
+  Process {
+    id: reader
+    stdout: StdioCollector { onStreamFinished: root.consumeRead(text) }
+  }
+
+  Process {
+    id: writer
+    property string payload: ""
+    property bool resultOk: false
+    stdout: StdioCollector {
+      onStreamFinished: {
+        if (text.length > 4096) {
+          root.error = "Preference writer returned too much data"
+          return
+        }
+        try {
+          var result = JSON.parse(text.trim())
+          writer.resultOk = result && result.ok === true
+          if (!writer.resultOk) root.error = root.safeError(result ? result.error : "Preference write failed")
+          else if (!root.dirty && !root.applyPreferences(result.preferences)) {
+            writer.resultOk = false
+            root.error = "Preference writer returned an invalid schema"
+          }
+        } catch (e) {
+          root.error = "Preference writer returned invalid JSON"
+        }
+      }
+    }
+    onStarted: {
+      write(payload)
+      stdinEnabled = false
+    }
+    onExited: function(code, status) {
+      root.saving = false
+      if (code === 0 && resultOk) {
+        root.exists = true
+        root.error = ""
+        root.notice = "Saved to preferences.json"
+      } else if (root.error === "") {
+        root.error = "Could not save preferences.json"
+      }
+      if (root.dirty) saveTimer.restart()
+    }
+  }
+
+  Component.onCompleted: load(false)
+}

--- a/BlipSettings.qml
+++ b/BlipSettings.qml
@@ -1,0 +1,621 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import QtQuick.Layouts
+import QtQuick.Shapes
+import qs.Commons
+import qs.Ui
+
+// In-app appearance editor. Changes apply immediately through the shared
+// BlipPreferences object and are debounced to ~/.config/blip/preferences.json.
+FocusScope {
+  id: root
+
+  property var preferences: null
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property color outgoingFill: accent
+  property color outgoingText: "#ffffff"
+  property color incomingFill: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
+  property color incomingText: foreground
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  property var hostWidget: null
+  property var threads: []
+  property string localError: ""
+  property bool resetArmed: false
+  property string page: "contacts"
+  readonly property bool editorActive: outgoingSetting.editorActive || incomingSetting.editorActive
+    || identitySettings.editorActive
+
+  signal closeRequested()
+  signal vcardFinished(string message, bool success)
+
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function focusDefault() { forceActiveFocus() }
+  function showPage(value) {
+    page = value === "appearance" ? "appearance" : "contacts"
+    settingsFlick.contentY = 0
+  }
+  function copyVCard(handle) {
+    return identityResolver.copyVCard(handle)
+  }
+  function editContact(handle) {
+    showPage("contacts")
+    identitySettings.editContact(handle)
+  }
+
+  BlipIdentities {
+    id: identityResolver
+    onChoicesChanged: {
+      if (root.hostWidget) root.hostWidget.refresh(true, false)
+    }
+    onVcardFinished: function(message, success) {
+      root.vcardFinished(message, success)
+    }
+  }
+
+  Keys.onEscapePressed: {
+    if (root.page === "contacts" && identitySettings.reviewActive) identitySettings.closeReview()
+    else root.closeRequested()
+  }
+
+  ColumnLayout {
+    anchors.fill: parent
+    spacing: root.space(10)
+
+    RowLayout {
+      Layout.fillWidth: true
+      PanelHero {
+        Layout.fillWidth: true
+        title: "Blip settings"
+        meta: root.page === "contacts" ? "Contacts" : "Appearance"
+        detail: ""
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+      }
+      PanelActionButton {
+        Layout.alignment: Qt.AlignTop
+        focusable: true
+        iconText: "×"
+        tooltipText: "Close settings (Esc)"
+        bordered: true
+        foreground: root.foreground
+        hoverColor: root.accent
+        fontFamily: root.fontFamily
+        fontSize: root.fontSize(Style.font.icon)
+        onClicked: root.closeRequested()
+      }
+    }
+
+    PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
+
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: root.space(8)
+      ActionButton {
+        label: "Contacts"
+        selected: root.page === "contacts"
+        onClicked: root.showPage("contacts")
+      }
+      ActionButton {
+        label: "Appearance"
+        selected: root.page === "appearance"
+        onClicked: root.showPage("appearance")
+      }
+      Item { Layout.fillWidth: true }
+      Text {
+        text: root.page === "contacts"
+          ? "Manage Mac Contacts or set an optional display preference"
+          : "Changes preview and apply live"
+        textFormat: Text.PlainText
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+
+    PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
+
+    Flickable {
+      id: settingsFlick
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+      contentWidth: width
+      contentHeight: settingsContent.implicitHeight
+      clip: true
+      boundsBehavior: Flickable.StopAtBounds
+      interactive: contentHeight > height
+      QQC.ScrollBar.vertical: QQC.ScrollBar { policy: QQC.ScrollBar.AsNeeded }
+
+      MouseArea {
+        anchors.fill: parent
+        z: -1
+        acceptedButtons: Qt.NoButton
+        onWheel: function(wheel) {
+          var delta = wheel.pixelDelta.y !== 0 ? wheel.pixelDelta.y * 3.0 : wheel.angleDelta.y * 4.5
+          var maximum = Math.max(0, settingsFlick.contentHeight - settingsFlick.height)
+          settingsFlick.contentY = Math.max(0, Math.min(maximum, settingsFlick.contentY - delta))
+          wheel.accepted = true
+        }
+      }
+
+      ColumnLayout {
+        id: settingsContent
+        width: Math.min(parent.width, root.space(1120))
+        anchors.horizontalCenter: parent.horizontalCenter
+        spacing: root.space(16)
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          visible: root.page === "contacts"
+          spacing: root.space(12)
+
+        IdentitySettings {
+          id: identitySettings
+          Layout.fillWidth: true
+          resolver: identityResolver
+          threads: root.threads
+          preferences: root.preferences
+          foreground: root.foreground
+          urgent: root.urgent
+          accent: root.accent
+          fontFamily: root.fontFamily
+          fontScale: root.fontScale
+          density: root.density
+          cornerScale: root.cornerScale
+          onFocusAreaRequested: function(localY) {
+            Qt.callLater(function() {
+              var mapped = identitySettings.mapToItem(settingsContent, 0, localY).y
+              var maximum = Math.max(0, settingsFlick.contentHeight - settingsFlick.height)
+              settingsFlick.contentY = Math.max(0, Math.min(maximum, mapped - root.space(12)))
+            })
+          }
+        }
+
+        Item { Layout.preferredHeight: root.space(6) }
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          visible: root.page === "appearance"
+          spacing: root.space(16)
+
+        Text {
+          Layout.fillWidth: true
+          text: "Changes apply live. The files under ~/.config/blip can be tracked in dotfiles or restored later."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.bodySmall)
+        }
+
+        // A real preview makes color, type, density, and rounding adjustments
+        // legible before the settings page is closed.
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: root.space(7)
+          RowLayout {
+            Layout.fillWidth: true
+            Item { Layout.fillWidth: true }
+            PreviewBubble {
+              mine: true
+              label: "Your bubble"
+              fillColor: root.outgoingFill
+              textColor: root.outgoingText
+            }
+          }
+          RowLayout {
+            Layout.fillWidth: true
+            PreviewBubble {
+              mine: false
+              label: "Their bubble"
+              fillColor: root.incomingFill
+              textColor: root.incomingText
+            }
+            Item { Layout.fillWidth: true }
+          }
+        }
+
+        PanelSectionHeader {
+          Layout.fillWidth: true
+          text: "COLORS"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          fontSize: root.fontSize(Style.font.caption)
+        }
+
+        ColorSetting {
+          id: outgoingSetting
+          Layout.fillWidth: true
+          title: "Outgoing bubbles"
+          preferenceKey: "outgoingBubbleColor"
+          currentValue: root.preferences ? root.preferences.outgoingBubbleColor : "theme"
+          resolvedColor: root.outgoingFill
+        }
+
+        ColorSetting {
+          id: incomingSetting
+          Layout.fillWidth: true
+          title: "Incoming bubbles"
+          preferenceKey: "incomingBubbleColor"
+          currentValue: root.preferences ? root.preferences.incomingBubbleColor : "theme"
+          resolvedColor: root.incomingFill
+        }
+
+        PanelSectionHeader {
+          Layout.fillWidth: true
+          text: "LAYOUT"
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          fontSize: root.fontSize(Style.font.caption)
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: root.space(5)
+          Text {
+            text: "Conversation list time"
+            textFormat: Text.PlainText
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          RowLayout {
+            spacing: root.space(7)
+            ActionButton {
+              label: "12-hour (AM/PM)"
+              selected: !root.preferences || root.preferences.use12HourConversationTimes
+              onClicked: if (root.preferences)
+                root.preferences.setBoolean("use12HourConversationTimes", true)
+            }
+            ActionButton {
+              label: "24-hour"
+              selected: root.preferences && !root.preferences.use12HourConversationTimes
+              onClicked: if (root.preferences)
+                root.preferences.setBoolean("use12HourConversationTimes", false)
+            }
+          }
+        }
+
+        PreferenceSlider {
+          Layout.fillWidth: true
+          title: "Window opacity"
+          preferenceKey: "backgroundOpacity"
+          currentValue: root.preferences ? root.preferences.backgroundOpacity : 0.70
+          from: 0.20; to: 1.0; stepSize: 0.05; decimals: 0; multiplier: 100; suffix: "%"
+        }
+        PreferenceSlider {
+          Layout.fillWidth: true
+          title: "Font scale"
+          preferenceKey: "fontScale"
+          currentValue: root.preferences ? root.preferences.fontScale : 1.0
+          from: 0.75; to: 1.50; stepSize: 0.05; decimals: 0; multiplier: 100; suffix: "%"
+        }
+        PreferenceSlider {
+          Layout.fillWidth: true
+          title: "Density"
+          preferenceKey: "density"
+          currentValue: root.preferences ? root.preferences.density : 1.0
+          from: 0.70; to: 1.40; stepSize: 0.05; decimals: 0; multiplier: 100; suffix: "%"
+        }
+        PreferenceSlider {
+          Layout.fillWidth: true
+          title: "Sidebar width"
+          preferenceKey: "sidebarWidth"
+          currentValue: root.preferences ? root.preferences.sidebarWidth : 320
+          from: 240; to: 520; stepSize: 10; decimals: 0; multiplier: 1; suffix: " px"
+        }
+        PreferenceSlider {
+          Layout.fillWidth: true
+          title: "Avatar size"
+          preferenceKey: "avatarSize"
+          currentValue: root.preferences ? root.preferences.avatarSize : 30
+          from: 24; to: 64; stepSize: 2; decimals: 0; multiplier: 1; suffix: " px"
+        }
+        PreferenceSlider {
+          Layout.fillWidth: true
+          title: "Corner roundness"
+          preferenceKey: "cornerScale"
+          currentValue: root.preferences ? root.preferences.cornerScale : 1.0
+          from: 0; to: 2.0; stepSize: 0.10; decimals: 1; multiplier: 1; suffix: "×"
+        }
+
+        Text {
+          Layout.fillWidth: true
+          visible: root.localError !== "" || (root.preferences && root.preferences.error !== "")
+          text: root.localError !== "" ? root.localError : String(root.preferences ? root.preferences.error : "")
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: root.urgent
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+
+        Text {
+          Layout.fillWidth: true
+          text: root.preferences
+            ? (root.preferences.saving ? "Saving…" : root.preferences.notice) + "\n" + root.preferences.configPath
+            : "Preferences unavailable"
+          textFormat: Text.PlainText
+          wrapMode: Text.WrapAnywhere
+          color: Qt.darker(root.foreground, 1.45)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+
+        RowLayout {
+          Layout.fillWidth: true
+          spacing: root.space(8)
+          ActionButton {
+            label: "Reload file"
+            onClicked: {
+              root.resetArmed = false
+              root.localError = ""
+              if (root.preferences) root.preferences.load(true)
+            }
+          }
+          Item { Layout.fillWidth: true }
+          ActionButton {
+            label: root.resetArmed ? "Confirm reset" : "Reset to defaults"
+            danger: root.resetArmed
+            onClicked: {
+              if (!root.resetArmed) {
+                root.resetArmed = true
+                return
+              }
+              root.resetArmed = false
+              root.localError = ""
+              if (root.preferences) root.preferences.restoreDefaults()
+            }
+          }
+        }
+
+        Item { Layout.preferredHeight: root.space(6) }
+        }
+      }
+    }
+  }
+
+  component PreviewBubble: Item {
+    id: previewBubble
+    property bool mine: false
+    property string label: ""
+    property color fillColor: root.incomingFill
+    property color textColor: root.incomingText
+
+    Layout.preferredWidth: Math.ceil(previewLabel.implicitWidth) + root.space(22)
+    Layout.preferredHeight: Math.ceil(previewLabel.implicitHeight) + root.space(14)
+
+    Shape {
+      anchors.fill: parent
+      antialiasing: true
+      ShapePath {
+        id: previewPath
+        readonly property real r: Math.min(
+          root.corner(root.space(16)), previewBubble.width / 2, previewBubble.height / 2
+        )
+        strokeColor: "transparent"
+        fillColor: previewBubble.fillColor
+        startX: r
+        startY: 0
+        PathLine { x: previewBubble.width - previewPath.r; y: 0 }
+        PathQuad {
+          x: previewBubble.width; y: previewPath.r
+          controlX: previewBubble.width; controlY: 0
+        }
+        PathLine {
+          x: previewBubble.width
+          y: previewBubble.mine ? previewBubble.height : previewBubble.height - previewPath.r
+        }
+        PathQuad {
+          x: previewBubble.mine ? previewBubble.width : previewBubble.width - previewPath.r
+          y: previewBubble.height
+          controlX: previewBubble.width; controlY: previewBubble.height
+        }
+        PathLine { x: previewBubble.mine ? previewPath.r : 0; y: previewBubble.height }
+        PathQuad {
+          x: 0
+          y: previewBubble.mine ? previewBubble.height - previewPath.r : previewBubble.height
+          controlX: 0; controlY: previewBubble.height
+        }
+        PathLine { x: 0; y: previewPath.r }
+        PathQuad {
+          x: previewPath.r; y: 0
+          controlX: 0; controlY: 0
+        }
+      }
+    }
+
+    Text {
+      id: previewLabel
+      anchors.centerIn: parent
+      text: previewBubble.label
+      textFormat: Text.PlainText
+      color: previewBubble.textColor
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.bodySmall)
+    }
+  }
+
+  component ColorSetting: ColumnLayout {
+    id: colorSetting
+    property string title: ""
+    property string preferenceKey: ""
+    property string currentValue: "theme"
+    property color resolvedColor: root.accent
+    readonly property bool editorActive: field.activeFocus
+    spacing: root.space(5)
+
+    function syncField() {
+      if (!field.activeFocus) field.text = currentValue === "theme" ? "" : currentValue
+    }
+    function focusField() { field.forceActiveFocus() }
+    function commit() {
+      var candidate = field.text.trim().toLowerCase()
+      if (candidate === "" || candidate === "theme") candidate = "theme"
+      if (candidate !== "theme" && !/^#[0-9a-f]{6}([0-9a-f]{2})?$/.test(candidate)) {
+        root.localError = title + ": use #rrggbb, #rrggbbaa, or Theme"
+        return
+      }
+      root.localError = ""
+      if (root.preferences) root.preferences.setColor(preferenceKey, candidate)
+      syncField()
+    }
+    onCurrentValueChanged: syncField()
+    Component.onCompleted: syncField()
+
+    Text {
+      text: colorSetting.title
+      textFormat: Text.PlainText
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.bodySmall)
+      font.bold: true
+    }
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: root.space(8)
+      Rectangle {
+        width: root.space(28); height: width
+        radius: root.corner(root.space(8))
+        color: colorSetting.resolvedColor
+        border.width: 1
+        border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.45)
+      }
+      TextField {
+        id: field
+        Layout.fillWidth: true
+        placeholderText: "theme"
+        foreground: root.foreground
+        accent: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+        maximumLength: 9
+        onAccepted: colorSetting.commit()
+        onEditingFinished: colorSetting.commit()
+      }
+      ActionButton {
+        label: "Theme"
+        onClicked: {
+          field.text = ""
+          root.localError = ""
+          if (root.preferences) root.preferences.setColor(colorSetting.preferenceKey, "theme")
+        }
+      }
+    }
+  }
+
+  component PreferenceSlider: ColumnLayout {
+    id: sliderRow
+    property string title: ""
+    property string preferenceKey: ""
+    property real currentValue: 0
+    property real from: 0
+    property real to: 1
+    property real stepSize: 0.1
+    property int decimals: 0
+    property real multiplier: 1
+    property string suffix: ""
+    spacing: root.space(4)
+
+    onCurrentValueChanged: if (!slider.pressed) slider.value = currentValue
+
+    RowLayout {
+      Layout.fillWidth: true
+      Text {
+        Layout.fillWidth: true
+        text: sliderRow.title
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+      }
+      Text {
+        text: (slider.value * sliderRow.multiplier).toFixed(sliderRow.decimals) + sliderRow.suffix
+        textFormat: Text.PlainText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+    }
+    QQC.Slider {
+      id: slider
+      Layout.fillWidth: true
+      from: sliderRow.from
+      to: sliderRow.to
+      stepSize: sliderRow.stepSize
+      value: sliderRow.currentValue
+      onMoved: {
+        root.resetArmed = false
+        root.localError = ""
+        if (root.preferences) root.preferences.setNumber(sliderRow.preferenceKey, value)
+      }
+      background: Rectangle {
+        x: slider.leftPadding
+        y: slider.topPadding + slider.availableHeight / 2 - height / 2
+        implicitWidth: 200
+        implicitHeight: root.space(4)
+        width: slider.availableWidth
+        height: implicitHeight
+        radius: height / 2
+        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+        Rectangle {
+          width: slider.visualPosition * parent.width
+          height: parent.height
+          radius: parent.radius
+          color: root.accent
+        }
+      }
+      handle: Rectangle {
+        x: slider.leftPadding + slider.visualPosition * (slider.availableWidth - width)
+        y: slider.topPadding + slider.availableHeight / 2 - height / 2
+        implicitWidth: root.space(16)
+        implicitHeight: width
+        radius: width / 2
+        color: root.accent
+        border.width: slider.activeFocus ? 2 : 1
+        border.color: root.foreground
+      }
+    }
+  }
+
+  component ActionButton: Rectangle {
+    id: action
+    property string label: ""
+    property bool danger: false
+    property bool selected: false
+    signal clicked()
+    implicitWidth: actionText.implicitWidth + root.space(18)
+    implicitHeight: actionText.implicitHeight + root.space(12)
+    radius: root.corner(root.space(8))
+    color: actionHover.hovered
+      ? Qt.rgba((danger ? root.urgent : root.accent).r,
+                (danger ? root.urgent : root.accent).g,
+                (danger ? root.urgent : root.accent).b, 0.18)
+      : selected ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.18)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.06)
+    border.width: 1
+    border.color: danger ? root.urgent : selected ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.35)
+    Text {
+      id: actionText
+      anchors.centerIn: parent
+      text: action.label
+      textFormat: Text.PlainText
+      color: action.danger ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: action.danger || action.selected
+    }
+    HoverHandler { id: actionHover; cursorShape: Qt.PointingHandCursor }
+    TapHandler { onTapped: action.clicked() }
+  }
+}

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -22,6 +22,7 @@ FocusScope {
 
   // ---- host contract (docs/app-design-review.md) ----------------------
   property var hostWidget: null
+  property var preferences: null
   /** Qt format strings, owned by the host widget (see BarWidget). Empty when no host is
    *  attached or the host has none, which thread.ts and Qt both read as "use the defaults". */
   readonly property string timeFormat: (hostWidget && hostWidget.timeFormat) || ""
@@ -40,7 +41,7 @@ FocusScope {
   readonly property color dim: Qt.darker(foreground, 1.45)
   /** An editor owns the keyboard — the host's key catcher must stand down. */
   readonly property bool editorActive:
-    composeField.activeFocus || searchField.activeFocus || newField.activeFocus || bubbleFocused
+    settingsMode || composeField.activeFocus || searchField.activeFocus || newField.activeFocus || bubbleFocused
   readonly property alias composeEditor: composeField
   readonly property real contentHeightHint: listContent.implicitHeight
   /** The view wants keyboard navigation focus back (list mode). */
@@ -55,15 +56,44 @@ FocusScope {
   readonly property color cyan: accent            // legacy name; accents/links
   readonly property color okColor: accent
 
-  readonly property color mineFill: accent
+  // App-local scale tokens layered on the live Omarchy theme. Defaults are
+  // exactly the pre-preferences values, so installing this layer is visual
+  // no-op until the user changes preferences.json or the Settings UI.
+  readonly property real fontScale: preferences ? preferences.fontScale : 1.0
+  readonly property real density: preferences ? preferences.density : 1.0
+  readonly property real cornerScale: preferences ? preferences.cornerScale : 1.0
+  readonly property int avatarSize: preferences ? preferences.avatarSize : 30
+  readonly property string outgoingColorSetting: preferences ? preferences.outgoingBubbleColor : "theme"
+  readonly property string incomingColorSetting: preferences ? preferences.incomingBubbleColor : "theme"
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function opaqueOver(fill, background) {
+    var alpha = fill.a
+    return Qt.rgba(
+      fill.r * alpha + background.r * (1 - alpha),
+      fill.g * alpha + background.g * (1 - alpha),
+      fill.b * alpha + background.b * (1 - alpha), 1
+    )
+  }
+  function contrastText(fill) {
+    var alpha = fill.a
+    var red = fill.r * alpha + Color.background.r * (1 - alpha)
+    var green = fill.g * alpha + Color.background.g * (1 - alpha)
+    var blue = fill.b * alpha + Color.background.b * (1 - alpha)
+    return (0.299 * red + 0.587 * green + 0.114 * blue) > 0.35 ? "#1a1a1a" : "#ffffff"
+  }
+
+  readonly property color mineFill: outgoingColorSetting === "theme" ? accent : outgoingColorSetting
   // Bubble text picks black/white by which CONTRASTS better with the fill:
   // (L+0.05)/0.15 vs 1.05/(L+0.05) cross over near L≈0.35. A 0.6 threshold
   // chose white on medium accents where dark text is clearly more legible
   // (e.g. Evergreen #4a9a68: white 3.4:1 vs dark 5.1:1).
-  readonly property color mineText:
-    (0.299 * mineFill.r + 0.587 * mineFill.g + 0.114 * mineFill.b) > 0.35 ? "#1a1a1a" : "#ffffff"
-  readonly property color theirsFill: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
-  readonly property color theirsText: foreground
+  readonly property color mineText: contrastText(mineFill)
+  readonly property color theirsFill: incomingColorSetting === "theme"
+    ? Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
+    : incomingColorSetting
+  readonly property color theirsText: incomingColorSetting === "theme" ? foreground : contrastText(theirsFill)
 
   readonly property string home: Quickshell.env("HOME")
   readonly property string threadScript:
@@ -115,8 +145,20 @@ FocusScope {
   property string pasteChat: ""
 
   readonly property var threads: hostWidget ? hostWidget.threads : []
-  readonly property var pinnedThreads: root.threads.filter(function(t) { return t.pinned === true })
-  readonly property var unpinnedThreads: root.threads.filter(function(t) { return t.pinned !== true })
+  // Messages.app owns pin membership and order. Pinned conversations leave
+  // the chronological list and render first as the familiar avatar grid.
+  readonly property var pinnedThreads: {
+    var out = []
+    for (var i = 0; i < threads.length; i++) if (threads[i].pinned === true) out.push(threads[i])
+    return out.sort(function(a, b) {
+      var ao = Number(a.pin_order); var bo = Number(b.pin_order)
+      if (ao !== bo) return ao - bo
+      return String(a.last_ts) < String(b.last_ts) ? 1 : -1
+    })
+  }
+  readonly property var regularThreads: threads.filter(function(thread) { return thread.pinned !== true })
+  readonly property var unpinnedThreads: regularThreads
+  readonly property var navigationThreads: pinnedThreads.concat(regularThreads)
   readonly property bool online: hostWidget ? hostWidget.online : false
   readonly property int unread: hostWidget ? hostWidget.unread : 0
 
@@ -197,10 +239,17 @@ FocusScope {
   property string threadRunningChat: "" // chat owned by the current threadProc
   property string bubblesJson: ""       // last rendered bubbles, for no-op reload detection
   property bool firstLoad: true         // first load of the open thread pins to bottom
+  property bool settingsMode: false
   property string pendingThreadChat: "" // latest chat requested while it runs
+  property var pendingThreadAliases: [] // historical ids coalesced into that chat
+  property var threadRunningAliases: []
   property string sendChat: ""          // immutable context for the current send
   property string sendText: ""
   property string reloadChat: ""
+  property string contactToast: ""
+  property bool contactToastError: false
+  property var contextPeople: []
+  property string contextMessageText: ""
 
   function threadIndex(thread) {
     for (var i = 0; i < root.threads.length; i++) {
@@ -208,9 +257,10 @@ FocusScope {
     }
     return -1
   }
-  // pins sort first in threads[], so 1 is the first pin when any exist
+  // Numbered in the sidebar's visible order (pins first) — the same list
+  // the 1-9 jump keys index.
   function threadHotkey(thread) {
-    var i = threadIndex(thread)
+    var i = navigationThreads.indexOf(thread)
     if (i < 0 || i > 8) return ""
     return String(i + 1)
   }
@@ -258,7 +308,7 @@ FocusScope {
           if (!flick.stick) { pushPending = true }  // reading history — defer
           else {
             pinToBottom = true
-            requestThreadLoad(String(t.chat))
+            requestThreadLoad(String(t.chat), t.aliases || [])
           }
         }
       }
@@ -267,6 +317,96 @@ FocusScope {
   }
   // Same rule as collector.isGroupChat(): anything that is not a phone/email.
   function isGroupId(c) { c = String(c || ""); return c !== "" && !/^\+?[0-9]{5,}$/.test(c) && c.indexOf("@") < 0 }
+  function isContactHandle(value) {
+    var handle = String(value || "")
+    return /^\+?[0-9][0-9 ()./-]{2,39}$/.test(handle)
+      || /^[^@\s]+@[^@\s]+$/.test(handle)
+  }
+  function contactHandleKey(value) {
+    var handle = String(value || "")
+    if (handle.indexOf("@") >= 0) return "email:" + handle.toLowerCase()
+    var digits = handle.replace(/\D/g, "")
+    return "phone:" + (digits.length >= 10 ? digits.slice(-10) : digits)
+  }
+  function contactPeople(thread) {
+    if (!thread) return []
+    var result = []
+    var seen = ({})
+    function add(handle, name) {
+      handle = String(handle || "").trim()
+      if (!root.isContactHandle(handle)) return
+      var key = root.contactHandleKey(handle)
+      if (seen[key] || result.length >= 64) return
+      seen[key] = true
+      name = String(name || handle).trim()
+      result.push({ handle: handle, name: name === "" ? handle : name })
+    }
+    if (!root.isGroupId(String(thread.chat || ""))) {
+      add(thread.handle || thread.chat, thread.pin_name || thread.name || thread.chat)
+      return result
+    }
+    var participants = Array.isArray(thread.participants) ? thread.participants : []
+    for (var i = 0; i < participants.length; i++) {
+      var person = participants[i]
+      if (typeof person === "string") add(person, person)
+      else add(person && person.handle, person && person.name)
+    }
+    // Cached group metadata from an older build may not have participant
+    // names yet. Recent inbound bubbles safely fill that gap until refresh.
+    if (thread === root.active) {
+      for (var j = 0; j < root.bubbles.length; j++) {
+        var bubble = root.bubbles[j]
+        if (!bubble.from_me) add(bubble.handle, bubble.name)
+      }
+    }
+    return result
+  }
+  function personMenuLabel(person) {
+    var name = String(person && person.name || "")
+    var handle = String(person && person.handle || "")
+    return name !== "" && name !== handle ? name + "  ·  " + handle : handle
+  }
+  function showContactToast(message, failed) {
+    contactToast = String(message || "")
+    contactToastError = failed === true
+    contactToastTimer.restart()
+  }
+  function openContactContext(thread, messageText) {
+    var people = contactPeople(thread)
+    contextPeople = people
+    contextMessageText = String(messageText || "")
+    if (people.length === 0 && contextMessageText === "") {
+      showContactToast("No contact person is available for this conversation", true)
+      return
+    }
+    if (people.length === 0) messageOnlyMenu.popup()
+    else if (people.length === 1)
+      (contextMessageText === "" ? directContactMenu : directMessageMenu).popup()
+    else
+      (contextMessageText === "" ? groupContactMenu : groupMessageMenu).popup()
+  }
+  function copyContactVCard(person) {
+    if (!person || !isContactHandle(person.handle)) return
+    if (!settingsView.copyVCard(person.handle)) {
+      showContactToast("Contacts is busy; try again in a moment", true)
+      return
+    }
+    showContactToast("Exporting “" + person.name + "” from Mac Contacts…", false)
+  }
+  function editContact(person) {
+    if (!person || !isContactHandle(person.handle)) return
+    openSettings("contacts")
+    Qt.callLater(function() { settingsView.editContact(person.handle) })
+  }
+  function threadContainsChat(thread, chat) {
+    if (!thread) return false
+    var wanted = String(chat || "")
+    if (String(thread.chat || "") === wanted) return true
+    var aliases = Array.isArray(thread.aliases) ? thread.aliases : []
+    for (var i = 0; i < aliases.length; i++)
+      if (String(aliases[i]) === wanted) return true
+    return false
+  }
   readonly property bool activeIsGroup: inThread && isGroupId(active.chat)
 
   /**
@@ -285,12 +425,14 @@ FocusScope {
 
   /** Back to the list view, scrolled to top — the host calls this on open. */
   function resetToList() {
+    settingsMode = false
     active = null
     bubbles = []
     note = ""
     cursor = -1
     loading = false
     pendingThreadChat = ""
+    pendingThreadAliases = []
     composeField.text = ""
     searching = false
     searchResults = []
@@ -312,10 +454,24 @@ FocusScope {
     note = ""
     loading = false
     pendingThreadChat = ""
+    pendingThreadAliases = []
     composeField.text = ""
     clearDraft()   // a queued file must never survive into another thread
     pinToBottom = false
     Qt.callLater(function() { threadFlick.contentY = 0; root.navigationFocusRequested() })
+  }
+
+  function openSettings(page) {
+    exitSearch()
+    exitNew()
+    settingsMode = true
+    settingsView.showPage(String(page || "contacts") === "appearance" ? "appearance" : "contacts")
+    Qt.callLater(settingsView.focusDefault)
+  }
+
+  function closeSettings() {
+    settingsMode = false
+    Qt.callLater(root.focusDefault)
   }
 
   function openThread(t) {
@@ -330,23 +486,27 @@ FocusScope {
     loading = true
     composeField.text = ""
     clearDraft()   // a queued file must never survive into another thread
-    requestThreadLoad(String(t.chat))
+    requestThreadLoad(String(t.chat), t.aliases || [])
     Qt.callLater(function() { composeField.forceActiveFocus() })
   }
 
-  function requestThreadLoad(chat) {
+  function requestThreadLoad(chat, aliases) {
     pendingThreadChat = String(chat || "")
+    pendingThreadAliases = Array.isArray(aliases) ? aliases.slice(0, 16) : []
     if (!threadProc.running) startNextThreadLoad()
   }
 
   function startNextThreadLoad() {
     if (threadProc.running || pendingThreadChat === "") return
     threadRunningChat = pendingThreadChat
+    threadRunningAliases = pendingThreadAliases
     pendingThreadChat = ""
+    pendingThreadAliases = []
     threadProc.command = ["bun", root.threadScript, threadRunningChat, "80",
                           "--time-format", root.timeFormat,
                           "--date-format", root.dateFormat,
                           "--date-format-with-year", root.dateFormatWithYear]
+      .concat(threadRunningAliases)
     threadProc.running = true
   }
 
@@ -581,6 +741,7 @@ FocusScope {
     newNote = ""
     newCursor = 0
     newQueryRan = ""
+    // Defer focus until the visibility change has completed its layout pass.
     Qt.callLater(function() {
       newField.forceActiveFocus()
       newField.selectAll()
@@ -595,7 +756,7 @@ FocusScope {
     newQueryRan = ""
     newField.text = ""
     newField.focus = false
-    root.navigationFocusRequested()
+    Qt.callLater(root.navigationFocusRequested)
   }
 
   // Same identity discipline as message search: a stale completion must
@@ -825,7 +986,7 @@ FocusScope {
     if (!flick.stick) { pushPending = true; return }
     if (threadProc.running && pendingThreadChat !== "") return
     pinToBottom = true
-    requestThreadLoad(String(active.chat))
+    requestThreadLoad(String(active.chat), active.aliases || [])
   }
 
   /** IPC hook (`newchat <query>`): drive the composer path minus the keyboard. */
@@ -852,7 +1013,7 @@ FocusScope {
   function openSearchHit(hit) {
     searching = false
     for (var i = 0; i < threads.length; i++) {
-      if (String(threads[i].chat) === String(hit.chat)) { openThread(threads[i]); return }
+      if (threadContainsChat(threads[i], hit.chat)) { openThread(threads[i]); return }
     }
     openThread({ chat: hit.chat, guid: "", name: hit.name, handle: hit.handle,
                  service: hit.service, last_ts: hit.ts, last_text: "",
@@ -976,7 +1137,8 @@ FocusScope {
               // Nothing changed — do NOT rebuild the Repeater (a rebuild
               // resets scroll and re-decodes every image). Push pings mostly
               // produce identical content; this makes them free.
-              if (root.hostWidget && root.readActive) root.hostWidget.markThreadRead(root.threadRunningChat)
+              if (root.hostWidget && root.readActive)
+                root.hostWidget.markThreadRead(root.threadRunningChat, root.threadRunningAliases)
               return
             }
             root.bubblesJson = j
@@ -987,7 +1149,8 @@ FocusScope {
             root.firstLoad = false
             Qt.callLater(root.autoFetchImages)
             // A dot means "looked at", so clear it only after content loaded.
-            if (root.hostWidget && root.readActive) root.hostWidget.markThreadRead(root.threadRunningChat)
+            if (root.hostWidget && root.readActive)
+              root.hostWidget.markThreadRead(root.threadRunningChat, root.threadRunningAliases)
           } else {
             root.bubbles = []
             root.note = String(d.error || "could not load this thread")
@@ -1002,6 +1165,7 @@ FocusScope {
       var completedChat = root.threadRunningChat
       var belongsHere = root.inThread && String(root.active.chat) === completedChat
       root.threadRunningChat = ""
+      root.threadRunningAliases = []
       if (belongsHere && root.pendingThreadChat === "") root.loading = false
       if (belongsHere && code !== 0) root.note = "thread loader failed (exit " + code + ")"
       if (root.pendingThreadChat !== "") Qt.callLater(root.startNextThreadLoad)
@@ -1073,7 +1237,7 @@ FocusScope {
     }
   }
 
-  // Clipboard snapshot (Ctrl+V): image → draft chip, text → insert at cursor.
+  // Clipboard snapshot (Ctrl+V): file/image → draft chip, text → composer.
   Process {
     id: pasteProc
     stdout: StdioCollector {
@@ -1083,7 +1247,7 @@ FocusScope {
         if (!root.inThread || String(root.active.chat) !== root.pasteChat) return
         try {
           var d = JSON.parse(text.trim())
-          if (d.kind === "image") root.setDraft(String(d.path || ""))
+          if (d.kind === "file" || d.kind === "image") root.setDraft(String(d.path || ""))
           else if (d.kind === "text") {
             composeField.insert(composeField.cursorPosition, String(d.text || ""))
           }
@@ -1242,26 +1406,29 @@ FocusScope {
     interval: 1500
     onTriggered: if (root.inThread && String(root.active.chat) === root.reloadChat) {
       root.loading = true
-      root.requestThreadLoad(root.reloadChat)
+      root.requestThreadLoad(root.reloadChat, root.active ? root.active.aliases || [] : [])
     }
   }
 
   // ---- keyboard navigation (the host's PanelKeyCatcher calls these)
   function moveCursor(dy) {
-    if (inThread || threads.length === 0 || dy === 0) return
-    cursor = (cursor + dy + threads.length) % threads.length
+    if (settingsMode || inThread || navigationThreads.length === 0 || dy === 0) return
+    cursor = (cursor + dy + navigationThreads.length) % navigationThreads.length
   }
   function activateCursor() {
-    if (!inThread && cursor >= 0) openThread(threads[cursor])
+    if (!inThread && cursor >= 0) openThread(navigationThreads[cursor])
   }
   function handleTextKey(text) {
+    if (settingsMode) return false
     if (text === "/") { startSearch(); return true }
     if (text === "n" || text === "N") { startNew(); return true }
     if (text >= "1" && text <= "9") {
       if (searching || newMode) return false
       var i = Number(text) - 1
-      if (i < 0 || i >= threads.length) return false
-      openThread(threads[i])
+      // navigationThreads = pinned first, then chronological — the order
+      // the sidebar actually shows.
+      if (i < 0 || i >= navigationThreads.length) return false
+      openThread(navigationThreads[i])
       return true
     }
     if ((inThread && !splitView) || searching || newMode) return false
@@ -1287,24 +1454,27 @@ FocusScope {
    *  something was unwound, false if the host should close. */
   function unwind() {
     if (shareUrl !== "") { closeShare(); return true }
+    if (settingsMode) { closeSettings(); return true }
     if (catchEscape()) return true
     if (inThread) { back(); return true }
     return false
   }
   function focusDefault() {
-    if (inThread) composeField.forceActiveFocus()
+    if (settingsMode) settingsView.focusDefault()
+    else if (inThread) composeField.forceActiveFocus()
     else navigationFocusRequested()
   }
 
   // ---- layout: one pane (popout) or two (window). Both panes always exist —
   // hiding, not unloading, keeps image state, selection, and scroll position.
   property bool splitView: false
-  property int sidebarWidth: 320
+  property int sidebarWidth: preferences ? preferences.sidebarWidth : 320
   readonly property bool listShowing: splitView || !inThread
 
   RowLayout {
     anchors.fill: parent
     spacing: 0
+    visible: !root.settingsMode
 
     // ------------------------------------------------------- thread pane
     Item {
@@ -1315,22 +1485,38 @@ FocusScope {
       Layout.preferredWidth: root.splitView ? root.sidebarWidth : -1
       ColumnLayout {
         anchors.fill: parent
-        // Gutters for the app: the popout's card supplies its own padding,
-        // the window's panes had text flush against the borders (Fred).
-        anchors.leftMargin: root.splitView ? Style.space(18) : 0
-        anchors.rightMargin: root.splitView ? Style.space(18) : 0
-        anchors.topMargin: root.splitView ? Style.space(10) : 0
-        anchors.bottomMargin: root.splitView ? Style.space(10) : 0
-        spacing: Style.space(root.splitView ? 14 : 8)
-        PanelHero {
+        // BlipWindow already supplies the outer edge inset. Keep only a small
+        // inner gutter here so the sidebar does not pay for the same padding
+        // twice; retain the larger right gutter beside the pane divider.
+        anchors.leftMargin: root.splitView ? root.space(6) : 0
+        anchors.rightMargin: root.splitView ? root.space(18) : 0
+        anchors.topMargin: root.splitView ? root.space(10) : 0
+        anchors.bottomMargin: root.splitView ? root.space(10) : 0
+        spacing: root.space(root.splitView ? 14 : 8)
+        RowLayout {
           Layout.fillWidth: true
-          title: "Blip"
-          meta: (!root.online
-                ? "Mac unreachable — bridge offline"
-                : (root.unread > 0 ? root.unread + " unread" : "all caught up"))
-          detail: ""   // Fred: not needed — and it squeezed the title to "B…"
-          foreground: root.foreground
-          fontFamily: root.fontFamily
+          spacing: root.space(8)
+          PanelHero {
+            Layout.fillWidth: true
+            title: "Blip"
+            meta: (!root.online
+                  ? "Mac unreachable — bridge offline"
+                  : (root.unread > 0 ? root.unread + " unread" : "all caught up"))
+            detail: ""   // Fred: not needed — and it squeezed the title to "B…"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+          }
+          PanelActionButton {
+            focusable: true
+            iconText: "⚙"
+            tooltipText: "Settings"
+            bordered: false
+            foreground: root.foreground
+            hoverColor: root.accent
+            fontFamily: root.fontFamily
+            fontSize: root.fontSize(Style.font.icon)
+            onClicked: root.openSettings()
+          }
         }
 
         PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
@@ -1375,7 +1561,7 @@ FocusScope {
           ColumnLayout {
             id: listContent
             width: parent.width
-            spacing: root.inThread ? Style.space(2) : Style.space(root.splitView ? 10 : 6)
+            spacing: root.inThread ? root.space(2) : root.space(root.splitView ? 10 : 6)
 
             // ------------------------------------------------- OFFLINE
             Text {
@@ -1387,7 +1573,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               wrapMode: Text.WordWrap
             }
             // Reachable but broken — say exactly what to fix (Full Disk Access,
@@ -1400,7 +1586,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.urgent
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               wrapMode: Text.WordWrap
             }
 
@@ -1408,11 +1594,14 @@ FocusScope {
             RowLayout {
               Layout.fillWidth: true
               visible: root.online && root.listShowing
+                       && (root.newMode || root.searchShowing || !root.splitView || root.unread > 0)
               PanelSectionHeader {
                 Layout.fillWidth: true
-                text: root.newMode ? "NEW MESSAGE" : root.searchShowing ? "SEARCH" : "MESSAGES"
+                visible: root.newMode || root.searchShowing
+                text: root.newMode ? "NEW MESSAGE" : "SEARCH"
                 foreground: root.foreground
                 fontFamily: root.fontFamily
+                fontSize: root.fontSize(Style.font.caption)
               }
               // A real button (PanelActionButton = the stock panels' control).
               // The hand-rolled Text+MouseArea version lost its clicks to the
@@ -1425,6 +1614,7 @@ FocusScope {
                 foreground: root.foreground
                 hoverColor: root.accent
                 fontFamily: root.fontFamily
+                fontSize: root.fontSize(Style.font.icon)
                 onClicked: root.startNew()
               }
               // Open the full app window. Hidden in the app itself (it IS the
@@ -1437,6 +1627,7 @@ FocusScope {
                 foreground: root.foreground
                 hoverColor: root.accent
                 fontFamily: root.fontFamily
+                fontSize: root.fontSize(Style.font.icon)
                 onClicked: root.openApp()
               }
               // Local only: moves readMark/readMarks in state.json so the
@@ -1451,7 +1642,7 @@ FocusScope {
                 textFormat: Text.PlainText
                 color: markAllHover.hovered ? root.mineFill : root.cyan
                 font.family: root.fontFamily
-                font.pixelSize: Style.font.caption
+                font.pixelSize: root.fontSize(Style.font.caption)
                 font.underline: markAllHover.hovered
                 HoverHandler { id: markAllHover; cursorShape: Qt.PointingHandCursor }
                 TapHandler { onTapped: root.markAllRead() }
@@ -1471,7 +1662,7 @@ FocusScope {
               foreground: root.foreground
               accent: root.accent
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               onAccepted: root.acceptNewField()
               Keys.onEscapePressed: root.exitNew()
               Keys.onPressed: function(event) {
@@ -1491,7 +1682,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
             }
 
             Repeater {
@@ -1500,8 +1691,8 @@ FocusScope {
                 required property var modelData
                 required property int index
                 Layout.fillWidth: true
-                implicitHeight: contactRow.implicitHeight + Style.space(12)
-                radius: Style.cornerRadius
+                implicitHeight: contactRow.implicitHeight + root.space(12)
+                radius: root.corner(Style.cornerRadius)
                 color: contactHover.hovered || root.newCursor === index
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
@@ -1512,16 +1703,16 @@ FocusScope {
                   anchors.left: parent.left
                   anchors.right: parent.right
                   anchors.verticalCenter: parent.verticalCenter
-                  anchors.leftMargin: Style.space(8)
-                  anchors.rightMargin: Style.space(8)
-                  spacing: Style.space(8)
+                  anchors.leftMargin: root.space(8)
+                  anchors.rightMargin: root.space(8)
+                  spacing: root.space(8)
                   Text {
                     text: String(modelData.name || "")
                     textFormat: Text.PlainText
                     elide: Text.ElideRight
                     color: root.foreground
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.bodySmall
+                    font.pixelSize: root.fontSize(Style.font.bodySmall)
                     font.bold: true
                   }
                   Text {
@@ -1531,7 +1722,7 @@ FocusScope {
                     elide: Text.ElideRight
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
                   }
                 }
               }
@@ -1545,7 +1736,7 @@ FocusScope {
               foreground: root.foreground
               accent: root.accent
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               onAccepted: root.acceptSearchField()
               onActiveFocusChanged: if (activeFocus && !root.searching) root.searching = true
               Keys.onEscapePressed: root.exitSearch()
@@ -1643,28 +1834,16 @@ FocusScope {
                       }
                     }
 
-                    RowLayout {
+                    Text {
                       Layout.fillWidth: true
-                      spacing: Style.space(4)
-                      Text {
-                        visible: root.threadHotkey(modelData) !== ""
-                        text: root.threadHotkey(modelData)
-                        textFormat: Text.PlainText
-                        color: root.dim
-                        font.family: root.fontFamily
-                        font.pixelSize: Style.font.caption
-                      }
-                      Text {
-                        Layout.fillWidth: true
-                        text: String(modelData.name || modelData.chat)
-                        textFormat: Text.PlainText
-                        horizontalAlignment: Text.AlignHCenter
-                        elide: Text.ElideRight
-                        color: root.foreground
-                        font.family: root.fontFamily
-                        font.pixelSize: Style.font.caption
-                        font.bold: modelData.unread > 0
-                      }
+                      text: String(modelData.name || modelData.chat)
+                      textFormat: Text.PlainText
+                      horizontalAlignment: Text.AlignHCenter
+                      elide: Text.ElideRight
+                      color: root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.bold: modelData.unread > 0
                     }
                   }
                 }
@@ -1678,7 +1857,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
             }
 
             Repeater {
@@ -1687,8 +1866,8 @@ FocusScope {
                 required property var modelData
                 required property int index
                 Layout.fillWidth: true
-                implicitHeight: hitCol.implicitHeight + Style.space(12)
-                radius: Style.cornerRadius
+                implicitHeight: hitCol.implicitHeight + root.space(12)
+                radius: root.corner(Style.cornerRadius)
                 color: hitHover.hovered || root.searchCursor === index
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
@@ -1700,9 +1879,9 @@ FocusScope {
                   anchors.left: parent.left
                   anchors.right: parent.right
                   anchors.verticalCenter: parent.verticalCenter
-                  anchors.leftMargin: Style.space(8)
-                  anchors.rightMargin: Style.space(8)
-                  spacing: Style.space(2)
+                  anchors.leftMargin: root.space(8)
+                  anchors.rightMargin: root.space(8)
+                  spacing: root.space(2)
                   RowLayout {
                     Layout.fillWidth: true
                     Text {
@@ -1714,7 +1893,7 @@ FocusScope {
                       elide: Text.ElideRight
                       color: root.foreground
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.bodySmall
+                      font.pixelSize: root.fontSize(Style.font.bodySmall)
                       font.bold: true
                     }
                     Text {
@@ -1722,7 +1901,7 @@ FocusScope {
                       textFormat: Text.PlainText
                       color: root.dim
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
+                      font.pixelSize: root.fontSize(Style.font.caption)
                     }
                   }
                   Text {
@@ -1736,7 +1915,41 @@ FocusScope {
                     wrapMode: Text.WordWrap
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
+                  }
+                }
+              }
+            }
+
+            // Messages.app's pinning plist supplies both membership and order.
+            // Keep the same visual grammar: large circular contacts in a grid,
+            // then the remaining conversations in chronological rows.
+            ColumnLayout {
+              Layout.fillWidth: true
+              visible: root.online && root.listShowing && !root.searchShowing
+                       && !root.newMode && root.pinnedThreads.length > 0
+              // Match the header-to-search breathing room: listContent's
+              // spacing supplies most of this gap and this margin supplies
+              // the difference from the outer divider spacing.
+              Layout.topMargin: root.space(root.splitView ? 4 : 2)
+              spacing: root.space(7)
+
+              GridLayout {
+                id: pinnedGrid
+                Layout.fillWidth: true
+                columns: root.splitView && root.sidebarWidth < 400 ? 3 : 4
+                columnSpacing: root.space(6)
+                rowSpacing: root.space(8)
+
+                Repeater {
+                  model: root.pinnedThreads
+                  delegate: PinnedConversation {
+                    required property var modelData
+                    required property int index
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: pinAvatarSize + root.space(38)
+                    thread: modelData
+                    selected: root.cursor === index
                   }
                 }
               }
@@ -1749,32 +1962,37 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               wrapMode: Text.WordWrap
             }
 
             Repeater {
-              model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.unpinnedThreads : []
+              model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.regularThreads : []
               delegate: Rectangle {
                 required property var modelData
                 required property int index
 
                 Layout.fillWidth: true
-                implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 20 : 12)
-                radius: Style.cornerRadius
+                implicitHeight: rowRow.implicitHeight + root.space(root.splitView ? 20 : 12)
+                radius: root.corner(Style.cornerRadius)
                 color: rowHover.hovered || root.cursor === root.threadIndex(modelData)
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
 
                 HoverHandler { id: rowHover }
                 TapHandler { onTapped: root.openThread(modelData) }
+                TapHandler {
+                  acceptedButtons: Qt.RightButton
+                  onTapped: root.openContactContext(modelData, "")
+                }
 
                 RowLayout {
                   id: rowRow
                   anchors.fill: parent
-                  anchors.margins: Style.space(6)
-                  spacing: Style.space(8)
+                  anchors.margins: root.space(6)
+                  spacing: root.space(8)
 
+                  // 1-9 jump hotkey for this row, numbered in sidebar order
                   Text {
                     Layout.preferredWidth: Style.space(16)
                     Layout.alignment: Qt.AlignVCenter
@@ -1790,7 +2008,7 @@ FocusScope {
                   // the iMessage blue dot — present only while the thread has
                   // unread inbound; the slot stays so names line up.
                   Rectangle {
-                    width: Style.space(9); height: width; radius: width / 2
+                    width: root.space(9); height: width; radius: width / 2
                     color: root.mineFill
                     opacity: modelData.unread > 0 ? 1 : 0
                   }
@@ -1799,7 +2017,7 @@ FocusScope {
                   // initials otherwise (the iMessage sidebar look)
                   Rectangle {
                     id: avatarCircle
-                    width: Style.space(30); height: width; radius: width / 2
+                    width: Math.max(1, Math.round(Style.spaceReal(root.avatarSize))); height: width; radius: width / 2
                     color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
                     // A group binds to ITS OWN chat id (its Messages group photo); a DM to
                     // the person. Binding a group to `handle` showed whoever spoke last —
@@ -1841,17 +2059,17 @@ FocusScope {
                       text: root.avatarInitials(modelData)
                       color: root.foreground
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
+                      font.pixelSize: root.fontSize(Style.font.caption)
                       font.bold: true
                     }
                   }
 
                   ColumnLayout {
                     Layout.fillWidth: true
-                    spacing: Style.space(1)
+                    spacing: root.space(1)
                     RowLayout {
                       Layout.fillWidth: true
-                      spacing: Style.space(6)
+                      spacing: root.space(6)
                       Text {
                         Layout.fillWidth: true
                         text: String(modelData.name || modelData.chat)
@@ -1859,7 +2077,7 @@ FocusScope {
                         elide: Text.ElideRight
                         color: root.foreground
                         font.family: root.fontFamily
-                        font.pixelSize: Style.font.bodySmall
+                        font.pixelSize: root.fontSize(Style.font.bodySmall)
                         font.bold: modelData.unread > 0
                       }
                       Text {
@@ -1867,7 +2085,7 @@ FocusScope {
                         textFormat: Text.PlainText
                         color: modelData.unread > 0 ? root.mineFill : root.dim
                         font.family: root.fontFamily
-                        font.pixelSize: Style.font.caption
+                        font.pixelSize: root.fontSize(Style.font.caption)
                       }
                     }
                     Text {
@@ -1878,10 +2096,24 @@ FocusScope {
                       maximumLineCount: 1
                       color: root.dim
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
+                      font.pixelSize: root.fontSize(Style.font.caption)
                     }
                   }
 
+                }
+
+                // Messages separates chronological conversations with a
+                // hairline that begins after the avatar rather than cutting
+                // through the unread-dot/avatar gutter.
+                Rectangle {
+                  anchors.left: parent.left
+                  anchors.leftMargin: root.space(6 + 9 + 8) + avatarCircle.width + root.space(8)
+                  anchors.right: parent.right
+                  anchors.rightMargin: root.space(6)
+                  anchors.bottom: parent.bottom
+                  height: Math.max(1, Math.round(Style.spaceReal(1)))
+                  visible: index < root.regularThreads.length - 1
+                  color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.10)
                 }
               }
             }
@@ -1908,14 +2140,14 @@ FocusScope {
         anchors.fill: parent
         // Gutters for the app: the popout's card supplies its own padding,
         // the window's panes had text flush against the borders (Fred).
-        anchors.leftMargin: root.splitView ? Style.space(18) : 0
-        anchors.rightMargin: root.splitView ? Style.space(18) : 0
-        anchors.topMargin: root.splitView ? Style.space(10) : 0
-        anchors.bottomMargin: root.splitView ? Style.space(10) : 0
-        spacing: Style.space(8)
+        anchors.leftMargin: root.splitView ? root.space(18) : 0
+        anchors.rightMargin: root.splitView ? root.space(18) : 0
+        anchors.topMargin: root.splitView ? root.space(10) : 0
+        anchors.bottomMargin: root.splitView ? root.space(10) : 0
+        spacing: root.space(8)
         RowLayout {
           Layout.fillWidth: true
-          spacing: Style.space(8)
+          spacing: root.space(8)
           PanelHero {
             Layout.fillWidth: true
             title: root.inThread ? String(root.active.name || root.active.chat) : "Select a conversation"
@@ -1934,13 +2166,14 @@ FocusScope {
           PanelActionButton {
             visible: root.splitView && !root.newMode
             Layout.alignment: Qt.AlignTop
-            Layout.topMargin: Style.space(6)
+            Layout.topMargin: root.space(6)
             iconText: "＋"
             tooltipText: "New message (n)"
-            bordered: true
+            bordered: false
             foreground: root.foreground
             hoverColor: root.accent
             fontFamily: root.fontFamily
+            fontSize: root.fontSize(Style.font.icon)
             onClicked: root.startNew()
           }
         }
@@ -2018,7 +2251,7 @@ FocusScope {
           ColumnLayout {
             id: content
             width: parent.width
-            spacing: root.inThread ? Style.space(2) : Style.space(6)
+            spacing: root.inThread ? root.space(2) : root.space(6)
 
             // ------------------------------------------- CONVERSATION
             Text {
@@ -2028,7 +2261,7 @@ FocusScope {
               horizontalAlignment: Text.AlignHCenter
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
             }
 
             Repeater {
@@ -2039,7 +2272,12 @@ FocusScope {
                 readonly property bool mine: modelData.from_me === true
 
                 Layout.fillWidth: true
-                spacing: Style.space(2)
+                spacing: root.space(2)
+
+                TapHandler {
+                  acceptedButtons: Qt.RightButton
+                  onTapped: root.openContactContext(root.active, String(modelData.text || ""))
+                }
 
                 // day divider — "Today", "Yesterday", "Aug 28"
                 Text {
@@ -2049,23 +2287,23 @@ FocusScope {
                   horizontalAlignment: Text.AlignHCenter
                   color: root.dim
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.caption
+                  font.pixelSize: root.fontSize(Style.font.caption)
                   font.bold: true
-                  topPadding: Style.space(10)
-                  bottomPadding: Style.space(4)
+                  topPadding: root.space(10)
+                  bottomPadding: root.space(4)
                 }
 
                 // in a group, iMessage names the sender above each run of theirs
                 Text {
                   Layout.alignment: Qt.AlignLeft
-                  Layout.leftMargin: Style.space(10)
-                  Layout.topMargin: Style.space(6)
+                  Layout.leftMargin: root.space(10)
+                  Layout.topMargin: root.space(6)
                   visible: root.activeIsGroup && !bubbleRow.mine && modelData.groupStart === true
                   text: String(modelData.name || "")
                   textFormat: Text.PlainText
                   color: root.dim
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.caption
+                  font.pixelSize: root.fontSize(Style.font.caption)
                 }
 
                 // "You unsent a message" tombstone replaces a retracted bubble
@@ -2079,9 +2317,9 @@ FocusScope {
                     textFormat: Text.PlainText
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
                     font.italic: true
-                    padding: Style.space(4)
+                    padding: root.space(4)
                   }
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }
                 }
@@ -2090,28 +2328,28 @@ FocusScope {
                 RowLayout {
                   Layout.fillWidth: true
                   visible: !modelData.retracted && String(modelData.replyText || "") !== ""
-                  Layout.topMargin: modelData.groupStart ? Style.space(6) : 0
+                  Layout.topMargin: modelData.groupStart ? root.space(6) : 0
                   spacing: 0
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
                   Rectangle {
-                    Layout.preferredWidth: Math.min(Math.ceil(replySnippet.implicitWidth) + Style.space(18), Math.round(content.width * 0.7))
-                    Layout.preferredHeight: Math.ceil(replySnippet.implicitHeight) + Style.space(10)
-                    radius: Style.space(12)
+                    Layout.preferredWidth: Math.min(Math.ceil(replySnippet.implicitWidth) + root.space(18), Math.round(content.width * 0.7))
+                    Layout.preferredHeight: Math.ceil(replySnippet.implicitHeight) + root.space(10)
+                    radius: root.corner(root.space(12))
                     color: "transparent"
                     border.color: root.dim
                     border.width: 1
                     opacity: 0.75
                     Text {
                       id: replySnippet
-                      x: Style.space(9); y: Style.space(5)
-                      width: Math.round(content.width * 0.7) - Style.space(18)
+                      x: root.space(9); y: root.space(5)
+                      width: Math.round(content.width * 0.7) - root.space(18)
                       text: "↩ " + (modelData.replyMine ? "You: " : "") + String(modelData.replyText || "")
                       textFormat: Text.PlainText
                       elide: Text.ElideRight
                       maximumLineCount: 1
                       color: root.dim
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
+                      font.pixelSize: root.fontSize(Style.font.caption)
                     }
                   }
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }
@@ -2153,7 +2391,7 @@ FocusScope {
                       root.isImageMime(chipRow.modelData.mime) &&
                       chipRow.fileUrl !== undefined && chipRow.fileUrl !== ""
                     Layout.fillWidth: true
-                    Layout.topMargin: index === 0 && bubbleRow.modelData.groupStart ? Style.space(6) : 0
+                    Layout.topMargin: index === 0 && bubbleRow.modelData.groupStart ? root.space(6) : 0
                     spacing: 0
                     Item { Layout.fillWidth: true; visible: bubbleRow.mine }
 
@@ -2185,16 +2423,16 @@ FocusScope {
                       Layout.preferredWidth: status === Image.Ready ? Math.min(maxW, implicitWidth) : maxW
                       Layout.preferredHeight: status === Image.Ready && implicitWidth > 0
                         ? Layout.preferredWidth * implicitHeight / implicitWidth
-                        : Style.space(120)
+                        : root.space(120)
                       HoverHandler { cursorShape: Qt.PointingHandCursor }
                       TapHandler { onTapped: root.openAttachment(chipRow.modelData) }
                     }
 
                     Rectangle {
                       visible: !chipRow.showImage
-                      Layout.preferredWidth: Math.ceil(chipText.implicitWidth) + Style.space(18)
-                      Layout.preferredHeight: Math.ceil(chipText.implicitHeight) + Style.space(12)
-                      radius: Style.space(14)
+                      Layout.preferredWidth: Math.ceil(chipText.implicitWidth) + root.space(18)
+                      Layout.preferredHeight: Math.ceil(chipText.implicitHeight) + root.space(12)
+                      radius: root.corner(root.space(14))
                       color: bubbleRow.mine ? root.mineFill : root.theirsFill
                       opacity: 0.85
                       Text {
@@ -2209,7 +2447,7 @@ FocusScope {
                         textFormat: Text.PlainText
                         color: bubbleRow.mine ? root.mineText : root.theirsText
                         font.family: root.fontFamily
-                        font.pixelSize: Style.font.caption
+                        font.pixelSize: root.fontSize(Style.font.caption)
                       }
                       HoverHandler { cursorShape: Qt.PointingHandCursor }
                       TapHandler { onTapped: root.openAttachment(chipRow.modelData) }
@@ -2231,7 +2469,7 @@ FocusScope {
                   onBareUrlChanged: if (bareUrl !== "") root.requestPreview(bareUrl)
                   visible: !modelData.retracted && (!!modelData.link || !!fetched)
                   Layout.fillWidth: true
-                  Layout.topMargin: modelData.groupStart ? Style.space(6) : 0
+                  Layout.topMargin: modelData.groupStart ? root.space(6) : 0
                   spacing: 0
                   // same anchoring as the chips: a card image completing ABOVE
                   // the viewport must not shove the reader's position.
@@ -2254,9 +2492,9 @@ FocusScope {
                     readonly property string imgUrl: modelData.link
                       ? (link.image_id ? String(root.attFiles[String(link.image_id)] || "") : "")
                       : String((linkRow.fetched && linkRow.fetched.image) || "")
-                    Layout.preferredWidth: Math.min(Math.round(content.width * 0.62), Style.space(380))
+                    Layout.preferredWidth: Math.min(Math.round(content.width * 0.62), root.space(380))
                     Layout.preferredHeight: linkCol.implicitHeight
-                    radius: Style.space(14)
+                    radius: root.corner(root.space(14))
                     clip: true
                     color: bubbleRow.mine ? root.mineFill : root.theirsFill
                     ColumnLayout {
@@ -2268,7 +2506,7 @@ FocusScope {
                         visible: linkCard.imgUrl !== "" && status === Image.Ready
                         Layout.fillWidth: true
                         Layout.preferredHeight: visible && implicitWidth > 0
-                          ? Math.min(Style.space(220), Math.round(linkCard.width * implicitHeight / implicitWidth))
+                          ? Math.min(root.space(220), Math.round(linkCard.width * implicitHeight / implicitWidth))
                           : 0
                         source: linkCard.imgUrl
                         asynchronous: true
@@ -2279,8 +2517,8 @@ FocusScope {
                       }
                       ColumnLayout {
                         Layout.fillWidth: true
-                        Layout.margins: Style.space(10)
-                        spacing: Style.space(2)
+                        Layout.margins: root.space(10)
+                        spacing: root.space(2)
                         Text {
                           Layout.fillWidth: true
                           visible: text !== ""
@@ -2291,7 +2529,7 @@ FocusScope {
                           elide: Text.ElideRight
                           color: bubbleRow.mine ? root.mineText : root.theirsText
                           font.family: root.fontFamily
-                          font.pixelSize: Style.font.bodySmall
+                          font.pixelSize: root.fontSize(Style.font.bodySmall)
                           font.bold: true
                         }
                         Text {
@@ -2305,7 +2543,7 @@ FocusScope {
                           color: bubbleRow.mine ? root.mineText : root.theirsText
                           opacity: 0.85
                           font.family: root.fontFamily
-                          font.pixelSize: Style.font.caption
+                          font.pixelSize: root.fontSize(Style.font.caption)
                         }
                         Text {
                           Layout.fillWidth: true
@@ -2315,7 +2553,7 @@ FocusScope {
                           color: bubbleRow.mine ? root.mineText : root.theirsText
                           opacity: 0.6
                           font.family: root.fontFamily
-                          font.pixelSize: Style.font.caption
+                          font.pixelSize: root.fontSize(Style.font.caption)
                         }
                       }
                     }
@@ -2331,14 +2569,16 @@ FocusScope {
                 // when the delegate's own width collapses to its content.
                 RowLayout {
                   Layout.fillWidth: true
-                  // a tapback pill overlaps the top edge — leave room for it
-                  Layout.topMargin: (modelData.groupStart ? Style.space(6) : 0)
-                                    + ((modelData.tapbacks || []).length > 0 ? Style.space(12) : 0)
+                  // A Messages-sized tapback pill overlaps the top edge —
+                  // reserve its raised portion so adjacent runs stay clear.
+                  Layout.topMargin: (modelData.groupStart ? root.space(6) : 0)
+                                    + ((modelData.tapbacks || []).length > 0 ? root.space(23) : 0)
                   visible: !modelData.retracted &&
                            (String(modelData.text || "") !== "" || (modelData.attachments || []).length === 0) &&
-                           // a message that is ONLY the URL shows just the card,
-                           // like Messages — for Apple's card and for ours
-                           !(modelData.link && String(modelData.text || "").trim() === String(modelData.link.url)) &&
+                           // URL-only messages show just the unfurled card. The
+                           // model handles Apple's canonicalized URL, while the
+                           // live check covers cards Blip fetched itself.
+                           modelData.linkOnly !== true &&
                            !(!modelData.link && !!linkRow.fetched
                              && String(modelData.text || "").trim() === linkRow.bareUrl)
                   spacing: 0
@@ -2347,10 +2587,10 @@ FocusScope {
 
                   Rectangle {
                     id: bubble
-                    readonly property real maxInner: Math.round(content.width * 0.78) - Style.space(22)
-                    Layout.preferredWidth: Math.ceil(bubbleText.contentWidth) + Style.space(22)
-                    Layout.preferredHeight: Math.ceil(bubbleText.contentHeight) + Style.space(14)
-                    radius: Style.space(16)
+                    readonly property real maxInner: Math.round(content.width * 0.78) - root.space(22)
+                    Layout.preferredWidth: Math.ceil(bubbleText.contentWidth) + root.space(22)
+                    Layout.preferredHeight: Math.ceil(bubbleText.contentHeight) + root.space(14)
+                    radius: root.corner(root.space(16))
                     color: bubbleRow.mine ? root.mineFill : root.theirsFill
 
                     // iMessage squares off the corner nearest the sender on the
@@ -2366,7 +2606,7 @@ FocusScope {
                     // can be highlighted and Ctrl+C'd like any other text.
                     TextEdit {
                       id: bubbleText
-                      x: Style.space(11); y: Style.space(7)
+                      x: root.space(11); y: root.space(7)
                       width: bubble.maxInner
                       // html is pre-escaped + linkified in thread.ts (tested);
                       // plain messages keep the cheap PlainText path.
@@ -2383,7 +2623,7 @@ FocusScope {
                       selectionColor: bubbleRow.mine ? "#ffffff" : root.mineFill
                       selectedTextColor: bubbleRow.mine ? root.mineFill : "#ffffff"
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.bodySmall
+                      font.pixelSize: root.fontSize(Style.font.bodySmall)
                       onActiveFocusChanged: root.bubbleFocused = activeFocus
                       Keys.onEscapePressed: { deselect(); composeField.forceActiveFocus() }
                       // Ctrl+C through wl-copy: Qt's own clipboard does not reliably
@@ -2409,38 +2649,74 @@ FocusScope {
                       }
                     }
 
-                    // right-click on a LINK = share sheet; anywhere else = copy the whole message
+                    // A link keeps its share action; any other bubble opens the
+                    // message/contact menu for this conversation.
                     TapHandler {
                       acceptedButtons: Qt.RightButton
                       onTapped: function(eventPoint) {
                         var p = bubbleText.mapFromItem(bubble, eventPoint.position.x, eventPoint.position.y)
                         var l = bubbleText.hasLink ? bubbleText.linkAt(p.x, p.y) : ""
                         if (l && l !== "") root.openShare(String(l))
-                        else root.copyText(String(modelData.text || ""))
+                        else root.openContactContext(root.active, String(modelData.text || ""))
                       }
                     }
 
                     // tapback pill overlapping the corner opposite the tail
                     Rectangle {
+                      id: tapbackPill
                       visible: (modelData.tapbacks || []).length > 0
-                      width: Math.ceil(tapbackText.implicitWidth) + Style.space(12)
-                      height: Math.ceil(tapbackText.implicitHeight) + Style.space(8)
+                      readonly property real minimumSize: Math.max(
+                        root.space(32), Math.ceil(tapbackText.implicitHeight) + root.space(12)
+                      )
+                      width: Math.max(
+                        minimumSize, Math.ceil(tapbackText.implicitWidth) + root.space(18)
+                      )
+                      height: minimumSize
                       radius: height / 2
-                      color: bubbleRow.mine ? Qt.darker(root.mineFill, 2.2) : root.mineFill
-                      border.color: Qt.rgba(0, 0, 0, 0.5)
-                      border.width: 2
+                      // Composite once against the theme background so the
+                      // pill and its tail remain opaque where they overlap a
+                      // translucent message bubble.
+                      color: root.incomingColorSetting === "theme"
+                        ? root.opaqueOver(
+                            Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.28),
+                            Color.background
+                          )
+                        : root.opaqueOver(Qt.darker(root.theirsFill, 1.2), Color.background)
+                      border.width: 0
                       anchors.top: parent.top
-                      anchors.topMargin: -Style.space(12)
+                      anchors.topMargin: -Math.round(height * 0.74)
                       anchors.right: bubbleRow.mine ? undefined : parent.right
-                      anchors.rightMargin: bubbleRow.mine ? 0 : -Style.space(6)
+                      anchors.rightMargin: bubbleRow.mine ? 0 : -Math.round(width * 0.35)
                       anchors.left: bubbleRow.mine ? parent.left : undefined
-                      anchors.leftMargin: bubbleRow.mine ? -Style.space(6) : 0
+                      anchors.leftMargin: bubbleRow.mine ? -Math.round(width * 0.35) : 0
+
+                      Rectangle {
+                        id: tapbackTailLarge
+                        width: Math.round(tapbackPill.height * 0.28)
+                        height: width
+                        radius: width / 2
+                        color: tapbackPill.color
+                        x: bubbleRow.mine ? 0 : tapbackPill.width - width
+                        y: Math.round(tapbackPill.height * 0.76)
+                      }
+                      Rectangle {
+                        id: tapbackTailSmall
+                        width: Math.max(3, Math.round(tapbackPill.height * 0.14))
+                        height: width
+                        radius: width / 2
+                        color: tapbackPill.color
+                        x: bubbleRow.mine
+                          ? -Math.round(tapbackPill.height * 0.08)
+                          : tapbackPill.width - width + Math.round(tapbackPill.height * 0.08)
+                        y: Math.round(tapbackPill.height * 1.08)
+                      }
                       Text {
                         id: tapbackText
+                        z: 1
                         anchors.centerIn: parent
                         text: root.tapbackRow(modelData.tapbacks)
                         textFormat: Text.PlainText
-                        font.pixelSize: Style.font.caption
+                        font.pixelSize: root.fontSize(Style.font.heading)
                       }
                     }
                   }
@@ -2458,8 +2734,8 @@ FocusScope {
                   spacing: 0
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
                   Text {
-                    Layout.rightMargin: bubbleRow.mine ? Style.space(6) : 0
-                    Layout.leftMargin: bubbleRow.mine ? 0 : Style.space(6)
+                    Layout.rightMargin: bubbleRow.mine ? root.space(6) : 0
+                    Layout.leftMargin: bubbleRow.mine ? 0 : root.space(6)
                     text: [modelData.failed === true ? "⚠ Not Delivered" : "",
                            String(modelData.time || ""),
                            modelData.edited === true ? "Edited" : "",
@@ -2470,8 +2746,8 @@ FocusScope {
                     color: modelData.failed === true ? root.urgent : root.dim
                     font.bold: modelData.failed === true
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
-                    bottomPadding: Style.space(4)
+                    font.pixelSize: root.fontSize(Style.font.caption)
+                    bottomPadding: root.space(4)
                   }
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }
                 }
@@ -2483,14 +2759,14 @@ FocusScope {
                   spacing: 0
                   Item { Layout.fillWidth: true }
                   Text {
-                    Layout.rightMargin: Style.space(6)
+                    Layout.rightMargin: root.space(6)
                     text: String(modelData.receipt || "")
                     textFormat: Text.PlainText
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
                     font.bold: true
-                    bottomPadding: Style.space(4)
+                    bottomPadding: root.space(4)
                   }
                 }
 
@@ -2505,7 +2781,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
             }
           }
         }
@@ -2522,9 +2798,9 @@ FocusScope {
           visible: root.inThread && root.draftPath !== ""
           spacing: 0
           Rectangle {
-            Layout.preferredWidth: Math.ceil(draftText.implicitWidth) + Style.space(18)
-            Layout.preferredHeight: Math.ceil(draftText.implicitHeight) + Style.space(12)
-            radius: Style.space(14)
+            Layout.preferredWidth: Math.ceil(draftText.implicitWidth) + root.space(18)
+            Layout.preferredHeight: Math.ceil(draftText.implicitHeight) + root.space(12)
+            radius: root.corner(root.space(14))
             color: root.mineFill
             opacity: 0.9
             Text {
@@ -2536,7 +2812,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.mineText
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
             }
             HoverHandler { cursorShape: Qt.PointingHandCursor }
             TapHandler { onTapped: root.clearDraft() }
@@ -2547,7 +2823,7 @@ FocusScope {
         RowLayout {
           Layout.fillWidth: true
           visible: root.inThread
-          spacing: Style.space(6)
+          spacing: root.space(6)
 
           TextField {
             id: composeField
@@ -2564,7 +2840,7 @@ FocusScope {
             foreground: root.foreground
             accent: root.mineFill
             font.family: root.fontFamily
-            font.pixelSize: Style.font.bodySmall
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
             onAccepted: root.send()
             Keys.onEscapePressed: root.back()
             // Ctrl+V goes through paste.ts: an image on the clipboard becomes
@@ -2581,14 +2857,14 @@ FocusScope {
           // send button — the blue arrow circle (lit when text OR a file is queued)
           Rectangle {
             readonly property bool armed: composeField.text.trim() !== "" || root.draftPath !== ""
-            width: Style.space(28); height: width; radius: width / 2
+            width: root.space(28); height: width; radius: width / 2
             color: armed ? root.mineFill : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.15)
             Text {
               anchors.centerIn: parent
               text: "↑"
               color: parent.armed ? "#ffffff" : root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.body
+              font.pixelSize: root.fontSize(Style.font.body)
               font.bold: true
             }
             TapHandler { onTapped: root.send() }
@@ -2602,17 +2878,285 @@ FocusScope {
           textFormat: Text.PlainText
           color: root.note === "sending…" ? root.dim : root.urgent
           font.family: root.fontFamily
-          font.pixelSize: Style.font.caption
+          font.pixelSize: root.fontSize(Style.font.caption)
           wrapMode: Text.WordWrap
         }
       }
     }
   }
 
+  component PinnedConversation: Item {
+    id: pinTile
+    required property var thread
+    property bool selected: false
+    readonly property int pinAvatarSize: Math.max(
+      Math.round(Style.spaceReal(root.avatarSize) * 1.75), root.space(48))
+    readonly property string avatarHandle: String(thread.handle || thread.chat || "")
+    readonly property string displayName: String(thread.pin_name || thread.name || thread.chat || "")
+
+    Rectangle {
+      anchors.fill: parent
+      radius: root.corner(root.space(12))
+      color: pinHover.hovered || pinTile.selected
+        ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+        : "transparent"
+    }
+
+    Column {
+      anchors.fill: parent
+      anchors.margins: root.space(4)
+      spacing: root.space(4)
+
+      Item {
+        width: parent.width
+        height: pinTile.pinAvatarSize
+
+        Rectangle {
+          id: pinAvatar
+          anchors.horizontalCenter: parent.horizontalCenter
+          width: pinTile.pinAvatarSize
+          height: width
+          radius: width / 2
+          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+          Component.onCompleted: if (!root.isGroupId(String(pinTile.thread.chat || "")))
+            root.requestAvatar(pinTile.avatarHandle)
+
+          Image {
+            id: pinAvatarImage
+            anchors.fill: parent
+            visible: false
+            source: root.avatarFiles[pinTile.avatarHandle] || ""
+            asynchronous: true
+            fillMode: Image.PreserveAspectCrop
+            sourceSize.width: 128
+            sourceSize.height: 128
+            onStatusChanged: if (status === Image.Error && pinTile.avatarHandle !== "") {
+              var files = Object.assign({}, root.avatarFiles)
+              files[pinTile.avatarHandle] = ""
+              root.avatarFiles = files
+            }
+          }
+          Item {
+            id: pinAvatarMask
+            anchors.fill: parent
+            visible: false
+            layer.enabled: true
+            Rectangle { anchors.fill: parent; radius: width / 2 }
+          }
+          MultiEffect {
+            anchors.fill: parent
+            source: pinAvatarImage
+            visible: pinAvatarImage.status === Image.Ready
+            maskEnabled: true
+            maskSource: pinAvatarMask
+          }
+          Text {
+            anchors.centerIn: parent
+            visible: pinAvatarImage.status !== Image.Ready
+            text: {
+              var name = pinTile.displayName
+              if (/^[+0-9]/.test(name) || name === "") return "#"
+              var parts = name.trim().split(/\s+/)
+              return (parts[0][0] + (parts.length > 1 ? parts[parts.length - 1][0] : "")).toUpperCase()
+            }
+            textFormat: Text.PlainText
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+
+          Rectangle {
+            visible: Number(pinTile.thread.unread || 0) > 0
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.rightMargin: -root.space(2)
+            anchors.topMargin: -root.space(2)
+            width: Math.max(root.space(18), unreadCount.implicitWidth + root.space(8))
+            height: root.space(18)
+            radius: height / 2
+            color: root.mineFill
+            border.width: 2
+            border.color: Color.background
+            Text {
+              id: unreadCount
+              anchors.centerIn: parent
+              text: Number(pinTile.thread.unread || 0) > 99 ? "99+" : String(pinTile.thread.unread || "")
+              textFormat: Text.PlainText
+              color: root.mineText
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+            }
+          }
+        }
+      }
+
+      Text {
+        width: parent.width
+        text: pinTile.displayName
+        textFormat: Text.PlainText
+        color: root.foreground
+        horizontalAlignment: Text.AlignHCenter
+        elide: Text.ElideRight
+        maximumLineCount: 1
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: Number(pinTile.thread.unread || 0) > 0
+      }
+    }
+
+    HoverHandler { id: pinHover; cursorShape: Qt.PointingHandCursor }
+    TapHandler { onTapped: root.openThread(pinTile.thread) }
+    TapHandler {
+      acceptedButtons: Qt.RightButton
+      onTapped: root.openContactContext(pinTile.thread, "")
+    }
+  }
+
+  // Qt's native Menu reserves rows for invisible children, so direct and
+  // group conversations use separate menus instead of hiding irrelevant
+  // actions. This avoids blank rows and disabled group flyouts in DMs.
+  component ContactActionSubmenu: Menu {
+    id: actionMenu
+    required property bool copyAction
+    title: copyAction ? "Copy vCard" : "Edit contact"
+    width: root.space(360)
+    Instantiator {
+      model: root.contextPeople
+      delegate: MenuItem {
+        required property var modelData
+        text: root.personMenuLabel(modelData)
+        onTriggered: {
+          if (actionMenu.copyAction) root.copyContactVCard(modelData)
+          else root.editContact(modelData)
+        }
+      }
+      onObjectAdded: function(index, object) { actionMenu.insertItem(index, object) }
+      onObjectRemoved: function(index, object) { actionMenu.removeItem(object) }
+    }
+  }
+
+  Menu {
+    id: messageOnlyMenu
+    width: root.space(300)
+    MenuItem {
+      text: "Copy message"
+      onTriggered: root.copyText(root.contextMessageText)
+    }
+  }
+
+  Menu {
+    id: directContactMenu
+    width: root.space(340)
+    MenuItem {
+      text: "Copy vCard — " + String(root.contextPeople[0] && root.contextPeople[0].name || "contact")
+      onTriggered: root.copyContactVCard(root.contextPeople[0])
+    }
+    MenuItem {
+      text: "Edit contact — " + String(root.contextPeople[0] && root.contextPeople[0].name || "contact")
+      onTriggered: root.editContact(root.contextPeople[0])
+    }
+  }
+
+  Menu {
+    id: directMessageMenu
+    width: root.space(340)
+    MenuItem {
+      text: "Copy message"
+      onTriggered: root.copyText(root.contextMessageText)
+    }
+    MenuSeparator { }
+    MenuItem {
+      text: "Copy vCard — " + String(root.contextPeople[0] && root.contextPeople[0].name || "contact")
+      onTriggered: root.copyContactVCard(root.contextPeople[0])
+    }
+    MenuItem {
+      text: "Edit contact — " + String(root.contextPeople[0] && root.contextPeople[0].name || "contact")
+      onTriggered: root.editContact(root.contextPeople[0])
+    }
+  }
+
+  Menu {
+    id: groupContactMenu
+    width: root.space(300)
+    ContactActionSubmenu { copyAction: true }
+    ContactActionSubmenu { copyAction: false }
+  }
+
+  Menu {
+    id: groupMessageMenu
+    width: root.space(300)
+    MenuItem {
+      text: "Copy message"
+      onTriggered: root.copyText(root.contextMessageText)
+    }
+    MenuSeparator { }
+    ContactActionSubmenu { copyAction: true }
+    ContactActionSubmenu { copyAction: false }
+  }
+
+  Timer {
+    id: contactToastTimer
+    interval: 3000
+    onTriggered: root.contactToast = ""
+  }
+
+  Rectangle {
+    z: 1000
+    visible: root.contactToast !== "" && !root.settingsMode
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    anchors.margins: root.space(14)
+    implicitWidth: Math.min(root.space(480), contactToastText.implicitWidth + root.space(24))
+    implicitHeight: contactToastText.implicitHeight + root.space(16)
+    radius: root.corner(root.space(9))
+    color: root.contactToastError
+      ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.22)
+      : Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.22)
+    border.width: 1
+    border.color: root.contactToastError ? root.urgent : root.accent
+    Text {
+      id: contactToastText
+      anchors.fill: parent
+      anchors.margins: root.space(8)
+      text: root.contactToast
+      textFormat: Text.PlainText
+      wrapMode: Text.WordWrap
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+    }
+  }
+
+  BlipSettings {
+    id: settingsView
+    anchors.fill: parent
+    visible: root.settingsMode
+    preferences: root.preferences
+    hostWidget: root.hostWidget
+    threads: root.threads
+    foreground: root.foreground
+    urgent: root.urgent
+    accent: root.accent
+    outgoingFill: root.mineFill
+    outgoingText: root.mineText
+    incomingFill: root.theirsFill
+    incomingText: root.theirsText
+    fontFamily: root.fontFamily
+    fontScale: root.fontScale
+    density: root.density
+    cornerScale: root.cornerScale
+    onVcardFinished: function(message, success) {
+      root.showContactToast(message, !success)
+    }
+    onCloseRequested: root.closeSettings()
+  }
+
     // drag a file from a file manager onto the open conversation → draft chip
     DropArea {
       anchors.fill: parent
-      enabled: root.inThread
+      enabled: root.inThread && !root.settingsMode
       keys: ["text/uri-list"]
       onDropped: (drop) => {
         if (!drop.hasUrls || drop.urls.length === 0) return

--- a/BlipWindow.qml
+++ b/BlipWindow.qml
@@ -19,11 +19,13 @@ import qs.Commons
 FloatingWindow {
   id: win
   property var hostWidget: null
+  property var preferences: null
   // "Blip (3)" while unread exists — selectors match the "Blip" PREFIX.
   title: "Blip" + (hostWidget && hostWidget.unread > 0 ? " (" + hostWidget.unread + ")" : "")
-  // Same fill as Omarchy's other FloatingWindow (dev gallery). A 0.70
-  // alpha assumed Hyprland blur, which Omarchy 4.x ships off.
-  color: Color.background
+  // Opaque unless the user deliberately lowers the portable appearance
+  // preference. Omarchy 4.x does not guarantee window blur.
+  readonly property real backdropAlpha: preferences ? preferences.backgroundOpacity : 0.70
+  color: Qt.rgba(Color.background.r, Color.background.g, Color.background.b, backdropAlpha)
   implicitWidth: 1040
   implicitHeight: 720
   minimumSize: Qt.size(720, 480)
@@ -40,6 +42,7 @@ FloatingWindow {
   readonly property string activeLastTs: view.activeLastTs
   function openThread(t) { view.openThread(t) }
   function shareLink(url) { return view.shareLink(url) }
+  function openSettings(page) { view.openSettings(page) }
   function pushReload() { view.pushReload() }
   function navText(event) {
     if (event.key === Qt.Key_Slash) return "/"
@@ -117,8 +120,10 @@ FloatingWindow {
         anchors.fill: parent
         // Inset from the window edge: Hyprland rounds the corners, and text
         // flush to the border got clipped by the radius (Fred).
-        anchors.margins: Style.space(12)
+        anchors.margins: Math.max(1, Math.round(Style.spaceReal(12)
+          * (win.preferences ? win.preferences.density : 1.0)))
         hostWidget: win.hostWidget
+        preferences: win.preferences
         splitView: true
         surfaceOpen: win.visible
         readActive: win.focused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog
 
+## Unreleased
+
+- Keep the Wayland clipboard owner alive after exporting a contact, so Copy
+  vCard reliably pastes a real `.vcf` file instead of leaving an empty clipboard.
+- Add conversation/message context menus for contact work. Direct chats offer
+  Copy vCard and Edit contact; groups expand those actions into named
+  participant submenus. vCards are exported by macOS Contacts as real `.vcf`
+  clipboard files, while editing jumps into the exact Blip contact workspace.
+- Add subtle post-avatar separators between chronological sidebar discussions,
+  matching the visual grouping used by Messages on macOS.
+- Balance the vertical space above and below sidebar search before the pinned
+  grid, and carry Mac-resolved participant names into group contact menus.
+- Enlarge tapback reactions, add Messages-like background padding and two-dot
+  tails, raise them away from message text, and render their fill fully opaque
+  without the badge-style outline.
+- Tailor contact context menus to direct chats, groups, and message-only rows,
+  eliminating hidden blank entries and irrelevant disabled flyouts.
+- Fix Mac contact edits that failed with “Message not understood”: unchanged
+  phone/email/address collections now retain their source fields, while an
+  actual replacement removes the concrete Contacts field specifiers.
+- Offer an explicit two-step recovery when Contacts is holding an unsaved edit
+  left by a failed automation attempt; it closes Contacts without saving only
+  after the user confirms that any pending Mac-side edit may be discarded.
+- Make cross-account consolidation commit and verify the chosen surviving
+  card before any source deletion. Source cards are then deleted independently,
+  so a rejected iCloud update can never remove the corresponding Gmail card.
+- Match the Appearance preview bubbles to the live sender-corner treatment,
+  and add a portable 12/24-hour conversation-list time preference (AM/PM by
+  default).
+- Coalesce migrated named group-chat records when their title and exact
+  participant set agree. Pin state follows the one logical conversation, the
+  newest source remains the send target, and history/unread state spans every
+  retained source identifier.
+
+- Remove the sidebar's duplicate left inset in the app window so search,
+  pinned conversations, and the message list sit closer to the window edge
+  while retaining breathing room beside the conversation divider.
+- Match Messages' compact sidebar hierarchy by moving Settings into the Blip
+  header and removing redundant Messages/Pinned labels. Pinned direct and
+  group conversations now use short names from Contacts' unified-card view.
+- Replace Messages' raw attachment placeholder glyph in conversation previews
+  with Photo, Video, Audio message, Contact card, or Attachment.
+- Suppress a message body when it contains only the URL already represented by
+  an unfurled link card, including when its preview metadata canonicalizes away
+  tracking parameters. Captions and other accompanying text remain visible.
+- Fix contact deletion and consolidation on macOS. Contacts.app does not expose
+  a scriptable delete command; Blip now applies the already previewed, exact-card
+  deletion through Apple's current Contacts framework and verifies every removal
+  before reporting success. Cross-account merges save the complete surviving card
+  first, then delete source cards in account-scoped requests because Contacts can
+  reject one save request spanning iCloud and Google backing stores.
+- Replace the disabled edit form shown after contact-change preparation with a
+  focused read-only review. Consolidation now names the card that will remain,
+  the source cards that will be removed, the complete merged contact, and a
+  visually separate final destructive confirmation before anything is saved.
+- Add a read-only cleanup scan for conversations still shown as phone numbers
+  or email addresses. It separates unmatched handles, ordinary one-card
+  matches, same-name duplicate-card candidates, and naming conflicts; exposes
+  source-account patterns; and can focus the review queue on Contacts matches.
+  Duplicate/conflict reviews remain per-person, previewed, and confirmed—there
+  is no destructive bulk merge based only on account membership.
+- Clarify why unresolved conversations appear in Contacts settings, distinguish
+  likely service short codes from people, and hide those short-code rows by
+  default behind a portable preference toggle. The review queue now reports
+  its full count and scrolls through every matching conversation instead of
+  silently stopping after twelve.
+- Place repeatable contact-field add actions beneath their current values and
+  show Apple’s standard phone labels as Mobile, Home, and Work while preserving
+  their original localized tokens when a contact draft is saved.
+- Split contact management from optional Blip display-name preferences. Users
+  can now compare, edit, delete, consolidate, link, and repair Mac Contacts
+  cards without first writing an `identities.json` name rule. Single matches
+  are selected for the current session; ambiguous matches require an explicit
+  session-only person selection. The UI directs deduplication straight to the
+  contact workspace and explains exactly when a portable display rule is useful.
+- Show each source card’s macOS Contacts account name (such as iCloud,
+  Google, or On My Mac) throughout review, comparison, editing, and destructive
+  confirmations. Name-resolution copy now distinguishes a remembered Contacts
+  match from a genuinely custom Blip-only display name.
+- Add a full in-Blip contact workspace: revision-pinned editing for names,
+  work fields, birthday, notes, phones, email addresses, websites, and postal
+  addresses; confirmed whole-card deletion; and editable multi-card
+  consolidation into a chosen source account. Every apply revalidates its
+  preview and saves a private bounded undo receipt first.
+
 ## 2.3.0 — 2026-09-03 — the contributors' release
 
 - **Photos in a message stopped arriving once they were full-size.** Someone
@@ -305,6 +390,38 @@ findings, the clear ones fixed here, the rest on the roadmap.
 **Repo**
 - CI on every push and PR (bun test, Mac tools byte-compile, shellcheck),
   CONTRIBUTING, issue/PR templates, security policy, GitHub Releases.
+- Add explicitly gated Mac Contacts repair from Blip: exact-card preview,
+  second confirmation, supported Contacts.app removal, Mac-local undo receipt,
+  and post-change revalidation. The restricted SSH key remains unable to turn
+  contact writes on by itself.
+- Add an in-Blip active-card comparison with bounded contact details, a
+  de-duplicated combined view, missing-detail hints, exact-card editing handoff,
+  and guarded invocation of Contacts' native link/merge action. Preview and
+  execution are separate, the confirmed action is pinned end-to-end, and Blip
+  never links during discovery or testing.
+- Keep the Settings UI visually stable during five-second configuration checks: silent identity reads no longer toggle visible loading state, and unchanged identity/preference results no longer rebuild QML models or controls.
+
+**Added**
+- File-backed appearance preferences with an in-app QML editor: bubble colors,
+  app-window opacity, font scale, density, sidebar width, avatar size, and
+  corner roundness. `~/.config/blip/preferences.json` is portable, atomically
+  written, owner-only, bounded, and reloaded live after an external restore.
+- Messages.app pinned conversations, sourced read-only from the Mac's pinning
+  plist and rendered in its ordered circular-avatar grid above the regular
+  chronological list.
+- Explicit contact-name resolution for ambiguous phone/email handles. The QML
+  chooser writes a bounded, atomic `~/.config/blip/identities.json` override;
+  a source-fix action opens the validated persistent card in Contacts.app on
+  the Mac without writing Apple’s private AddressBook database.
+
+**Changed**
+- Contact-name repair is now a guided two-stage flow: selecting a candidate is
+  harmless, remembering the Contacts match is explicit, and optional Mac repair lists and
+  opens every exact source card separately. Generic one-click **Use** and
+  **Fix on Mac** controls were removed.
+- Settings now separates Contacts from Appearance with tabs. Contact repair is
+  a list-to-detail flow with Back/Escape navigation, bounded content width, and
+  collapsed Mac/source-card details instead of one enormous settings scroll.
 
 ## 2.0.0 — 2026-08-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ treating a Mac as the gateway. Read this before touching anything.
 ## Shape
 
 ```
-(Mac side)    bridge/mac/           VENDORED from claude-on-mac (pin in bridge/BRIDGE-VERSION; refresh with
+(Mac side)    bridge/mac/           VENDORED from claude-on-mac with documented Blip extensions (pin in bridge/BRIDGE-VERSION; refresh with
               imsg imsg-send        scripts/sync-bridge.sh <rev>). Installed to ~/.blip/bin on the Mac by
               contacts tcc-check    bridge/mac/install.sh. Blip is ONE source for release (Fred's rule).
               blip-dispatch         forced-command gate for ~/.ssh/blip_ed25519: only the five tools run.
@@ -17,6 +17,11 @@ treating a Mac as the gateway. Read this before touching anything.
                                     — single-quoted, expands on the MAC). `ssh -n` preflight; exit 69 offline.
                                     Blip only ever calls ~/bin/imsg*. No hostnames in code, ever.
 collector.ts                        poll → {threads, unread, toast}. Pure functions + one spawn.
+preferences.ts                      bounded schema + atomic ~/.config/blip/preferences.json I/O.
+BlipPreferences.qml                 one shared live preference source; QML never parses the writable file.
+identities.ts                       bounded ~/.config/blip/identities.json choices + Mac candidate broker.
+BlipIdentities.qml                  QML helper client; handles travel to the bridge over stdin, never argv.
+BlipSettings.qml                    in-app editor for appearance and ambiguous contact names.
 thread.ts                           one conversation → decorated bubbles. Pure + one spawn.
 fetch.ts                            attachment id → ~/.cache/blip/att (0700/0600, 500MB LRU).
 send-file.ts                        local file + caption → imsg-send --file-stdin --text-stdin-bytes N
@@ -89,7 +94,69 @@ what it is handed. Keep it that way.
 - **The Linux shims' ssh preflight must use `ssh -n`.** A bare
   `ssh <mac> true` connectivity probe EATS STDIN, which silently empties
   `imsg-send --file-stdin` payloads. Fixed 2026-08-31.
-- **`bridge.conf` is data, never `source`d.** The shim parses four keys and
+- **Pins belong to Messages.app.** The ordered pin list lives in
+  `com.apple.messages.pinning.plist`, not `chat.db`. `imsg chats` resolves its
+  bounded pD/pP tokens to canonical chat identifiers and emits pin state and
+  order; Blip must not create a divergent Linux-only favorites list.
+- **Preferences cross a bounded helper.** QML never feeds
+  `~/.config/blip/preferences.json` into `FileView`. `preferences.ts` rejects
+  symlinks/FIFOs/wrong owners/oversized or invalid JSON and writes 0600 via a
+  pinned directory fd + atomic rename. Keep the schema portable and versioned.
+- **Ambiguous contact names are explicit choices, never guesses.**
+  `~/.config/blip/identities.json` is a portable, versioned, owner-only map
+  validated and written by `identities.ts`. Candidate lookups are bounded on
+  both sides of ssh and carry the handle via stdin. A display-name preference
+  is optional and separate from contact management. Session-only candidate
+  selection must be enough to compare, edit, delete, consolidate, link, or
+  repair cards; those operations must never require or create an
+  `identities.json` entry. Saving a display preference remains an explicit,
+  separately labeled action. Mac review uses
+  opaque per-card tokens to open an exact validated `addressbook://` record in
+  Contacts.app. Card comparison returns bounded selected-card fields and opaque
+  content revisions with raw ids retained on the Mac. Full-card edits,
+  deletions, and consolidations require a hashed preview, revalidate every
+  exact revision at apply time, and write a private bounded undo receipt before
+  Contacts.app saves. Edits preserve the target photo; deletion and
+  consolidation receipts cannot guarantee restored account placement, links,
+  or photos, so the destructive confirmation must keep saying so. Gated narrow
+  repair can remove an exact revalidated
+  phone/email with confirmation and an undo receipt. Cross-NAME
+  consolidation exists but only with BOTH owner tokens presented explicitly
+  (the user declared the two names the same person); it is merge-only —
+  per-card edit/delete/link keep single-person authority — and the union
+  renumbers account numbers so they stay unique. Gated linking uses only
+  Contacts' allowlisted enabled menu action, pins the previewed action through
+  execution, and requires another confirmation. Blip never edits the private
+  AddressBook SQLite database.
+- **Contacts saves are async to every read path.** A CNContactStore commit is
+  not instantly visible to Contacts.app's JXA view (`describe`) or the
+  abcddb, so read-your-write verification must settle-poll
+  (`settled_card_detail`); comparing a fresh save against an immediate
+  read-back falsely reports "Contacts changed the card". Saves can also throw
+  transient Cocoa 134092 while contactsd rebuilds its graph or refreshes
+  CardDAV accounts — and Blip's own consolidation preflight launches
+  Contacts.app, which triggers those refreshes — so every mutating stage in
+  contact-delete.swift retries on a fresh store session. Google CardDAV also
+  REWRITES person UIDs shortly after a card is created or synced; never cache
+  a Gmail-container uid across user think-time without revalidating.
+- **Never rebuild a card's labeled-value collections wholesale.** Replacing a
+  value Contacts already has forces contactsd to fault the old row out, and
+  ONE damaged stored row then fails the whole save with Cocoa 134092 —
+  persistently ("Unhandled error occurred during faulting"). apply() reuses
+  the contact's own CNLabeledValue objects for unchanged label+value pairs
+  and leaves an equal birthday untouched (synced birthdays carry
+  calendar/timezone the drafts' bare components lack). Beware the label
+  round-trip: Contacts.app's scripting layer reports UNLABELED values under
+  default kind names ("Email", "Phone"), which must normalize back to nil —
+  matching on the literal name both misses the source row and mints a custom
+  label. When the native path faults anyway, Contacts.app's own write path
+  still works — the pipeline recovers the reviewed plan through setCard and a
+  guarded delete-fallback (native stays primary). Two scripting regressions
+  on macOS 15.5: the add-to-person Apple event fails with "No error. (0)" —
+  push onto the person's collection specifiers instead — and removals can
+  fail with "Message not understood", so add-only edits must never take the
+  remove-all path.
+- **`bridge.conf` is data, never `source`d.** The shim parses an allowlisted schema and
   validates them; keep it that way (audit #7). `automation=on` is what lets
   `qs ipc … goto/compose/bubbles` work — off, they return a refusal string.
 - **Opening a link = `xdg-open` THEN focus the browser window.** Omarchy runs

--- a/ContactCardCompare.qml
+++ b/ContactCardCompare.qml
@@ -1,0 +1,799 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+
+// Local comparison and revision-pinned management of the exact active
+// Contacts cards selected by the bridge. Apple's link action remains separate.
+ColumnLayout {
+  id: root
+
+  property var resolver: null
+  property var comparison: null
+  // Cross-name merge: the user explicitly combined two named candidates.
+  // The scope is merge-only — per-card edit/delete and linking keep
+  // single-person authority.
+  readonly property bool crossMerge: comparison !== null
+    && String(comparison.otherOwnerToken || "") !== ""
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  property bool combinedExpanded: false
+  property bool showSharedFields: false
+  property var editorCard: null
+  property var editorInitialCard: null
+  property string editorMode: "edit"
+  readonly property int sharedCount: sharedRowCount(comparison)
+
+  onComparisonChanged: {
+    showSharedFields = false
+    combinedExpanded = false
+    editorCard = null
+    editorInitialCard = null
+  }
+
+  spacing: space(20)
+
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function cleanLabel(value) {
+    var label = String(value || "").trim()
+    var apple = /^_\$!<(.+)>!\$_$/.exec(label)
+    return apple ? apple[1] : label
+  }
+  function displayFieldLabel(fieldType, value) {
+    var detail = cleanLabel(value)
+    return detail === "" || detail.toLowerCase() === fieldType.toLowerCase()
+      ? fieldType
+      : fieldType + " · " + detail
+  }
+  function appendRow(rows, label, value) {
+    var text = String(value || "").trim()
+    if (text !== "") rows.push({ label: label, value: text })
+  }
+  function addressText(address) {
+    var parts = []
+    var street = String(address && address.street || "").trim()
+    var city = String(address && address.city || "").trim()
+    var state = String(address && address.state || "").trim()
+    var postal = String(address && address.postalCode || "").trim()
+    var country = String(address && address.country || "").trim()
+    if (street !== "") parts.push(street)
+    var locality = [city, state, postal].filter(function(value) { return value !== "" }).join(" ")
+    if (locality !== "") parts.push(locality)
+    if (country !== "") parts.push(country)
+    return parts.join(", ")
+  }
+  function cardRows(card) {
+    if (!card) return []
+    var rows = []
+    appendRow(rows, "Display name", card.displayName)
+    appendRow(rows, "First name", card.firstName)
+    appendRow(rows, "Middle name", card.middleName)
+    appendRow(rows, "Last name", card.lastName)
+    appendRow(rows, "Nickname", card.nickname)
+    appendRow(rows, "Organization", card.organization)
+    appendRow(rows, "Department", card.department)
+    appendRow(rows, "Job title", card.jobTitle)
+    appendRow(rows, "Birthday", card.birthday)
+    var groups = [
+      { name: "Phone", values: card.phones || [] },
+      { name: "Email", values: card.emails || [] },
+      { name: "Website", values: card.urls || [] }
+    ]
+    for (var groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      var group = groups[groupIndex]
+      for (var valueIndex = 0; valueIndex < group.values.length; valueIndex++) {
+        var item = group.values[valueIndex]
+        appendRow(rows, displayFieldLabel(group.name, item.label), item.value)
+      }
+    }
+    var addresses = card.addresses || []
+    for (var addressIndex = 0; addressIndex < addresses.length; addressIndex++) {
+      var address = addresses[addressIndex]
+      appendRow(rows, displayFieldLabel("Address", address.label), addressText(address))
+    }
+    appendRow(rows, "Notes", card.note)
+    return rows
+  }
+  function rowKey(row) {
+    return String(row && row.label || "").toLowerCase() + "\u0000"
+      + String(row && row.value || "").toLowerCase()
+  }
+  function sharedRowMap(value) {
+    var result = ({})
+    if (!value || !Array.isArray(value.cards) || value.cards.length < 2) return result
+    var counts = ({})
+    for (var cardIndex = 0; cardIndex < value.cards.length; cardIndex++) {
+      var perCard = ({})
+      var rows = cardRows(value.cards[cardIndex])
+      for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) perCard[rowKey(rows[rowIndex])] = true
+      var keys = Object.keys(perCard)
+      for (var keyIndex = 0; keyIndex < keys.length; keyIndex++)
+        counts[keys[keyIndex]] = Number(counts[keys[keyIndex]] || 0) + 1
+    }
+    var allKeys = Object.keys(counts)
+    for (var index = 0; index < allKeys.length; index++) {
+      var key = allKeys[index]
+      if (counts[key] === value.cards.length) result[key] = true
+    }
+    return result
+  }
+  function sharedRowCount(value) { return Object.keys(sharedRowMap(value)).length }
+  function visibleRows(card) {
+    var rows = cardRows(card)
+    if (showSharedFields) return rows
+    var shared = sharedRowMap(comparison)
+    return rows.filter(function(row) { return !shared[rowKey(row)] })
+  }
+  function unionRows(value) {
+    if (!value || !Array.isArray(value.cards)) return []
+    var result = []
+    var seen = ({})
+    for (var cardIndex = 0; cardIndex < value.cards.length; cardIndex++) {
+      var rows = cardRows(value.cards[cardIndex])
+      for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+        var row = rows[rowIndex]
+        var key = rowKey(row)
+        if (seen[key]) continue
+        seen[key] = true
+        result.push(row)
+      }
+    }
+    return result
+  }
+  function missingFields(card) {
+    if (!card) return []
+    var missing = []
+    if (String(card.firstName || "") === "" && String(card.lastName || "") === "") missing.push("name")
+    if (!card.phones || card.phones.length === 0) missing.push("phone")
+    if (!card.emails || card.emails.length === 0) missing.push("email")
+    if (!card.addresses || card.addresses.length === 0) missing.push("address")
+    if (String(card.birthday || "") === "") missing.push("birthday")
+    return missing
+  }
+  function missingDetails(card) {
+    var missing = missingFields(card)
+    return missing.length === 0 ? "Core details present" : "Missing: " + missing.join(", ")
+  }
+  function incompleteCardCount(value) {
+    if (!value || !Array.isArray(value.cards)) return 0
+    var count = 0
+    for (var i = 0; i < value.cards.length; i++) if (missingFields(value.cards[i]).length > 0) count++
+    return count
+  }
+  function cloneList(value) {
+    return JSON.parse(JSON.stringify(Array.isArray(value) ? value : []))
+  }
+  function uniqueList(cards, property, address) {
+    var result = []
+    var seen = ({})
+    for (var i = 0; i < cards.length; i++) {
+      var values = cards[i] && Array.isArray(cards[i][property]) ? cards[i][property] : []
+      for (var j = 0; j < values.length; j++) {
+        var item = values[j]
+        var key = address
+          ? [item.street, item.city, item.state, item.postalCode, item.country, item.countryCode]
+            .join("\u0000").toLowerCase()
+          : String(item.value || "").toLowerCase()
+        if (key === "" || seen[key]) continue
+        seen[key] = true
+        result.push(JSON.parse(JSON.stringify(item)))
+      }
+    }
+    return result
+  }
+  function mergedDraft(target) {
+    var cards = comparison && Array.isArray(comparison.cards) ? comparison.cards : []
+    var draft = ({})
+    var scalars = ["firstName", "middleName", "lastName", "nickname", "organization",
+      "department", "jobTitle", "birthday", "note"]
+    for (var i = 0; i < scalars.length; i++) {
+      var key = scalars[i]
+      draft[key] = String(target && target[key] || "")
+      if (draft[key] !== "") continue
+      for (var j = 0; j < cards.length; j++) {
+        var candidate = String(cards[j] && cards[j][key] || "")
+        if (candidate !== "") { draft[key] = candidate; break }
+      }
+    }
+    draft.phones = uniqueList(cards, "phones", false)
+    draft.emails = uniqueList(cards, "emails", false)
+    draft.urls = uniqueList(cards, "urls", false)
+    draft.addresses = uniqueList(cards, "addresses", true)
+    return draft
+  }
+  function editCard(card) {
+    if (resolver) resolver.cancelMutation()
+    editorMode = "edit"
+    editorCard = card
+    editorInitialCard = card
+  }
+  function mergeInto(card) {
+    if (resolver) resolver.cancelMutation()
+    editorMode = "consolidate"
+    editorCard = card
+    editorInitialCard = mergedDraft(card)
+  }
+
+  ContactCardEditor {
+    Layout.fillWidth: true
+    visible: root.editorCard !== null
+    resolver: root.resolver
+    card: root.editorCard
+    comparison: root.comparison
+    initialCard: root.editorInitialCard
+    mode: root.editorMode
+    foreground: root.foreground
+    urgent: root.urgent
+    accent: root.accent
+    fontFamily: root.fontFamily
+    fontScale: root.fontScale
+    density: root.density
+    cornerScale: root.cornerScale
+    onCloseRequested: {
+      root.editorCard = null
+      root.editorInitialCard = null
+      root.editorMode = "edit"
+    }
+  }
+
+  RowLayout {
+    visible: root.editorCard === null
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: root.space(2)
+      Text {
+        Layout.fillWidth: true
+        text: root.comparison ? root.comparison.name : "Contact cards"
+        textFormat: Text.PlainText
+        elide: Text.ElideRight
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.body)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.comparison
+          ? root.comparison.cardCount + " source cards · " + root.comparison.sourceCount
+            + (root.comparison.sourceCount === 1 ? " Contacts source" : " Contacts sources")
+          : ""
+        textFormat: Text.PlainText
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+    SmallButton {
+      label: "Reload cards from Mac"
+      enabled: root.resolver && !root.resolver.loading && root.comparison
+      onClicked: root.resolver.compareCards(root.comparison.handle, root.comparison.ownerToken)
+    }
+    SmallButton {
+      label: "Back to contact tasks"
+      enabled: root.resolver && !root.resolver.loading
+      onClicked: root.resolver.cancelComparison()
+    }
+  }
+
+  ActionHeader {
+    visible: root.editorCard === null
+    Layout.topMargin: root.space(4)
+    title: "Compare source cards"
+    detail: root.showSharedFields || root.sharedCount === 0
+      ? "Showing every discovered value."
+      : root.sharedCount + (root.sharedCount === 1 ? " shared value is" : " shared values are")
+        + " tucked away so differences stand out."
+  }
+
+  RowLayout {
+    visible: root.editorCard === null
+    Layout.fillWidth: true
+    spacing: root.space(8)
+    Text {
+      Layout.fillWidth: true
+      text: root.showSharedFields ? "ALL FIELDS" : "DIFFERENCES ONLY"
+      textFormat: Text.PlainText
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: true
+    }
+    SmallButton {
+      visible: root.sharedCount > 0
+      label: root.showSharedFields ? "Show differences only" : "Show all fields"
+      onClicked: root.showSharedFields = !root.showSharedFields
+    }
+  }
+
+  GridLayout {
+    visible: root.editorCard === null
+    Layout.fillWidth: true
+    columns: root.width >= root.space(820) && root.comparison && root.comparison.cardCount === 2 ? 2 : 1
+    columnSpacing: root.space(12)
+    rowSpacing: root.space(12)
+
+    Repeater {
+      model: root.comparison ? root.comparison.cards : []
+      delegate: Rectangle {
+        id: cardBox
+        required property var modelData
+        readonly property var displayedRows: root.visibleRows(modelData)
+        Layout.fillWidth: true
+        Layout.preferredWidth: root.space(390)
+        Layout.alignment: Qt.AlignTop
+        implicitHeight: cardContents.implicitHeight + root.space(28)
+        radius: root.corner(root.space(12))
+        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.045)
+        border.width: 1
+        border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+
+        ColumnLayout {
+          id: cardContents
+          anchors.fill: parent
+          anchors.margins: root.space(14)
+          spacing: root.space(10)
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Text {
+              Layout.fillWidth: true
+              text: "SOURCE CARD " + cardBox.modelData.cardNumber
+              textFormat: Text.PlainText
+              elide: Text.ElideRight
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+            }
+            InfoPill { label: cardBox.modelData.sourceName }
+          }
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Text {
+              Layout.fillWidth: true
+              text: root.missingDetails(cardBox.modelData)
+              textFormat: Text.PlainText
+              elide: Text.ElideRight
+              color: root.missingFields(cardBox.modelData).length > 0 ? root.urgent : root.accent
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+            }
+            SmallButton {
+              visible: !root.crossMerge
+              label: "Edit in Blip…"
+              primary: true
+              enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+              onClicked: root.editCard(cardBox.modelData)
+            }
+            SmallButton {
+              label: "Open on Mac…"
+              enabled: root.resolver && !root.resolver.loading
+              onClicked: root.resolver.openOnMac(root.comparison.handle, cardBox.modelData.token)
+            }
+          }
+
+          Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: 1
+            color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.13)
+          }
+
+          Text {
+            Layout.fillWidth: true
+            visible: cardBox.displayedRows.length === 0
+            text: "No card-specific values."
+            textFormat: Text.PlainText
+            color: Qt.darker(root.foreground, 1.4)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+
+          Repeater {
+            model: cardBox.displayedRows
+            delegate: RowLayout {
+              required property var modelData
+              Layout.fillWidth: true
+              spacing: root.space(10)
+              Text {
+                Layout.preferredWidth: root.space(106)
+                Layout.alignment: Qt.AlignTop
+                text: String(modelData.label || "")
+                textFormat: Text.PlainText
+                wrapMode: Text.WordWrap
+                color: Qt.darker(root.foreground, 1.45)
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+              }
+              Text {
+                Layout.fillWidth: true
+                text: String(modelData.value || "")
+                textFormat: Text.PlainText
+                wrapMode: Text.WrapAnywhere
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ActionHeader {
+    // With a single card there is nothing to consolidate â hide the section
+    // instead of presenting a preview with no action.
+    visible: root.editorCard === null && root.comparison !== null
+      && root.comparison.cardCount > 1
+    Layout.topMargin: root.space(20)
+    title: "Consolidate into one card"
+    detail: root.crossMerge
+      ? "You marked these differently-named cards as the same person. Pick the card that should survive — the name (and every other field) can be adjusted in the review before anything is saved."
+      : root.incompleteCardCount(root.comparison) === 0
+        ? "Choose this option to build one editable card and delete the other source cards after confirmation."
+        : "Choose this option to fill blanks, combine unique values, and delete the other source cards after review."
+  }
+
+  Rectangle {
+    // Single card, but another NAME uses this handle: point at the one real
+    // path to a merge (make the names match) instead of a dead end.
+    visible: root.editorCard === null && root.comparison !== null
+      && root.comparison.cardCount === 1
+      && root.resolver && root.resolver.candidates.length > 1
+    Layout.topMargin: root.space(20)
+    Layout.fillWidth: true
+    implicitHeight: samePersonHint.implicitHeight + root.space(24)
+    radius: root.corner(root.space(10))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+    border.width: 1
+    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
+
+    ColumnLayout {
+      id: samePersonHint
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(6)
+      Text {
+        Layout.fillWidth: true
+        text: "SAME PERSON UNDER ANOTHER NAME?"
+        textFormat: Text.PlainText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: {
+          var others = []
+          var cands = root.resolver ? root.resolver.candidates : []
+          for (var i = 0; i < cands.length; i++) {
+            if (!root.comparison || cands[i].token !== root.comparison.ownerToken)
+              others.push("“" + String(cands[i].name || "") + "”")
+          }
+          return "This person has only one card, so there is nothing to consolidate. If "
+            + (others.length > 0 ? others.join(" or ") : "the other name")
+            + " is really the same person — a married-name change, say — go back and use "
+            + "Merge with… on that person’s row. You can adjust the surviving name "
+            + "during the merge review."
+        }
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.3)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+  }
+
+  Rectangle {
+    visible: root.editorCard === null && root.comparison !== null
+      && root.comparison.cardCount > 1
+    Layout.fillWidth: true
+    implicitHeight: combinedContents.implicitHeight + root.space(24)
+    radius: root.corner(root.space(10))
+    color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.065)
+    border.width: 1
+    border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.28)
+
+    ColumnLayout {
+      id: combinedContents
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(8)
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.space(8)
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: root.space(2)
+          Text {
+            Layout.fillWidth: true
+            text: "MERGED PREVIEW"
+            textFormat: Text.PlainText
+            color: root.accent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: "Unique values Blip discovered across every active source card."
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.35)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+        SmallButton {
+          label: root.combinedExpanded ? "Hide preview" : "Show merged values"
+          onClicked: root.combinedExpanded = !root.combinedExpanded
+        }
+      }
+      Repeater {
+        model: root.combinedExpanded ? root.unionRows(root.comparison) : []
+        delegate: RowLayout {
+          required property var modelData
+          Layout.fillWidth: true
+          spacing: root.space(10)
+          Text {
+            Layout.preferredWidth: root.space(112)
+            Layout.alignment: Qt.AlignTop
+            text: String(modelData.label || "")
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.45)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          Text {
+            Layout.fillWidth: true
+            text: String(modelData.value || "")
+            textFormat: Text.PlainText
+            wrapMode: Text.WrapAnywhere
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        visible: root.comparison && root.comparison.cardCount > 1
+        spacing: root.space(8)
+        Text {
+          Layout.fillWidth: true
+          text: "Choose the source card—and therefore the named Contacts source—that should remain."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+        Repeater {
+          model: root.comparison ? root.comparison.cards : []
+          delegate: SmallButton {
+            required property var modelData
+            label: "Merge into " + modelData.sourceName + " · card " + modelData.cardNumber + "…"
+            enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+            onClicked: root.mergeInto(modelData)
+          }
+        }
+      }
+    }
+  }
+
+  ActionHeader {
+    visible: root.editorCard === null && root.comparison && root.comparison.cardCount > 1
+      && !root.crossMerge
+    Layout.topMargin: root.space(20)
+    title: "Or link cards · optional"
+    detail: "An alternative to consolidation: keep both source cards and ask Contacts to present them as one person. Checking makes no changes."
+  }
+
+  Rectangle {
+    visible: root.editorCard === null && root.comparison && root.comparison.cardCount > 1
+      && !root.crossMerge
+    Layout.fillWidth: true
+    implicitHeight: linkContents.implicitHeight + root.space(24)
+    radius: root.corner(root.space(10))
+    color: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+      ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.09)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+    border.width: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready ? 2 : 1
+    border.color: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+      ? root.urgent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+
+    ColumnLayout {
+      id: linkContents
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(9)
+
+      RowLayout {
+        Layout.fillWidth: true
+        visible: !root.resolver || root.resolver.linkPreview === null
+        spacing: root.space(10)
+        Text {
+          Layout.fillWidth: true
+          text: "Contacts keeps the source accounts authoritative. Blip only selects the exact cards and requests Apple’s action."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+        SmallButton {
+          primary: true
+          label: "Prepare link in Contacts…"
+          enabled: root.resolver && !root.resolver.loading && root.comparison
+            && root.resolver.contactWrites && root.comparison.writeEnabled
+          onClicked: root.resolver.prepareLink()
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.linkPreview !== null
+        text: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+          ? "CONFIRM AN UPSTREAM CONTACTS CHANGE"
+          : "CONTACTS DID NOT OFFER THIS ACTION"
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+          ? root.urgent : root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.linkPreview !== null
+        text: root.resolver && root.resolver.linkPreview
+          ? root.resolver.linkPreview.ready
+            ? "Run Contacts’ “" + root.resolver.linkPreview.action + "” on these exact "
+              + root.resolver.linkPreview.cardCount + " cards? This changes Contacts and may sync to their source accounts. Blip cannot provide an automatic unlink receipt."
+            : "Contacts disabled “" + root.resolver.linkPreview.action
+              + "” for this selection. The cards may already be linked or ineligible. Nothing changed."
+          : ""
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.linkPreview !== null
+        spacing: root.space(8)
+        Item { Layout.fillWidth: true }
+        SmallButton {
+          label: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+            ? "Cancel" : "Dismiss"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.resolver.cancelLink()
+        }
+        SmallButton {
+          visible: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+          danger: true
+          primary: true
+          label: root.resolver && root.resolver.linkPreview
+            ? "Run “" + root.resolver.linkPreview.action + "”"
+            : "Run Contacts action"
+          enabled: root.resolver && !root.resolver.loading && root.resolver.linkPreview
+            && root.resolver.linkPreview.ready && root.resolver.linkPreview.writeEnabled
+          onClicked: root.resolver.linkCards()
+        }
+      }
+    }
+  }
+
+  Text {
+    visible: root.editorCard === null && root.resolver && !root.resolver.contactWrites
+    Layout.fillWidth: true
+    text: "Editing, deleting, consolidating, and linking are disabled by the local and Mac write gates. Viewing and opening exact cards remain read-only."
+    textFormat: Text.PlainText
+    wrapMode: Text.WordWrap
+    color: Qt.darker(root.foreground, 1.35)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+
+  component ActionHeader: RowLayout {
+    property string title: ""
+    property string detail: ""
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: root.space(1)
+      Text {
+        Layout.fillWidth: true
+        text: parent.parent.title.toUpperCase()
+        textFormat: Text.PlainText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: parent.parent.detail
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+  }
+
+  component InfoPill: Rectangle {
+    property string label: ""
+    implicitWidth: Math.min(pillText.implicitWidth + root.space(12), root.space(220))
+    implicitHeight: pillText.implicitHeight + root.space(6)
+    radius: height / 2
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.07)
+    border.width: 1
+    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+    Text {
+      id: pillText
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: root.space(6)
+      anchors.rightMargin: root.space(6)
+      text: parent.label
+      textFormat: Text.PlainText
+      elide: Text.ElideRight
+      color: Qt.darker(root.foreground, 1.25)
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+    }
+  }
+
+  component SmallButton: Rectangle {
+    id: button
+    property string label: ""
+    property bool danger: false
+    property bool primary: false
+    signal clicked()
+    implicitWidth: buttonText.implicitWidth + root.space(16)
+    implicitHeight: buttonText.implicitHeight + root.space(10)
+    radius: root.corner(root.space(7))
+    opacity: enabled ? 1.0 : 0.45
+    color: buttonHover.hovered
+      ? Qt.rgba((danger ? root.urgent : root.accent).r,
+                (danger ? root.urgent : root.accent).g,
+                (danger ? root.urgent : root.accent).b, 0.18)
+      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+    border.width: 1
+    border.color: danger ? root.urgent : primary ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
+    Text {
+      id: buttonText
+      anchors.centerIn: parent
+      text: button.label
+      textFormat: Text.PlainText
+      color: button.danger ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: button.primary
+    }
+    HoverHandler { id: buttonHover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
+    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+  }
+}

--- a/ContactCardEditor.qml
+++ b/ContactCardEditor.qml
@@ -1,0 +1,757 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// Full, local editor for the bounded Contacts fields exposed by the bridge.
+// Saving is always a two-step preview/apply operation in BlipIdentities.
+ColumnLayout {
+  id: root
+
+  property var resolver: null
+  property var card: null
+  property var comparison: null
+  property var initialCard: null
+  property string mode: "edit"
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  readonly property bool isMerge: mode === "consolidate"
+  readonly property bool previewOpen: resolver && resolver.mutationPreview !== null
+
+  signal closeRequested()
+
+  spacing: space(14)
+
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function text(value) { return String(value || "") }
+  function cleanLabel(value) {
+    var label = text(value)
+    var apple = /^_\$!<(.+)>!\$_$/.exec(label)
+    return apple ? apple[1] : label
+  }
+  function loadValueModel(model, values) {
+    model.clear()
+    var source = Array.isArray(values) ? values : []
+    for (var i = 0; i < source.length && i < 16; i++) {
+      var item = source[i] || ({})
+      model.append({
+        label: cleanLabel(item.label),
+        originalLabel: text(item.label),
+        value: text(item.value)
+      })
+    }
+  }
+  function loadAddressModel(model, values) {
+    model.clear()
+    var source = Array.isArray(values) ? values : []
+    for (var i = 0; i < source.length && i < 16; i++) {
+      var item = source[i] || ({})
+      model.append({
+        label: cleanLabel(item.label),
+        originalLabel: text(item.label),
+        street: text(item.street),
+        city: text(item.city),
+        state: text(item.state),
+        postalCode: text(item.postalCode),
+        country: text(item.country),
+        countryCode: text(item.countryCode)
+      })
+    }
+  }
+  function reload() {
+    var source = initialCard || card
+    if (!source) return
+    firstName.text = text(source.firstName)
+    middleName.text = text(source.middleName)
+    lastName.text = text(source.lastName)
+    nickname.text = text(source.nickname)
+    organization.text = text(source.organization)
+    department.text = text(source.department)
+    jobTitle.text = text(source.jobTitle)
+    birthday.text = text(source.birthday)
+    notes.text = text(source.note)
+    loadValueModel(phones, source.phones)
+    loadValueModel(emails, source.emails)
+    loadValueModel(urls, source.urls)
+    loadAddressModel(addresses, source.addresses)
+  }
+  function modelValues(model, keys) {
+    var result = []
+    for (var i = 0; i < model.count; i++) {
+      var source = model.get(i)
+      var item = ({})
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j]
+        var value = text(source[key]).trim()
+        if (key === "label") {
+          var original = text(source.originalLabel).trim()
+          item[key] = original !== "" && value === cleanLabel(original) ? original : value
+        } else item[key] = value
+      }
+      var meaningful = false
+      for (var k = 0; k < keys.length; k++) {
+        if (keys[k] !== "label" && item[keys[k]] !== "") meaningful = true
+      }
+      if (meaningful) result.push(item)
+    }
+    return result
+  }
+  function draft() {
+    return {
+      firstName: firstName.text.trim(), middleName: middleName.text.trim(),
+      lastName: lastName.text.trim(), nickname: nickname.text.trim(),
+      organization: organization.text.trim(), department: department.text.trim(),
+      jobTitle: jobTitle.text.trim(), birthday: birthday.text.trim(), note: notes.text.trim(),
+      phones: modelValues(phones, ["label", "value"]),
+      emails: modelValues(emails, ["label", "value"]),
+      urls: modelValues(urls, ["label", "value"]),
+      addresses: modelValues(addresses,
+        ["label", "street", "city", "state", "postalCode", "country", "countryCode"])
+    }
+  }
+  function review() {
+    if (!resolver || !card) return
+    if (isMerge) resolver.prepareConsolidation(card, draft())
+    else resolver.prepareCardEdit(card, draft())
+  }
+  function removedCardsLabel() {
+    if (!resolver || !resolver.mutationPreview) return ""
+    var cards = comparison && Array.isArray(comparison.cards) ? comparison.cards : []
+    var result = []
+    for (var i = 0; i < cards.length; i++) {
+      var candidate = cards[i]
+      if (!candidate || candidate.cardNumber === resolver.mutationPreview.cardNumber) continue
+      result.push(candidate.sourceName + " · card " + candidate.cardNumber)
+    }
+    return result.length > 0 ? result.join("; ")
+      : resolver.mutationPreview.sourceCardCount + " other source card(s)"
+  }
+  function addressSummary(value) {
+    if (!value) return ""
+    var parts = [value.street, value.city, value.state, value.postalCode, value.country]
+    var result = []
+    for (var i = 0; i < parts.length; i++) {
+      var part = text(parts[i]).trim()
+      if (part !== "") result.push(part)
+    }
+    return result.join(", ")
+  }
+  function closeEditor() {
+    if (resolver && resolver.loading) return
+    if (resolver) resolver.cancelMutation()
+    closeRequested()
+  }
+
+  onCardChanged: Qt.callLater(reload)
+  onInitialCardChanged: Qt.callLater(reload)
+  Component.onCompleted: reload()
+
+  ListModel { id: phones }
+  ListModel { id: emails }
+  ListModel { id: urls }
+  ListModel { id: addresses }
+
+  RowLayout {
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: root.space(2)
+      Text {
+        Layout.fillWidth: true
+        text: root.previewOpen
+          ? root.isMerge ? "Review merged contact" : "Review contact changes"
+          : root.isMerge ? "Build one merged contact" : "Edit source card " + (root.card ? root.card.cardNumber : "")
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.body)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.previewOpen
+          ? "Nothing has been written to Mac Contacts yet. Review the result and source-card outcome below."
+          : root.isMerge
+          ? (root.card ? root.card.sourceName : "Contacts source") + " · card "
+            + (root.card ? root.card.cardNumber : "") + " will remain; the other source cards will be deleted after confirmation."
+          : (root.card ? root.card.sourceName : "Contacts source") + " · card "
+            + (root.card ? root.card.cardNumber : "")
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+    ActionButton { label: "Close editor"; enabled: !root.resolver || !root.resolver.loading; onClicked: root.closeEditor() }
+  }
+
+  NoticeBox {
+    visible: !root.previewOpen
+    tone: root.isMerge ? "warning" : "info"
+    message: root.isMerge
+      ? "Review every field below. Blip started with the target card’s choices, filled its blanks, and combined unique phone, email, website, and address values. The target card’s photo is retained; photos on deleted source cards are not copied."
+      : "Changes stay in this form until you click Review changes. Blip then rechecks the exact Mac card and shows a separate confirmation before saving. The existing photo is retained."
+  }
+
+  SectionTitle { visible: !root.previewOpen; label: "NAME & WORK" }
+  GridLayout {
+    visible: !root.previewOpen
+    Layout.fillWidth: true
+    columns: width >= root.space(720) ? 2 : 1
+    columnSpacing: root.space(12)
+    rowSpacing: root.space(9)
+    Field { id: firstName; title: "First name"; maximum: 160 }
+    Field { id: middleName; title: "Middle name"; maximum: 160 }
+    Field { id: lastName; title: "Last name"; maximum: 160 }
+    Field { id: nickname; title: "Nickname"; maximum: 160 }
+    Field { id: organization; title: "Organization" }
+    Field { id: department; title: "Department" }
+    Field { id: jobTitle; title: "Job title" }
+    Field { id: birthday; title: "Birthday"; hint: "YYYY-MM-DD or --MM-DD"; maximum: 10 }
+  }
+
+  ValueList { visible: !root.previewOpen; title: "PHONE NUMBERS"; model: phones; emptyLabel: "Add phone" }
+  ValueList { visible: !root.previewOpen; title: "EMAIL ADDRESSES"; model: emails; emptyLabel: "Add email" }
+  ValueList { visible: !root.previewOpen; title: "WEBSITES"; model: urls; emptyLabel: "Add website" }
+
+  RowLayout {
+    visible: !root.previewOpen
+    Layout.fillWidth: true
+    SectionTitle { Layout.fillWidth: true; label: "POSTAL ADDRESSES" }
+  }
+  Text {
+    Layout.fillWidth: true
+    visible: !root.previewOpen && addresses.count === 0
+    text: "No postal addresses"
+    textFormat: Text.PlainText
+    color: Qt.darker(root.foreground, 1.4)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+  Repeater {
+    model: root.previewOpen ? null : addresses
+    delegate: Rectangle {
+      id: addressRow
+      required property int index
+      required property string label
+      required property string street
+      required property string city
+      required property string state
+      required property string postalCode
+      required property string country
+      required property string countryCode
+      Layout.fillWidth: true
+      implicitHeight: addressFields.implicitHeight + root.space(20)
+      radius: root.corner(root.space(8))
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.035)
+      border.width: 1
+      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.16)
+      ColumnLayout {
+        id: addressFields
+        anchors.fill: parent
+        anchors.margins: root.space(10)
+        spacing: root.space(7)
+        RowLayout {
+          Layout.fillWidth: true
+          Text { Layout.fillWidth: true; text: "ADDRESS " + (addressRow.index + 1); textFormat: Text.PlainText;
+            color: root.foreground; font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption); font.bold: true }
+          ActionButton { danger: true; label: "Remove"; enabled: !root.previewOpen; onClicked: addresses.remove(addressRow.index) }
+        }
+        GridLayout {
+          Layout.fillWidth: true
+          columns: width >= root.space(700) ? 2 : 1
+          columnSpacing: root.space(10); rowSpacing: root.space(7)
+          AddressField { title: "Label"; role: "label"; value: addressRow.label; row: addressRow.index; maximum: 80 }
+          AddressField { title: "Street"; role: "street"; value: addressRow.street; row: addressRow.index; maximum: 320 }
+          AddressField { title: "City"; role: "city"; value: addressRow.city; row: addressRow.index; maximum: 320 }
+          AddressField { title: "State / region"; role: "state"; value: addressRow.state; row: addressRow.index; maximum: 320 }
+          AddressField { title: "Postal code"; role: "postalCode"; value: addressRow.postalCode; row: addressRow.index; maximum: 80 }
+          AddressField { title: "Country"; role: "country"; value: addressRow.country; row: addressRow.index; maximum: 160 }
+          AddressField { title: "Country code"; role: "countryCode"; value: addressRow.countryCode; row: addressRow.index; maximum: 8 }
+        }
+      }
+    }
+  }
+  RowLayout {
+    visible: !root.previewOpen
+    Layout.fillWidth: true
+    Layout.topMargin: root.space(2)
+    Layout.bottomMargin: root.space(4)
+    Item { Layout.fillWidth: true }
+    ActionButton {
+      label: "Add address"
+      enabled: addresses.count < 16 && !root.previewOpen
+      onClicked: addresses.append({ label: "", originalLabel: "", street: "", city: "", state: "",
+        postalCode: "", country: "", countryCode: "" })
+    }
+  }
+
+  SectionTitle { visible: !root.previewOpen; label: "NOTES" }
+  TextField {
+    id: notes
+    Layout.fillWidth: true
+    placeholderText: "Notes"
+    foreground: root.foreground; accent: root.accent
+    font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+    maximumLength: 1000
+    enabled: !root.previewOpen
+    visible: !root.previewOpen
+  }
+
+  MutationReview {
+    Layout.fillWidth: true
+    visible: root.resolver && root.resolver.mutationPreview !== null
+    preview: root.resolver ? root.resolver.mutationPreview : null
+  }
+
+  RowLayout {
+    Layout.fillWidth: true
+    visible: !root.resolver || root.resolver.mutationPreview === null
+    spacing: root.space(8)
+    ActionButton {
+      visible: !root.isMerge
+      danger: true
+      label: "Delete this source card…"
+      enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+      onClicked: root.resolver.prepareCardDelete(root.card)
+    }
+    Item { Layout.fillWidth: true }
+    ActionButton { label: "Discard draft"; onClicked: root.closeEditor() }
+    ActionButton {
+      primary: true
+      label: root.isMerge ? "Review merged contact…" : "Review changes…"
+      enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+      onClicked: root.review()
+    }
+  }
+
+  component SectionTitle: Text {
+    property string label: ""
+    Layout.fillWidth: true
+    text: label
+    textFormat: Text.PlainText
+    color: root.accent
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+    font.bold: true
+  }
+
+  component Field: ColumnLayout {
+    id: fieldBox
+    property alias text: input.text
+    property string title: ""
+    property string hint: ""
+    property int maximum: 320
+    Layout.fillWidth: true
+    spacing: root.space(4)
+    Text { text: parent.title; textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.25);
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+    TextField {
+      id: input
+      Layout.fillWidth: true
+      placeholderText: fieldBox.hint
+      foreground: root.foreground; accent: root.accent
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+      maximumLength: fieldBox.maximum
+      enabled: !root.previewOpen
+    }
+  }
+
+  component ValueList: ColumnLayout {
+    id: valueList
+    property string title: ""
+    property string emptyLabel: "Add value"
+    required property ListModel model
+    Layout.fillWidth: true
+    spacing: root.space(6)
+    SectionTitle { label: valueList.title }
+    Text {
+      Layout.fillWidth: true
+      visible: parent.model.count === 0
+      text: "None"
+      textFormat: Text.PlainText
+      color: Qt.darker(root.foreground, 1.4)
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption)
+    }
+    Repeater {
+      model: parent.model
+      delegate: RowLayout {
+        id: valueRow
+        required property int index
+        required property string label
+        required property string value
+        Layout.fillWidth: true
+        spacing: root.space(7)
+        TextField {
+          Layout.preferredWidth: root.space(150)
+          text: valueRow.label
+          placeholderText: "Label"
+          foreground: root.foreground; accent: root.accent
+          font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+          maximumLength: 80
+          enabled: !root.previewOpen
+          onTextChanged: valueList.model.setProperty(valueRow.index, "label", text)
+        }
+        TextField {
+          Layout.fillWidth: true
+          text: valueRow.value
+          placeholderText: "Value"
+          foreground: root.foreground; accent: root.accent
+          font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+          maximumLength: 320
+          enabled: !root.previewOpen
+          onTextChanged: valueList.model.setProperty(valueRow.index, "value", text)
+        }
+        ActionButton { danger: true; label: "Remove"; enabled: !root.previewOpen; onClicked: valueList.model.remove(valueRow.index) }
+      }
+    }
+    RowLayout {
+      Layout.fillWidth: true
+      Layout.topMargin: root.space(2)
+      Layout.bottomMargin: root.space(4)
+      Item { Layout.fillWidth: true }
+      ActionButton {
+        label: valueList.emptyLabel
+        enabled: valueList.model.count < 16 && !root.previewOpen
+        onClicked: valueList.model.append({ label: "", originalLabel: "", value: "" })
+      }
+    }
+  }
+
+  component AddressField: ColumnLayout {
+    property string title: ""
+    property string role: ""
+    property string value: ""
+    property int row: 0
+    property int maximum: 320
+    Layout.fillWidth: true
+    spacing: root.space(3)
+    Text { text: parent.title; textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.3);
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+    TextField {
+      Layout.fillWidth: true; text: parent.value
+      foreground: root.foreground; accent: root.accent
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+      maximumLength: parent.maximum
+      enabled: !root.previewOpen
+      onTextChanged: addresses.setProperty(parent.row, parent.role, text)
+    }
+  }
+
+  component NoticeBox: Rectangle {
+    property string tone: "info"
+    property string message: ""
+    Layout.fillWidth: true
+    implicitHeight: noticeText.implicitHeight + root.space(20)
+    radius: root.corner(root.space(8))
+    color: tone === "warning" ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.08)
+      : Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.07)
+    border.width: 1
+    border.color: tone === "warning" ? root.urgent : Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.38)
+    Text { id: noticeText; anchors.fill: parent; anchors.margins: root.space(10); text: parent.message;
+      textFormat: Text.PlainText; wrapMode: Text.WordWrap; color: root.foreground;
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+  }
+
+  component MutationReview: Rectangle {
+    id: reviewBox
+    required property var preview
+    Layout.fillWidth: true
+    implicitHeight: reviewContent.implicitHeight + root.space(28)
+    radius: root.corner(root.space(12))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.035)
+    border.width: 1
+    border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.42)
+
+    ColumnLayout {
+      id: reviewContent
+      anchors.fill: parent
+      anchors.margins: root.space(14)
+      spacing: root.space(14)
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        spacing: root.space(4)
+        Text {
+          Layout.fillWidth: true
+          text: reviewBox.preview && reviewBox.preview.action === "consolidate"
+            ? "REVIEW CONSOLIDATION" : reviewBox.preview && reviewBox.preview.action === "delete"
+              ? "REVIEW DELETION" : "REVIEW CONTACT CHANGES"
+          textFormat: Text.PlainText
+          color: root.accent
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+          font.bold: true
+        }
+        Text {
+          Layout.fillWidth: true
+          text: "This is a read-only preview. Nothing below has been saved to Contacts."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.bodySmall)
+          font.bold: true
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        implicitHeight: sourceOutcome.implicitHeight + root.space(20)
+        radius: root.corner(root.space(8))
+        color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.07)
+        border.width: 1
+        border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.3)
+        ColumnLayout {
+          id: sourceOutcome
+          anchors.fill: parent
+          anchors.margins: root.space(10)
+          spacing: root.space(6)
+          ReviewOutcomeRow {
+            label: reviewBox.preview && reviewBox.preview.action === "delete" ? "DELETE" : "KEEP AND UPDATE"
+            value: reviewBox.preview
+              ? reviewBox.preview.sourceName + " · card " + reviewBox.preview.cardNumber : ""
+            danger: reviewBox.preview && reviewBox.preview.action === "delete"
+          }
+          ReviewOutcomeRow {
+            visible: reviewBox.preview && reviewBox.preview.action === "consolidate"
+            label: "DELETE AFTER MERGE"
+            value: root.removedCardsLabel()
+            danger: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: reviewBox.preview
+              ? "Different from the surviving card: " + reviewBox.preview.changedFields.join(", ") + "."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.3)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+      }
+
+      SectionTitle {
+        label: reviewBox.preview && reviewBox.preview.action === "delete"
+          ? "CONTACT CARD TO DELETE" : reviewBox.preview && reviewBox.preview.action === "consolidate"
+            ? "MERGED CONTACT TO KEEP" : "CONTACT AFTER SAVING"
+      }
+      GridLayout {
+        Layout.fillWidth: true
+        columns: width >= root.space(720) ? 2 : 1
+        columnSpacing: root.space(10)
+        rowSpacing: root.space(8)
+        ReviewField { label: "First name"; value: firstName.text }
+        ReviewField { label: "Middle name"; value: middleName.text }
+        ReviewField { label: "Last name"; value: lastName.text }
+        ReviewField { label: "Nickname"; value: nickname.text }
+        ReviewField { label: "Organization"; value: organization.text }
+        ReviewField { label: "Department"; value: department.text }
+        ReviewField { label: "Job title"; value: jobTitle.text }
+        ReviewField { label: "Birthday"; value: birthday.text }
+      }
+      ReviewValueList { title: "PHONE NUMBERS"; sourceModel: phones }
+      ReviewValueList { title: "EMAIL ADDRESSES"; sourceModel: emails }
+      ReviewValueList { title: "WEBSITES"; sourceModel: urls }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        visible: addresses.count > 0
+        spacing: root.space(6)
+        SectionTitle { label: "POSTAL ADDRESSES" }
+        Repeater {
+          model: addresses
+          delegate: ReviewOutcomeRow {
+            required property string street
+            required property string city
+            required property string state
+            required property string postalCode
+            required property string country
+            value: root.addressSummary({ street: street, city: city, state: state,
+              postalCode: postalCode, country: country })
+          }
+        }
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        visible: notes.text.trim() !== ""
+        spacing: root.space(6)
+        SectionTitle { label: "NOTES" }
+        Text {
+          Layout.fillWidth: true
+          text: notes.text
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.bodySmall)
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        implicitHeight: finalConfirmation.implicitHeight + root.space(22)
+        radius: root.corner(root.space(9))
+        color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.08)
+        border.width: 1
+        border.color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.65)
+        ColumnLayout {
+          id: finalConfirmation
+          anchors.fill: parent
+          anchors.margins: root.space(11)
+          spacing: root.space(8)
+          Text {
+            Layout.fillWidth: true
+            text: "FINAL CONFIRMATION"
+            textFormat: Text.PlainText
+            color: root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: reviewBox.preview ? reviewBox.preview.action === "edit"
+              ? "Save this reviewed contact to " + reviewBox.preview.sourceName + "?"
+              : reviewBox.preview.action === "delete"
+                ? "Delete this reviewed source card from " + reviewBox.preview.sourceName + "?"
+                : "Save the reviewed merged contact to " + reviewBox.preview.sourceName
+                  + " and delete " + reviewBox.preview.sourceCardCount + " other source card(s)?"
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: reviewBox.preview ? reviewBox.preview.action === "delete"
+              ? "Undo can recreate the text fields in the default writable account, but cannot restore the original account placement, links, or photo."
+              : reviewBox.preview.action === "consolidate"
+                ? "Undo can recreate removed text fields as new cards, but their original account placement, links, and photos cannot be guaranteed."
+                : "An owner-only undo receipt will be saved on the Mac."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.25)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Item { Layout.fillWidth: true }
+            ActionButton { label: "Back to edit"; onClicked: root.resolver.cancelMutation() }
+            ActionButton {
+              danger: reviewBox.preview && reviewBox.preview.action !== "edit"
+              primary: true
+              label: reviewBox.preview && reviewBox.preview.action === "edit"
+                ? "Save to Mac Contacts" : reviewBox.preview && reviewBox.preview.action === "delete"
+                  ? "Delete card from Contacts" : "Merge and delete source cards"
+              enabled: root.resolver && !root.resolver.loading && reviewBox.preview
+                && reviewBox.preview.writeEnabled
+              onClicked: root.resolver.applyMutation()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  component ReviewField: Rectangle {
+    property string label: ""
+    property string value: ""
+    Layout.fillWidth: true
+    visible: value.trim() !== ""
+    implicitHeight: reviewFieldContent.implicitHeight + root.space(16)
+    radius: root.corner(root.space(7))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.045)
+    ColumnLayout {
+      id: reviewFieldContent
+      anchors.fill: parent
+      anchors.margins: root.space(8)
+      spacing: root.space(2)
+      Text { text: parent.parent.label; textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.35);
+        font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+      Text { Layout.fillWidth: true; text: parent.parent.value; textFormat: Text.PlainText;
+        wrapMode: Text.WordWrap; color: root.foreground; font.family: root.fontFamily;
+        font.pixelSize: root.fontSize(Style.font.bodySmall); font.bold: true }
+    }
+  }
+
+  component ReviewValueList: ColumnLayout {
+    id: reviewList
+    property string title: ""
+    required property ListModel sourceModel
+    Layout.fillWidth: true
+    visible: sourceModel.count > 0
+    spacing: root.space(6)
+    SectionTitle { label: reviewList.title }
+    Repeater {
+      model: reviewList.sourceModel
+      delegate: ReviewOutcomeRow {}
+    }
+  }
+
+  component ReviewOutcomeRow: RowLayout {
+    required property string label
+    required property string value
+    property bool danger: false
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    Text {
+      Layout.preferredWidth: root.space(170)
+      text: parent.label === "" ? "UNLABELED" : parent.label.toUpperCase()
+      textFormat: Text.PlainText
+      color: parent.danger ? root.urgent : Qt.darker(root.foreground, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: true
+    }
+    Text {
+      Layout.fillWidth: true
+      text: parent.value
+      textFormat: Text.PlainText
+      wrapMode: Text.WordWrap
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.bodySmall)
+    }
+  }
+
+  component ActionButton: Rectangle {
+    id: button
+    property string label: ""
+    property bool danger: false
+    property bool primary: false
+    signal clicked()
+    implicitWidth: buttonText.implicitWidth + root.space(16)
+    implicitHeight: buttonText.implicitHeight + root.space(10)
+    radius: root.corner(root.space(7)); opacity: enabled ? 1.0 : 0.45
+    color: hover.hovered ? Qt.rgba((danger ? root.urgent : root.accent).r,
+      (danger ? root.urgent : root.accent).g, (danger ? root.urgent : root.accent).b, 0.18)
+      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+    border.width: 1; border.color: danger ? root.urgent : primary ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
+    Text { id: buttonText; anchors.centerIn: parent; text: button.label; textFormat: Text.PlainText;
+      color: button.danger ? root.urgent : root.foreground; font.family: root.fontFamily;
+      font.pixelSize: root.fontSize(Style.font.caption); font.bold: button.primary }
+    HoverHandler { id: hover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
+    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+  }
+}

--- a/IdentitySettings.qml
+++ b/IdentitySettings.qml
@@ -1,0 +1,1726 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// Mac contact management and optional Blip display-name preferences are
+// deliberately separate workflows. Selecting a candidate is session-only.
+ColumnLayout {
+  id: root
+
+  property var resolver: null
+  property var threads: []
+  property var preferences: null
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  property string selectedToken: ""
+  property bool macReviewExpanded: false
+  property bool namingExpanded: false
+  property bool auditActionableOnly: false
+  property bool directContactPending: false
+  property bool directWorkspacePending: false
+  property bool directEditorPending: false
+  property bool discardUnsavedConfirm: false
+  readonly property bool editorActive: customField.activeFocus
+  readonly property bool reviewActive: resolver && resolver.activeHandle !== ""
+  readonly property var savedChoices: resolver ? resolver.identities : []
+  readonly property bool hideShortCodeConversations: !preferences
+    || preferences.hideShortCodeConversations
+  readonly property var unresolvedWithShortCodes: unresolvedThreads(threads, true)
+  readonly property var reviewableConversations: unresolvedThreads(threads, false)
+  readonly property var auditableConversations: auditableThreads(threads)
+
+  // Previous results stay on screen during a re-scan, visibly grayed out
+  // until the fresh ones land. A first scan has nothing stale to dim.
+  readonly property bool staleWhileScanning:
+    resolver ? resolver.auditRunning === true && currentAudit !== null : false
+
+  // Animated three-dot progress while a scan is in flight. The dots are
+  // space-padded so the monospace label keeps one width and the button
+  // never jitters.
+  property int scanDotPhase: 0
+  readonly property string animatedDots: [".  ", ".. ", "..."][scanDotPhase]
+  Timer {
+    running: root.resolver
+      ? root.resolver.auditRunning === true || root.resolver.loading === true
+      : false
+    interval: 400
+    repeat: true
+    onTriggered: root.scanDotPhase = (root.scanDotPhase + 1) % 3
+  }
+
+  // A Contacts mutation makes a finished cleanup scan stale. The scan has
+  // its own dedicated process, so the quiet re-run starts IMMEDIATELY after
+  // the mutation; the list page shows the in-flight state and keeps the
+  // previous results visible until the fresh ones land. If a scan is
+  // already running when another mutation lands, the timer retries until
+  // the worker frees up.
+  Timer {
+    id: auditRefreshTimer
+    interval: 1000
+    repeat: true
+    property int attempts: 0
+    onTriggered: {
+      attempts += 1
+      if (attempts > 90 || !root.resolver) { running = false; return }
+      if (root.resolver.auditContacts(root.reviewHandles(), true)) running = false
+    }
+  }
+  Connections {
+    target: root.resolver
+    function onContactsMutated() {
+      if (root.resolver && root.resolver.audit && root.auditableConversations.length > 0) {
+        auditRefreshTimer.attempts = 0
+        auditRefreshTimer.running = true
+        auditRefreshTimer.triggered()
+      }
+    }
+  }
+
+  // Load the cleanup results as soon as the contacts page opens: with the
+  // fingerprint cache this is one cheap round-trip when nothing changed on
+  // the Mac, and a quiet background scan (own process, spinner shown) when
+  // something did.
+  property bool autoAuditStarted: false
+  function maybeAutoAudit() {
+    if (autoAuditStarted || !visible || !resolver) return
+    if (resolver.audit || resolver.auditRunning) return
+    if (auditableConversations.length === 0) return
+    autoAuditStarted = true
+    resolver.auditContacts(reviewHandles(), true)
+  }
+  onVisibleChanged: maybeAutoAudit()
+  onAuditableConversationsChanged: maybeAutoAudit()
+  readonly property var visibleConversations: hideShortCodeConversations
+    ? reviewableConversations : unresolvedWithShortCodes
+  readonly property var currentAudit: resolver && resolver.audit
+    && resolver.audit.handleCount === auditableConversations.length
+    && resolver.auditFingerprint === reviewFingerprint() ? resolver.audit : null
+  readonly property var unresolved: auditActionableOnly && currentAudit
+    ? actionableConversations(reviewableConversations) : visibleConversations
+  readonly property int hiddenShortCodeCount: shortCodeCount(unresolvedWithShortCodes)
+  readonly property int unresolvedAuditActionableCount: currentAudit
+    ? actionableConversations(reviewableConversations).length : 0
+  readonly property var selectedCandidate: candidateForToken(selectedToken)
+  readonly property var activeChoice: choiceForHandle(resolver ? resolver.activeHandle : "")
+  readonly property bool selectedChoiceIsSaved: selectedCandidate && activeChoice
+    && activeChoice.source === "contacts"
+    && activeChoice.contactToken === selectedCandidate.token
+    && activeChoice.name === selectedCandidate.name
+  readonly property bool unsavedContactsError:
+    String(resolver ? resolver.error : "").toLowerCase()
+      .indexOf("contacts has unsaved changes") >= 0
+
+  signal focusAreaRequested(real localY)
+
+  spacing: space(10)
+
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function directHandle(value) {
+    var handle = String(value || "")
+    return /^\+?[0-9]{5,}$/.test(handle) || /^[^@\s]+@[^@\s]+$/.test(handle)
+  }
+  // "handle" is Blip-internal vocabulary; the UI says number/email.
+  function handleNoun() {
+    return String(resolver ? resolver.activeHandle : "").indexOf("@") >= 0 ? "email" : "number"
+  }
+  function handleKey(value) {
+    var handle = String(value || "")
+    if (handle.indexOf("@") >= 0) return "email:" + handle.toLowerCase()
+    var digits = handle.replace(/\D/g, "")
+    return "phone:" + (digits.length >= 10 ? digits.slice(-10) : digits)
+  }
+  function likelyServiceHandle(value) {
+    var handle = String(value || "")
+    return handle.indexOf("@") < 0 && handle.replace(/\D/g, "").length < 10
+  }
+  function unresolvedDetail(thread) {
+    var handle = String(thread && (thread.handle || thread.chat) || "")
+    var audited = auditEntryFor(handle)
+    if (audited) {
+      var suffix = thread && thread.pinned === true ? " · Pinned" : ""
+      if (audited.kind === "duplicate") {
+        var duplicate = audited.entry.candidates[0]
+        return duplicate.recordCount + " matching cards · " + auditSources(audited.entry)
+          + " · likely duplicate" + suffix
+      }
+      if (audited.kind === "conflict")
+        return audited.entry.candidates.length + " different Contacts names share this handle · review required" + suffix
+      return "One matching card for " + audited.entry.candidates[0].name + " · not a duplicate" + suffix
+    }
+    if (currentAudit && !likelyServiceHandle(handle))
+      return "No matching Mac contact card found" + (thread && thread.pinned === true ? " · Pinned" : "")
+    var detail = likelyServiceHandle(handle)
+      ? "Short code or service sender · usually no contact cleanup needed"
+      : handle.indexOf("@") >= 0
+        ? "Email address · no single Contacts name found"
+        : "Phone number · no single Contacts name found"
+    return detail + (thread && thread.pinned === true ? " · Pinned" : "")
+  }
+  function auditEntryFor(handle) {
+    if (!currentAudit) return null
+    var groups = [
+      { kind: "duplicate", entries: currentAudit.duplicates },
+      { kind: "conflict", entries: currentAudit.conflicts },
+      { kind: "single", entries: currentAudit.singleCards }
+    ]
+    for (var groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      var entries = groups[groupIndex].entries
+      for (var i = 0; i < entries.length; i++) {
+        if (handleKey(entries[i].handle) === handleKey(handle))
+          return { kind: groups[groupIndex].kind, entry: entries[i] }
+      }
+    }
+    return null
+  }
+  function actionableConversations(value) {
+    if (!Array.isArray(value) || !currentAudit) return []
+    return value.filter(function(thread) {
+      return auditEntryFor(String(thread && (thread.handle || thread.chat) || "")) !== null
+    })
+  }
+  function reviewHandles() {
+    var result = []
+    for (var i = 0; i < auditableConversations.length; i++)
+      result.push(String(auditableConversations[i].handle || auditableConversations[i].chat || ""))
+    return result
+  }
+  function reviewFingerprint() {
+    var keys = []
+    for (var i = 0; i < auditableConversations.length; i++)
+      keys.push(handleKey(auditableConversations[i].handle || auditableConversations[i].chat || ""))
+    keys.sort()
+    return JSON.stringify(keys)
+  }
+  function auditSources(entry) {
+    var seen = ({})
+    var result = []
+    var candidates = entry && Array.isArray(entry.candidates) ? entry.candidates : []
+    for (var candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
+      var cards = candidates[candidateIndex].cards || []
+      for (var cardIndex = 0; cardIndex < cards.length; cardIndex++) {
+        var source = String(cards[cardIndex].sourceName || "")
+        if (source !== "" && !seen[source]) { seen[source] = true; result.push(source) }
+      }
+    }
+    return result.join(" + ")
+  }
+  function auditNames(entry) {
+    var result = []
+    var candidates = entry && Array.isArray(entry.candidates) ? entry.candidates : []
+    for (var i = 0; i < candidates.length; i++) result.push(candidates[i].name)
+    return result.join(" · ")
+  }
+  function unresolvedThreads(value, includeShortCodes) {
+    if (!Array.isArray(value)) return []
+    var seen = ({})
+    var result = []
+    for (var i = 0; i < value.length; i++) {
+      var thread = value[i]
+      if (!thread) continue
+      var chat = String(thread.chat || "")
+      var handle = String(thread.handle || chat)
+      var name = String(thread.name || "")
+      if (!directHandle(chat) || (name !== chat && name !== handle && !directHandle(name))) continue
+      if (includeShortCodes !== true && likelyServiceHandle(handle)) continue
+      if (seen[chat]) continue
+      seen[chat] = true
+      result.push(thread)
+    }
+    result.sort(function(a, b) {
+      var ap = a.pinned === true ? 0 : 1
+      var bp = b.pinned === true ? 0 : 1
+      if (ap !== bp) return ap - bp
+      return String(a.last_ts || "") < String(b.last_ts || "") ? 1 : -1
+    })
+    return result
+  }
+  function auditableThreads(value) {
+    if (!Array.isArray(value)) return []
+    var seen = ({})
+    var result = []
+    for (var i = 0; i < value.length; i++) {
+      var thread = value[i]
+      if (!thread) continue
+      var chat = String(thread.chat || "")
+      var handle = String(thread.handle || chat)
+      if (!directHandle(chat) || likelyServiceHandle(handle)) continue
+      var key = handleKey(handle)
+      if (seen[key]) continue
+      seen[key] = true
+      result.push(thread)
+    }
+    return result
+  }
+  function shortCodeCount(value) {
+    if (!Array.isArray(value)) return 0
+    var count = 0
+    for (var i = 0; i < value.length; i++) {
+      if (likelyServiceHandle(value[i] && (value[i].handle || value[i].chat))) count++
+    }
+    return count
+  }
+  function choiceForHandle(handle) {
+    var key = handleKey(handle)
+    if (key === "phone:" || key === "email:") return null
+    for (var i = 0; i < savedChoices.length; i++) {
+      if (handleKey(savedChoices[i].handle) === key) return savedChoices[i]
+    }
+    return null
+  }
+  function candidateForToken(token) {
+    if (!resolver || token === "") return null
+    for (var i = 0; i < resolver.candidates.length; i++) {
+      if (resolver.candidates[i].token === token) return resolver.candidates[i]
+    }
+    return null
+  }
+  function candidateDetail(candidate) {
+    var cards = candidate.recordCount === 1 ? "1 contact card" : candidate.recordCount + " contact cards"
+    var sources = candidate.sourceCount === 1 ? "1 source" : candidate.sourceCount + " sources"
+    return cards + " · " + sources + (candidate.hasPhoto ? " · has photo" : "")
+  }
+  function beginReview(handle, directEdit) {
+    if (!resolver || resolver.loading) return
+    directContactPending = false
+    directWorkspacePending = false
+    directEditorPending = false
+    var saved = choiceForHandle(handle)
+    selectedToken = saved && saved.source === "contacts" ? saved.contactToken : ""
+    customField.text = saved && saved.source === "custom" ? saved.name : ""
+    namingExpanded = false
+    macReviewExpanded = false
+    var started = resolver.findCandidates(handle)
+    directContactPending = directEdit === true && started
+  }
+  function editContact(handle) {
+    beginReview(handle, true)
+  }
+  function openNamePreference() {
+    if (!resolver || resolver.loading) return
+    if (resolver.comparison) resolver.cancelComparison()
+    macReviewExpanded = false
+    namingExpanded = true
+  }
+  function openContactManagement() {
+    if (!resolver || resolver.loading || resolver.candidates.length === 0) return
+    var candidate = selectedCandidate
+    if (!candidate && resolver.candidates.length === 1) {
+      selectedToken = resolver.candidates[0].token
+      candidate = resolver.candidates[0]
+    }
+    namingExpanded = false
+    macReviewExpanded = true
+    if (candidate && (!resolver.comparison
+        || resolver.comparison.ownerToken !== candidate.token)) {
+      resolver.compareCards(resolver.activeHandle, candidate.token)
+    }
+  }
+  function closeReview() {
+    if (!resolver || resolver.loading) return
+    if (resolver.dismissReview()) {
+      selectedToken = ""
+      customField.text = ""
+      namingExpanded = false
+      macReviewExpanded = false
+      directContactPending = false
+      directWorkspacePending = false
+      directEditorPending = false
+    }
+  }
+  function selectCandidate(candidate) {
+    if (!candidate || !resolver || resolver.loading) return
+    if (resolver.repairPreview) resolver.cancelRepair()
+    if (resolver.comparison) resolver.cancelComparison()
+    selectedToken = candidate.token
+    customField.text = ""
+  }
+
+  Connections {
+    target: root.resolver
+    function onActiveHandleChanged() {
+      var saved = root.choiceForHandle(root.resolver.activeHandle)
+      root.selectedToken = saved && saved.source === "contacts" ? saved.contactToken : ""
+      customField.text = saved && saved.source === "custom" ? saved.name : ""
+      root.namingExpanded = false
+    }
+    function onIdentitiesChanged() {
+      if (root.choiceForHandle(root.resolver.activeHandle)) root.namingExpanded = false
+    }
+    function onAuditChanged() {
+      if (!root.resolver.audit) root.auditActionableOnly = false
+    }
+    function onCandidatesChanged() {
+      var saved = root.activeChoice
+      if (root.directContactPending && root.resolver.currentOperation === "candidates") {
+        root.directContactPending = false
+        var directCandidate = saved && saved.source === "contacts"
+          ? root.candidateForToken(saved.contactToken) : null
+        if (!directCandidate && root.resolver.candidates.length === 1)
+          directCandidate = root.resolver.candidates[0]
+        root.namingExpanded = false
+        root.macReviewExpanded = true
+        if (directCandidate) {
+          root.selectedToken = directCandidate.token
+          root.directWorkspacePending = true
+          root.directEditorPending = directCandidate.recordCount === 1
+          Qt.callLater(root.openContactManagement)
+        } else {
+          root.selectedToken = ""
+          Qt.callLater(function() { root.focusAreaRequested(root.space(96)) })
+        }
+        return
+      }
+      if (saved && saved.source === "contacts"
+          && root.candidateForToken(saved.contactToken)) {
+        root.selectedToken = saved.contactToken
+        return
+      }
+      if (root.selectedToken !== "" && root.candidateForToken(root.selectedToken)) return
+      root.selectedToken = root.resolver.candidates.length === 1
+        ? root.resolver.candidates[0].token : ""
+    }
+    function onComparisonChanged() {
+      if (!root.directWorkspacePending || !root.resolver.comparison) return
+      root.directWorkspacePending = false
+      if (root.directEditorPending && root.resolver.comparison.cards.length === 1)
+        contactWorkspace.editCard(root.resolver.comparison.cards[0])
+      root.directEditorPending = false
+      Qt.callLater(function() {
+        root.focusAreaRequested(contactWorkspace.mapToItem(root, 0, 0).y)
+      })
+    }
+  }
+
+  ColumnLayout {
+    Layout.fillWidth: true
+    visible: !root.reviewActive
+    spacing: root.space(12)
+
+  Text {
+    Layout.fillWidth: true
+    visible: root.savedChoices.length > 0
+    text: "SAVED DISPLAY PREFERENCES"
+    textFormat: Text.PlainText
+    color: Qt.darker(root.foreground, 1.25)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+    font.bold: true
+  }
+
+  Repeater {
+    model: root.savedChoices
+    delegate: Rectangle {
+      required property var modelData
+      Layout.fillWidth: true
+      implicitHeight: savedRow.implicitHeight + root.space(16)
+      radius: root.corner(root.space(10))
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+      border.width: 1
+      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.15)
+
+      RowLayout {
+        id: savedRow
+        anchors.fill: parent
+        anchors.margins: root.space(8)
+        spacing: root.space(8)
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: root.space(2)
+          Text {
+            Layout.fillWidth: true
+            text: String(modelData.name || "")
+            textFormat: Text.PlainText
+            elide: Text.ElideRight
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: modelData.source === "contacts"
+              ? String(modelData.handle || "") + " · From Contacts · contact unchanged"
+              : String(modelData.handle || "") + " · custom Blip-only name"
+            textFormat: Text.PlainText
+            elide: Text.ElideMiddle
+            color: Qt.darker(root.foreground, 1.4)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+        SmallButton {
+          label: "Open…"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.beginReview(modelData.handle)
+        }
+        SmallButton {
+          label: modelData.source === "contacts" ? "Stop using name" : "Remove custom name"
+          danger: true
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.resolver.clearChoice(modelData.handle)
+        }
+      }
+    }
+  }
+
+  Rectangle {
+    Layout.fillWidth: true
+    visible: root.unresolvedWithShortCodes.length > 0
+    implicitHeight: unresolvedHelp.implicitHeight + root.space(20)
+    radius: root.corner(root.space(9))
+    color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.07)
+    border.width: 1
+    border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.32)
+    ColumnLayout {
+      id: unresolvedHelp
+      anchors.fill: parent
+      anchors.margins: root.space(10)
+      spacing: root.space(4)
+      Text {
+        Layout.fillWidth: true
+        text: "WHY THEY ARE HERE"
+        textFormat: Text.PlainText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: "Blip is using the phone number or email because Contacts did not provide one unambiguous name. Review a person to compare or merge matching Mac cards, or optionally choose what Blip displays. Short codes and service senders can simply be left alone. Nothing changes until you review and confirm it."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+      }
+    }
+  }
+
+  Rectangle {
+    Layout.fillWidth: true
+    Layout.topMargin: root.space(8)
+    visible: root.auditableConversations.length > 0
+    implicitHeight: auditContent.implicitHeight + root.space(24)
+    radius: root.corner(root.space(10))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.035)
+    border.width: 1
+    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+    ColumnLayout {
+      id: auditContent
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(8)
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.space(8)
+        Text {
+          Layout.fillWidth: true
+          text: "FIND CONTACT CLEANUP OPPORTUNITIES"
+          textFormat: Text.PlainText
+          color: root.currentAudit ? root.accent : root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+          font.bold: true
+        }
+        SmallButton {
+          label: root.resolver && root.resolver.auditRunning
+            ? "Scanning" + root.animatedDots
+            : root.currentAudit ? "Scan again"
+            : "Scan " + root.auditableConversations.length + " conversations"
+          enabled: root.resolver && !root.resolver.auditRunning
+          onClicked: root.resolver.auditContacts(root.reviewHandles())
+        }
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.currentAudit
+          ? "Read-only scan complete. Account names and matching fields are evidence, not permission to merge. Every contact change still opens its own preview and confirmation."
+          : "Run a read-only Mac Contacts scan to separate unmatched numbers, existing cards, likely duplicate cards, and handles assigned to conflicting names. Named conversations are included, so duplicates remain visible after Contacts supplies a display name. The scan changes nothing."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.3)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+      }
+      Text {
+        Layout.fillWidth: true
+        visible: root.currentAudit !== null
+        opacity: root.staleWhileScanning ? 0.45 : 1
+        Behavior on opacity { NumberAnimation { duration: 180 } }
+        text: root.currentAudit
+          ? root.currentAudit.noMatchCount + " no matching card · "
+            + root.currentAudit.singleCards.length + " single-card matches · "
+            + root.currentAudit.duplicates.length + " likely duplicates · "
+            + root.currentAudit.conflicts.length + " naming conflicts"
+          : ""
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+        font.bold: true
+      }
+      Repeater {
+        model: root.currentAudit ? root.currentAudit.duplicates : []
+        AuditResultRow {
+          required property var modelData
+          entry: modelData
+          kind: "duplicate"
+          opacity: root.staleWhileScanning ? 0.45 : 1
+          Behavior on opacity { NumberAnimation { duration: 180 } }
+        }
+      }
+      Repeater {
+        model: root.currentAudit ? root.currentAudit.conflicts : []
+        AuditResultRow {
+          required property var modelData
+          entry: modelData
+          kind: "conflict"
+          opacity: root.staleWhileScanning ? 0.45 : 1
+          Behavior on opacity { NumberAnimation { duration: 180 } }
+        }
+      }
+      Text {
+        Layout.fillWidth: true
+        visible: root.currentAudit && root.currentAudit.singleCards.length > 0
+        opacity: root.staleWhileScanning ? 0.45 : 1
+        Behavior on opacity { NumberAnimation { duration: 180 } }
+        text: root.currentAudit
+          ? root.currentAudit.singleCards.length + " conversations already have one matching card. They are not duplicates."
+          : ""
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+      Text {
+        Layout.fillWidth: true
+        visible: root.currentAudit && root.currentAudit.noMatchCount > 0
+        opacity: root.staleWhileScanning ? 0.45 : 1
+        Behavior on opacity { NumberAnimation { duration: 180 } }
+        text: root.currentAudit
+          ? root.currentAudit.noMatchCount + " conversations have no matching card. Blip recommends no bulk write for them."
+          : ""
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        visible: root.currentAudit !== null
+        Item { Layout.fillWidth: true }
+        SmallButton {
+          visible: root.unresolvedAuditActionableCount > 0
+          primary: root.auditActionableOnly
+          label: root.auditActionableOnly
+            ? "Show all " + root.reviewableConversations.length
+            : "Focus on " + root.unresolvedAuditActionableCount + " Contacts matches"
+          onClicked: root.auditActionableOnly = !root.auditActionableOnly
+        }
+      }
+    }
+  }
+
+  RowLayout {
+    Layout.fillWidth: true
+    Layout.topMargin: root.space(12)
+    visible: root.unresolvedWithShortCodes.length > 0
+    spacing: root.space(12)
+    Text {
+      Layout.fillWidth: true
+      text: "CHOOSE A CONVERSATION TO REVIEW"
+      textFormat: Text.PlainText
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.bodySmall)
+      font.bold: true
+    }
+    ToggleSwitch {
+      label: "Hide short-code senders"
+      checked: root.hideShortCodeConversations
+      enabled: root.preferences && root.preferences.loaded
+      onToggled: function(value) {
+        if (root.preferences) root.preferences.setBoolean("hideShortCodeConversations", value)
+      }
+    }
+  }
+
+  Text {
+    Layout.fillWidth: true
+    visible: root.unresolvedWithShortCodes.length > 0
+    text: "These conversations show a phone number or email instead of one unambiguous Contacts name. Choose one to inspect its matching cards, clean up Contacts, or set an optional Blip display preference."
+    textFormat: Text.PlainText
+    wrapMode: Text.WordWrap
+    color: Qt.darker(root.foreground, 1.3)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.bodySmall)
+  }
+
+  Text {
+    Layout.fillWidth: true
+    visible: root.unresolvedWithShortCodes.length > 0
+    text: root.auditActionableOnly && root.currentAudit
+      ? root.unresolved.length + " Contacts matches shown · "
+        + root.reviewableConversations.length + " phone/email conversations in the full queue."
+      : root.hideShortCodeConversations
+      ? root.reviewableConversations.length + (root.reviewableConversations.length === 1
+        ? " phone/email conversation to review · "
+        : " phone/email conversations to review · ")
+        + root.hiddenShortCodeCount + (root.hiddenShortCodeCount === 1
+          ? " short-code/service conversation hidden."
+          : " short-code/service conversations hidden.")
+      : root.visibleConversations.length + " conversations shown · "
+        + root.hiddenShortCodeCount + (root.hiddenShortCodeCount === 1
+          ? " looks like a short-code/service sender."
+          : " look like short-code/service senders.")
+    opacity: root.staleWhileScanning ? 0.45 : 1
+    Behavior on opacity { NumberAnimation { duration: 180 } }
+    textFormat: Text.PlainText
+    color: Qt.darker(root.foreground, 1.4)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+
+  Repeater {
+    model: root.unresolved
+    delegate: Rectangle {
+      required property var modelData
+      Layout.fillWidth: true
+      opacity: root.staleWhileScanning ? 0.45 : 1
+      Behavior on opacity { NumberAnimation { duration: 180 } }
+      implicitHeight: unresolvedRow.implicitHeight + root.space(22)
+      radius: root.corner(root.space(9))
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.035)
+      border.width: 1
+      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.13)
+      RowLayout {
+        id: unresolvedRow
+        anchors.fill: parent
+        anchors.margins: root.space(11)
+        spacing: root.space(12)
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: root.space(2)
+          Text {
+            Layout.fillWidth: true
+            text: String(modelData.chat || "")
+            textFormat: Text.PlainText
+            elide: Text.ElideMiddle
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: root.unresolvedDetail(modelData)
+            textFormat: Text.PlainText
+            elide: Text.ElideRight
+            color: Qt.darker(root.foreground, 1.4)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+        SmallButton {
+          label: root.likelyServiceHandle(modelData.chat) ? "Review anyway…" : "Review contact…"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.beginReview(modelData.chat)
+        }
+      }
+    }
+  }
+
+  Text {
+    Layout.fillWidth: true
+    visible: root.savedChoices.length === 0 && root.unresolvedWithShortCodes.length === 0
+    text: root.resolver && !root.resolver.loaded ? "Loading contact names…" : "No unresolved direct conversations."
+    textFormat: Text.PlainText
+    color: Qt.darker(root.foreground, 1.4)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.bodySmall)
+  }
+  }
+
+  Rectangle {
+    Layout.fillWidth: true
+    visible: root.resolver && root.resolver.activeHandle !== ""
+    implicitHeight: guide.implicitHeight + root.space(32)
+    radius: root.corner(root.space(12))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.025)
+    border.width: 1
+    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.16)
+
+    ColumnLayout {
+      id: guide
+      anchors.fill: parent
+      anchors.margins: root.space(16)
+      spacing: root.space(18)
+
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.space(8)
+        SmallButton {
+          label: "← All conversations"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.closeReview()
+        }
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: root.space(2)
+          Text {
+            Layout.fillWidth: true
+            text: root.activeChoice ? root.activeChoice.name
+              : root.selectedCandidate ? root.selectedCandidate.name : "Conversation contact"
+            textFormat: Text.PlainText
+            elide: Text.ElideRight
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.body)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: String(root.resolver ? root.resolver.activeHandle : "")
+            textFormat: Text.PlainText
+            elide: Text.ElideMiddle
+            color: Qt.darker(root.foreground, 1.4)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: !root.namingExpanded && !root.macReviewExpanded
+        text: "What do you want to do? These are separate workflows."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.3)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+      }
+
+      GridLayout {
+        id: taskGrid
+        Layout.fillWidth: true
+        visible: !root.namingExpanded && !root.macReviewExpanded
+        columns: width >= root.space(760) ? 2 : 1
+        rowSpacing: root.space(12)
+        columnSpacing: root.space(12)
+        // Side by side, both cards take the taller card's height so the pair
+        // reads as one row; stacked, each keeps its own.
+        readonly property real pairHeight:
+          Math.max(manageTask.implicitHeight, namingTask.implicitHeight)
+
+        Rectangle {
+          Layout.fillWidth: true
+          Layout.alignment: Qt.AlignTop
+          implicitHeight: (taskGrid.columns === 2
+            ? taskGrid.pairHeight : manageTask.implicitHeight) + root.space(24)
+          radius: root.corner(root.space(10))
+          color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.1)
+          border.width: 1
+          border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.4)
+          ColumnLayout {
+            id: manageTask
+            anchors.fill: parent
+            anchors.margins: root.space(12)
+            spacing: root.space(7)
+            Text {
+              Layout.fillWidth: true
+              text: "MANAGE MAC CONTACTS"
+              textFormat: Text.PlainText
+              color: root.accent
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+            }
+            Text {
+              Layout.fillWidth: true
+              text: "Deduplicate, merge, edit, delete, or link source cards. This never creates a Blip display-name preference."
+              textFormat: Text.PlainText
+              wrapMode: Text.WordWrap
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
+            }
+            Item { Layout.fillHeight: true }
+            SmallButton {
+              Layout.alignment: Qt.AlignRight
+              primary: true
+              label: root.selectedCandidate && root.selectedCandidate.recordCount > 1
+                ? "Manage " + root.selectedCandidate.recordCount + " source cards…"
+                : "Manage Contacts…"
+              enabled: root.resolver && !root.resolver.loading
+                && root.resolver.candidates.length > 0
+              onClicked: root.openContactManagement()
+            }
+          }
+        }
+
+        Rectangle {
+          Layout.fillWidth: true
+          Layout.alignment: Qt.AlignTop
+          implicitHeight: (taskGrid.columns === 2
+            ? taskGrid.pairHeight : namingTask.implicitHeight) + root.space(24)
+          radius: root.corner(root.space(10))
+          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+          border.width: 1
+          border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.2)
+          ColumnLayout {
+            id: namingTask
+            anchors.fill: parent
+            anchors.margins: root.space(12)
+            spacing: root.space(7)
+            Text {
+              Layout.fillWidth: true
+              text: "SET A BLIP DISPLAY PREFERENCE · OPTIONAL"
+              textFormat: Text.PlainText
+              color: Qt.darker(root.foreground, 1.25)
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+            }
+            Text {
+              Layout.fillWidth: true
+              text: root.activeChoice
+                ? "Current preference: “" + root.activeChoice.name + "”. Change or remove the portable rule Blip uses for this conversation."
+                : "Use only when Blip shows a number or an unwanted name. Skip this when you only want to deduplicate Contacts."
+              textFormat: Text.PlainText
+              wrapMode: Text.WordWrap
+              color: Qt.darker(root.foreground, 1.3)
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
+            }
+            Item { Layout.fillHeight: true }
+            SmallButton {
+              Layout.alignment: Qt.AlignRight
+              label: root.activeChoice ? "Change display preference…" : "Choose display name…"
+              enabled: root.resolver && !root.resolver.loading
+              onClicked: root.openNamePreference()
+            }
+          }
+        }
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        visible: root.namingExpanded
+          && (!root.resolver || root.resolver.comparison === null)
+        spacing: root.space(10)
+
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.space(8)
+        SectionHeading { label: "OPTIONAL BLIP DISPLAY NAME" }
+        SmallButton {
+          visible: root.activeChoice !== null
+          danger: true
+          label: "Remove display preference"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.resolver.clearChoice(root.resolver.activeHandle)
+        }
+        SmallButton {
+          label: "Back to tasks"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.namingExpanded = false
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        text: "This saves a portable rule in identities.json for what Blip displays. It does not edit Mac Contacts, and it is not needed to compare or merge duplicate cards."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.loading
+        text: "Checking Contacts on the Mac…"
+        textFormat: Text.PlainText
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      Repeater {
+        model: root.resolver ? root.resolver.candidates : []
+        delegate: Rectangle {
+          id: candidateBox
+          required property var modelData
+          readonly property bool selected: root.selectedToken === modelData.token
+          Layout.fillWidth: true
+          implicitHeight: candidateRow.implicitHeight + root.space(16)
+          radius: root.corner(root.space(9))
+          color: selected
+            ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.16)
+            : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+          border.width: selected ? 2 : 1
+          border.color: selected ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.16)
+
+          RowLayout {
+            id: candidateRow
+            anchors.fill: parent
+            anchors.margins: root.space(8)
+            spacing: root.space(9)
+            Rectangle {
+              implicitWidth: root.space(16)
+              implicitHeight: implicitWidth
+              radius: width / 2
+              color: candidateBox.selected ? root.accent : "transparent"
+              border.width: 2
+              border.color: candidateBox.selected ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.4)
+              Text {
+                anchors.centerIn: parent
+                visible: candidateBox.selected
+                text: "✓"
+                color: Color.background
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+                font.bold: true
+              }
+            }
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: root.space(2)
+              Text {
+                Layout.fillWidth: true
+                text: String(modelData.name || "")
+                textFormat: Text.PlainText
+                elide: Text.ElideRight
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.bodySmall)
+                font.bold: true
+              }
+              Text {
+                Layout.fillWidth: true
+                text: root.candidateDetail(modelData)
+                textFormat: Text.PlainText
+                elide: Text.ElideRight
+                color: Qt.darker(root.foreground, 1.4)
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+              }
+            }
+            SmallButton {
+              label: candidateBox.selected ? "Selected" : "Select"
+              enabled: root.resolver && !root.resolver.loading && !candidateBox.selected
+              onClicked: root.selectCandidate(modelData)
+            }
+          }
+          HoverHandler { cursorShape: Qt.PointingHandCursor }
+          TapHandler { onTapped: root.selectCandidate(modelData) }
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && !root.resolver.loading && root.resolver.candidates.length === 0
+        text: "No matching Contacts card was found. Add this handle to a person on the Mac, check again, or save a custom Blip-only name below."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        visible: root.selectedCandidate !== null
+        implicitHeight: selectedSummary.implicitHeight + root.space(16)
+        radius: root.corner(root.space(9))
+        color: root.selectedChoiceIsSaved
+          ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.14)
+          : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+        border.width: 2
+        border.color: root.selectedChoiceIsSaved
+          ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
+        ColumnLayout {
+          id: selectedSummary
+          anchors.fill: parent
+          anchors.margins: root.space(8)
+          spacing: root.space(5)
+          Text {
+            Layout.fillWidth: true
+            text: root.selectedCandidate
+              ? root.selectedChoiceIsSaved
+                ? "✓ Current display preference: “" + root.selectedCandidate.name + "”"
+                : "Save “" + root.selectedCandidate.name + "” as Blip’s display preference"
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.selectedChoiceIsSaved ? root.accent : root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: root.selectedChoiceIsSaved
+              ? "Stored in identities.json. Mac Contacts remains unchanged; remove this preference to return to Blip’s normal contact-name lookup."
+              : "This adds a portable name rule for this number. Skip it if your only goal is to deduplicate or edit the contact cards."
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.35)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          SmallButton {
+            Layout.alignment: Qt.AlignLeft
+            visible: !root.selectedChoiceIsSaved
+            primary: true
+            label: root.selectedCandidate
+              ? "Save Contacts name as display preference"
+              : "Save Contacts display preference"
+            enabled: root.resolver && !root.resolver.loading && root.selectedCandidate !== null
+            onClicked: root.resolver.choose(
+              root.resolver.activeHandle, root.selectedCandidate.name, root.selectedCandidate.token)
+          }
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        text: "OR SAVE A CUSTOM BLIP-ONLY DISPLAY NAME"
+        textFormat: Text.PlainText
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.space(8)
+        TextField {
+          id: customField
+          Layout.fillWidth: true
+          placeholderText: "Type a local display name"
+          foreground: root.foreground
+          accent: root.accent
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.bodySmall)
+          maximumLength: 160
+          onTextChanged: if (activeFocus && text.trim() !== "") root.selectedToken = ""
+        }
+        SmallButton {
+          label: "Save custom name in Blip only"
+          enabled: root.resolver && !root.resolver.loading && customField.text.trim() !== ""
+          onClicked: root.resolver.setCustom(root.resolver.activeHandle, customField.text)
+        }
+      }
+
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        implicitHeight: 1
+        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+      }
+
+      RowLayout {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        spacing: root.space(8)
+        SectionHeading { label: "MANAGE MAC CONTACTS" }
+        SmallButton {
+          visible: contactWorkspace.editorCard === null
+            && (!root.resolver || root.resolver.mutationPreview === null)
+            && (!root.resolver || root.resolver.repairPreview === null)
+            && (!root.resolver || root.resolver.comparison === null)
+          label: "Refresh source cards"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.resolver.findCandidates(root.resolver.activeHandle)
+        }
+        SmallButton {
+          visible: !root.resolver || root.resolver.comparison === null
+          label: "Back to tasks"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: {
+            if (root.resolver.comparison) root.resolver.cancelComparison()
+            root.macReviewExpanded = false
+          }
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        text: root.resolver && root.resolver.candidates.length > 1
+          ? root.resolver.candidates.length + " different people are named for this " + root.handleNoun() + " in Contacts. Pick who this conversation belongs to — from there you can merge the cards or remove the " + root.handleNoun() + " from the wrong one."
+          : root.selectedCandidate && root.selectedCandidate.recordCount > 1
+            ? root.selectedCandidate.recordCount + " source cards found. Compare, edit, consolidate, delete, or link them from Blip."
+            : "One source card found. You can review, edit, or delete it from Blip."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        spacing: root.space(12)
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.candidates.length > 0 && root.selectedCandidate === null
+        text: "Pick a person below. That only opens their cards for review — it is temporary, never saved, and changes nothing in Contacts."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.urgent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+
+      Repeater {
+        model: root.resolver ? root.resolver.candidates : []
+        delegate: Rectangle {
+          id: sourceCandidate
+          required property var modelData
+          readonly property bool intended: root.selectedToken === modelData.token
+          property bool cardsExpanded: !intended && modelData.recordCount <= 3
+          visible: !(intended && root.resolver && root.resolver.comparison
+            && root.resolver.comparison.ownerToken === modelData.token)
+          Layout.fillWidth: true
+          implicitHeight: sourceGroup.implicitHeight + root.space(16)
+          radius: root.corner(root.space(9))
+          color: intended
+            ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.09)
+            : root.selectedCandidate
+              ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.07)
+              : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+          border.width: 1
+          border.color: intended
+            ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.35)
+            : root.selectedCandidate
+              ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.35)
+              : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.2)
+
+          ColumnLayout {
+            id: sourceGroup
+            anchors.fill: parent
+            anchors.margins: root.space(8)
+            spacing: root.space(6)
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: root.space(8)
+              Text {
+                Layout.fillWidth: true
+                text: (sourceCandidate.intended ? "WORKING ON: "
+                  : root.selectedCandidate
+                    ? "OTHER PERSON USING THIS " + root.handleNoun().toUpperCase() + ": "
+                    : "POSSIBLE PERSON: ")
+                  + String(sourceCandidate.modelData.name || "")
+                textFormat: Text.PlainText
+                wrapMode: Text.WordWrap
+                color: sourceCandidate.intended || !root.selectedCandidate
+                  ? root.foreground : root.urgent
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+                font.bold: true
+              }
+              SmallButton {
+                // Explicit same-person declaration: opens the standard
+                // compare/merge workspace spanning BOTH people's cards.
+                visible: !sourceCandidate.intended && root.selectedCandidate !== null
+                  && root.resolver && root.resolver.contactWrites
+                label: "Merge with " + (root.selectedCandidate ? root.selectedCandidate.name : "") + "…"
+                enabled: root.resolver && !root.resolver.loading
+                onClicked: root.resolver.compareCards(
+                  root.resolver.activeHandle, root.selectedToken, sourceCandidate.modelData.token)
+              }
+              SmallButton {
+                label: !sourceCandidate.intended ? "Work on this person…"
+                  : root.resolver && root.resolver.comparison
+                  && root.resolver.comparison.ownerToken === sourceCandidate.modelData.token
+                  ? "Contact workspace open"
+                  : sourceCandidate.modelData.recordCount === 1 ? "Manage contact…"
+                    : "Manage " + sourceCandidate.modelData.recordCount + " cards…"
+                enabled: root.resolver && !root.resolver.loading
+                  && (!sourceCandidate.intended || !root.resolver.comparison
+                    || root.resolver.comparison.ownerToken !== sourceCandidate.modelData.token)
+                onClicked: {
+                  if (sourceCandidate.intended) root.resolver.compareCards(
+                    root.resolver.activeHandle, sourceCandidate.modelData.token)
+                  else root.selectCandidate(sourceCandidate.modelData)
+                }
+              }
+              SmallButton {
+                label: sourceCandidate.cardsExpanded
+                  ? "Hide cards"
+                  : "Show " + sourceCandidate.modelData.recordCount
+                    + (sourceCandidate.modelData.recordCount === 1 ? " card" : " cards")
+                enabled: root.resolver && !root.resolver.loading
+                onClicked: sourceCandidate.cardsExpanded = !sourceCandidate.cardsExpanded
+              }
+            }
+            Text {
+              Layout.fillWidth: true
+              text: sourceCandidate.intended
+                ? "You’re reviewing this person’s cards temporarily — nothing is saved as a Blip name, and every Mac Contacts change asks for its own confirmation."
+                : root.selectedCandidate
+                  ? "A different person? Remove just this " + root.handleNoun() + " from their card. The same person under another name (a married-name change, say)? Merge the cards — you can adjust the surviving name during the review."
+                  : "Opens their cards for review — from there you can edit them, merge duplicates, or remove this " + root.handleNoun() + " from the wrong card."
+              textFormat: Text.PlainText
+              wrapMode: Text.WordWrap
+              color: Qt.darker(root.foreground, 1.4)
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+            }
+            Repeater {
+              model: sourceCandidate.cardsExpanded ? sourceCandidate.modelData.cards : []
+              delegate: RowLayout {
+                id: sourceCard
+                required property var modelData
+                required property int index
+                Layout.fillWidth: true
+                spacing: root.space(8)
+                Text {
+                  Layout.fillWidth: true
+                  text: "Card " + (sourceCard.index + 1) + " of " + sourceCandidate.modelData.recordCount
+                    + " · " + sourceCard.modelData.sourceName
+                    + (sourceCandidate.modelData.sourceCount > 1
+                      ? " · source " + sourceCard.modelData.accountNumber
+                        + " of " + sourceCandidate.modelData.sourceCount : "")
+                    + (sourceCard.modelData.matchCount > 1
+                      ? " · " + sourceCard.modelData.matchCount + " matching fields" : "")
+                    + (sourceCard.modelData.hasPhoto ? " · has photo" : "")
+                  textFormat: Text.PlainText
+                  elide: Text.ElideRight
+                  color: Qt.darker(root.foreground, 1.4)
+                  font.family: root.fontFamily
+                  font.pixelSize: root.fontSize(Style.font.caption)
+                }
+                SmallButton {
+                  label: "Open card " + (sourceCard.index + 1) + " on Mac…"
+                  enabled: root.resolver && !root.resolver.loading
+                  onClicked: root.resolver.openOnMac(root.resolver.activeHandle, sourceCard.modelData.token)
+                }
+                SmallButton {
+                  visible: !sourceCandidate.intended && root.selectedCandidate !== null
+                    && root.resolver && root.resolver.contactWrites
+                  danger: true
+                  label: "Remove this " + root.handleNoun() + "…"
+                  enabled: root.resolver && !root.resolver.loading
+                  onClicked: root.resolver.inspectOnMac(
+                    root.resolver.activeHandle, sourceCard.modelData.token, root.selectedToken)
+                }
+              }
+            }
+          }
+        }
+      }
+
+      ContactCardCompare {
+        id: contactWorkspace
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.comparison !== null
+          && root.resolver.comparison.ownerToken === root.selectedToken
+        resolver: root.resolver
+        comparison: root.resolver ? root.resolver.comparison : null
+        foreground: root.foreground
+        urgent: root.urgent
+        accent: root.accent
+        fontFamily: root.fontFamily
+        fontScale: root.fontScale
+        density: root.density
+        cornerScale: root.cornerScale
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.repairPreview !== null
+        implicitHeight: repairConfirmation.implicitHeight + root.space(20)
+        radius: root.corner(root.space(9))
+        color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.09)
+        border.width: 2
+        border.color: root.urgent
+
+        ColumnLayout {
+          id: repairConfirmation
+          anchors.fill: parent
+          anchors.margins: root.space(10)
+          spacing: root.space(7)
+          Text {
+            Layout.fillWidth: true
+            text: root.resolver && root.resolver.repairPreview
+              ? "Remove " + root.resolver.repairPreview.handle + " from “"
+                + root.resolver.repairPreview.name + "”?"
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: root.resolver && root.resolver.repairPreview
+              ? "Verified card " + root.resolver.repairPreview.cardNumber + " of "
+                + root.resolver.repairPreview.cardCount + " from "
+                + root.resolver.repairPreview.sourceName + ". This will remove "
+                + root.resolver.repairPreview.fieldCount + " matching "
+                + root.resolver.repairPreview.kind
+                + (root.resolver.repairPreview.fieldCount === 1 ? " field" : " fields")
+                + " from synced Mac Contacts. An undo receipt will be saved on the Mac."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          Text {
+            Layout.fillWidth: true
+            visible: root.resolver && root.resolver.repairPreview
+              && !root.resolver.repairPreview.writeEnabled
+            text: "The Mac-side contact-writes gate is disabled. Re-run setup with explicit contact-write access."
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+            font.bold: true
+          }
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Item { Layout.fillWidth: true }
+            SmallButton {
+              label: "Cancel"
+              enabled: root.resolver && !root.resolver.loading
+              onClicked: root.resolver.cancelRepair()
+            }
+            SmallButton {
+              danger: true
+              primary: true
+              label: "Remove from Mac Contacts"
+              enabled: root.resolver && !root.resolver.loading
+                && root.resolver.repairPreview && root.resolver.repairPreview.writeEnabled
+              onClicked: root.resolver.removeOnMac()
+            }
+          }
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        // The undo offer belongs to the contact it changed — one merge's
+        // receipt must not follow the user into another person's workspace.
+        // The token stays in memory, so returning to that contact within the
+        // session re-offers it (the private Mac receipt outlives both).
+        visible: root.resolver && /^undo:[0-9a-f]{32}$/.test(root.resolver.undoToken)
+          && root.handleKey(root.resolver.undoHandle)
+             === root.handleKey(root.resolver.activeHandle)
+        implicitHeight: undoContents.implicitHeight + root.space(18)
+        radius: root.corner(root.space(9))
+        color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.12)
+        border.width: 1
+        border.color: root.accent
+        RowLayout {
+          id: undoContents
+          anchors.fill: parent
+          anchors.margins: root.space(9)
+          spacing: root.space(8)
+          Text {
+            Layout.fillWidth: true
+            text: root.resolver
+              ? (root.resolver.undoAction === "edit" ? "Edited one source card for “"
+                : root.resolver.undoAction === "delete" ? "Deleted one source card for “"
+                : root.resolver.undoAction === "consolidate"
+                  ? "Consolidated " + root.resolver.undoCardCount + " source cards for “"
+                  : "Removed " + root.resolver.undoHandle + " from “")
+                + root.resolver.undoName
+                + "”. Undo is available here now; its private Mac receipt expires in seven days."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          SmallButton {
+            primary: true
+            label: "Undo Mac change"
+            enabled: root.resolver && !root.resolver.loading
+            onClicked: root.resolver.undoOnMac()
+          }
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && !root.resolver.contactWrites
+        text: "Contact editing is disabled. Set contact_writes=on locally and enable the separate owner-only gate on the Mac to use it. Viewing and opening cards remain read-only."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: contactWorkspace.editorCard === null && root.resolver
+          && root.resolver.candidates.length > 0 && root.selectedCandidate !== null
+        text: "Viewing or opening a card makes no change. Editing, deletion, consolidation, and handle removal all require a separate confirmation."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      }
+    }
+  }
+
+  Text {
+    Layout.fillWidth: true
+    visible: root.resolver && (root.resolver.error !== "" || root.resolver.notice !== "")
+    // While an operation runs ("Consolidating the verified source cards…"),
+    // the notice's ellipsis animates as a three-dot progress indicator.
+    text: root.resolver && root.resolver.error !== ""
+      ? root.resolver.error
+      : root.resolver && root.resolver.loading
+        ? String(root.resolver.notice).replace(/…$/, "") + root.animatedDots
+        : String(root.resolver ? root.resolver.notice : "")
+    textFormat: Text.PlainText
+    wrapMode: Text.WordWrap
+    color: root.resolver && root.resolver.error !== "" ? root.urgent : Qt.darker(root.foreground, 1.4)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+
+  Rectangle {
+    Layout.fillWidth: true
+    implicitHeight: unsavedRecovery.implicitHeight + root.space(20)
+    visible: root.unsavedContactsError
+    radius: root.corner(root.space(8))
+    color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.07)
+    border.width: 1
+    border.color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.55)
+
+    ColumnLayout {
+      id: unsavedRecovery
+      anchors.fill: parent
+      anchors.margins: root.space(10)
+      spacing: root.space(8)
+
+      Text {
+        Layout.fillWidth: true
+        text: root.discardUnsavedConfirm
+          ? "Discard every pending change currently open in Contacts on the Mac?"
+          : "Contacts is holding an unfinished in-memory edit."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.discardUnsavedConfirm
+          ? "This closes Contacts without saving. Continue only if the pending edit is the failed Blip attempt; any separate edit you made directly on the Mac would also be discarded."
+          : "Finish or discard a real edit in Contacts on the Mac. If this was left by Blip’s failed save, Blip can close Contacts without saving it after one more confirmation."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.3)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        Item { Layout.fillWidth: true }
+        SmallButton {
+          visible: root.discardUnsavedConfirm
+          label: "Cancel"
+          onClicked: root.discardUnsavedConfirm = false
+        }
+        SmallButton {
+          danger: root.discardUnsavedConfirm
+          primary: !root.discardUnsavedConfirm
+          label: root.discardUnsavedConfirm
+            ? "Discard and close Contacts" : "Resolve pending edit…"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: {
+            if (!root.discardUnsavedConfirm) {
+              root.discardUnsavedConfirm = true
+              return
+            }
+            root.discardUnsavedConfirm = false
+            root.resolver.discardUnsavedContacts()
+          }
+        }
+      }
+    }
+  }
+
+  Text {
+    Layout.fillWidth: true
+    visible: !root.reviewActive
+    text: root.resolver ? root.resolver.configPath : "~/.config/blip/identities.json"
+    textFormat: Text.PlainText
+    wrapMode: Text.WrapAnywhere
+    color: Qt.darker(root.foreground, 1.5)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+
+  component SectionHeading: Text {
+    property string label: ""
+    Layout.fillWidth: true
+    text: label
+    textFormat: Text.PlainText
+    color: Qt.darker(root.foreground, 1.2)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+    font.bold: true
+  }
+
+  component SmallButton: Rectangle {
+    id: button
+    property string label: ""
+    property bool danger: false
+    property bool primary: false
+    signal clicked()
+    implicitWidth: buttonText.implicitWidth + root.space(16)
+    implicitHeight: buttonText.implicitHeight + root.space(10)
+    radius: root.corner(root.space(7))
+    opacity: enabled ? 1.0 : 0.45
+    color: buttonHover.hovered
+      ? Qt.rgba((danger ? root.urgent : root.accent).r,
+                (danger ? root.urgent : root.accent).g,
+                (danger ? root.urgent : root.accent).b, 0.18)
+      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+    border.width: 1
+    border.color: danger ? root.urgent : primary ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
+    Text {
+      id: buttonText
+      anchors.centerIn: parent
+      text: button.label
+      textFormat: Text.PlainText
+      color: button.danger ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: button.primary
+    }
+    HoverHandler { id: buttonHover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
+    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+  }
+
+  component ToggleSwitch: RowLayout {
+    id: toggle
+    property string label: ""
+    property bool checked: false
+    signal toggled(bool value)
+    spacing: root.space(7)
+    opacity: enabled ? 1.0 : 0.45
+    Text {
+      text: toggle.label
+      textFormat: Text.PlainText
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+    }
+    Rectangle {
+      Layout.preferredWidth: root.space(34)
+      Layout.preferredHeight: root.space(20)
+      radius: height / 2
+      color: toggle.checked
+        ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.65)
+        : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.16)
+      border.width: 1
+      border.color: toggle.checked ? root.accent
+        : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.35)
+      Rectangle {
+        width: parent.height - root.space(6)
+        height: width
+        radius: width / 2
+        anchors.verticalCenter: parent.verticalCenter
+        x: toggle.checked ? parent.width - width - root.space(3) : root.space(3)
+        color: toggle.checked ? root.foreground
+          : Qt.darker(root.foreground, 1.35)
+      }
+    }
+    HoverHandler { enabled: toggle.enabled; cursorShape: Qt.PointingHandCursor }
+    TapHandler { enabled: toggle.enabled; onTapped: toggle.toggled(!toggle.checked) }
+  }
+
+  component AuditResultRow: Rectangle {
+    id: auditRow
+    required property var entry
+    property string kind: "duplicate"
+    Layout.fillWidth: true
+    implicitHeight: auditRowContent.implicitHeight + root.space(16)
+    radius: root.corner(root.space(8))
+    color: kind === "conflict"
+      ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.07)
+      : Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.07)
+    border.width: 1
+    border.color: kind === "conflict" ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.38)
+      : Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.34)
+    RowLayout {
+      id: auditRowContent
+      anchors.fill: parent
+      anchors.margins: root.space(8)
+      spacing: root.space(8)
+      ColumnLayout {
+        Layout.fillWidth: true
+        spacing: root.space(2)
+        Text {
+          Layout.fillWidth: true
+          text: auditRow.kind === "conflict"
+            ? "CONFLICT · " + root.auditNames(auditRow.entry)
+            : "LIKELY DUPLICATE · " + auditRow.entry.candidates[0].name
+          textFormat: Text.PlainText
+          elide: Text.ElideRight
+          color: auditRow.kind === "conflict" ? root.urgent : root.accent
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+          font.bold: true
+        }
+        Text {
+          Layout.fillWidth: true
+          text: auditRow.entry.handle + (root.auditSources(auditRow.entry) === ""
+            ? "" : " · " + root.auditSources(auditRow.entry))
+          textFormat: Text.PlainText
+          elide: Text.ElideMiddle
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+      }
+      SmallButton {
+        label: auditRow.kind === "conflict" ? "Review conflict…" : "Review duplicate…"
+        enabled: root.resolver && !root.resolver.loading
+        onClicked: root.beginReview(auditRow.entry.handle)
+      }
+    }
+  }
+}

--- a/Panel.qml
+++ b/Panel.qml
@@ -23,6 +23,7 @@ Panel {
 
   property var anchorItem: null
   property var hostWidget: null
+  property var preferences: null
   readonly property var barIdentity: hostWidget || root
 
   // ---- proxies: BarWidget and the IPC hooks talk to the panel, the view does the work
@@ -59,12 +60,13 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    focusTarget: view.inThread ? view.composeEditor : keyCatcher
+    focusTarget: view.settingsMode ? keyCatcher : (view.inThread ? view.composeEditor : keyCatcher)
     contentWidth: panel.fittedContentWidth(Style.space(440))
     // The floor keeps the panel usable if a mode flip's relayout ever lags
     // again — search/new modes always have at least a field to show.
     contentHeight: panel.fittedContentHeight(
-      view.inThread ? Style.space(640)
+      view.settingsMode ? Style.space(640)
+        : view.inThread ? Style.space(640)
         : Math.max(view.contentHeightHint,
                    (view.newMode || view.searching) ? Style.space(280) : 0),
       Style.space(640))
@@ -88,6 +90,7 @@ Panel {
         id: view
         anchors.fill: parent
         hostWidget: root.hostWidget
+        preferences: root.preferences
         surfaceOpen: root.opened
         foreground: root.bar ? root.bar.foreground : Color.foreground
         urgent: root.bar ? root.bar.urgent : Color.urgent

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <img alt="Omarchy" src="https://img.shields.io/badge/Omarchy-plugin-5fd7ff?style=flat-square">
   <img alt="QuickShell" src="https://img.shields.io/badge/QuickShell-QML-0a84ff?style=flat-square">
   <img alt="bun" src="https://img.shields.io/badge/bun-TypeScript-f9f1e1?style=flat-square">
-  <img alt="tests" src="https://img.shields.io/badge/tests-282%20passing-2ea043?style=flat-square">
+  <img alt="tests" src="https://img.shields.io/badge/tests-350%20passing-2ea043?style=flat-square">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-lightgrey?style=flat-square">
 </p>
 
@@ -63,6 +63,8 @@ people who showed up with pull requests. What is in it now:
   bare; for the bare ones Blip fetches the page and builds the card from its
   Open Graph tags. Right-click any link for a share sheet: open, copy, a QR
   code your phone can scan, or send it to another device with LocalSend.
+- **Contact-name resolver** for numbers/emails that appear on multiple cards:
+  choose the right name for Blip, or open the matching source card on the Mac.
 - **Real-time push** — messages land in ~2 s via a watcher on the Mac.
 - **Attachments both ways** — photos inline and upright (EXIF orientation is
   baked in, so they are not sideways in your viewer either), files as chips,
@@ -123,7 +125,9 @@ Linux side. If the Mac is asleep, the widget dims and says so.
 - **link cards** — URL messages show the preview image, title, and host, like Messages. Apple only decorates some links; for the rest Blip fetches the page's own Open Graph card itself, so a bare URL still gets its picture. Click opens the link, **right-click opens the share sheet** (open · copy · QR for your phone · send to a device via LocalSend, Omarchy's share). `link_previews=off` in `bridge.conf` disables the fetching
 - **photos render inline** — images ≤5MB auto-fetch over SSH (HEIC converted on the Mac); click opens full-size. PDFs/videos are chips — click fetches and opens them
 - **send files** — Ctrl+V an image into the compose box, type `/attach <path>`, or drag-and-drop; a caption rides along
-- select text and Ctrl+C · right-click a bubble to copy it whole · right-click a **link** in a bubble for the share sheet
+- select text and Ctrl+C · right-click a bubble or conversation for **Copy
+  message**, **Copy vCard**, or **Edit contact**; group chats list each person;
+  right-click a **link** in a bubble for the share sheet
 - the share sheet **opens itself** for a link you send, and for one that arrives while Blip is open
 - compose box at the bottom, Enter sends — **DMs and groups**
 
@@ -291,6 +295,10 @@ wizard pauses here and re-checks when you press Enter)
   That is what lets an ssh session read `chat.db`.
 - *Automation → Messages* → the first send from ssh pops an Allow prompt on
   the Mac's screen; click it once.
+- Optional contact management: allow *Automation → Contacts*. For Apple's
+  separate native link action, also add
+  `/usr/libexec/sshd-keygen-wrapper` under *Privacy & Security →
+  Accessibility*. Contact writes still require both explicit Blip write gates.
 
 `ssh your-mac python3 ~/.blip/bin/blip-check` shows ✅/❌ per grant at any
 time, with the fix for each ❌.
@@ -335,6 +343,124 @@ send on their own service automatically.
 on the first screen polls and owns the app window, the others show the
 badge and forward clicks to it.
 
+## Settings and portable configuration
+
+Choose the gear in Blip's message header to edit appearance live. The editor
+writes a normal JSON file at `~/.config/blip/preferences.json`, so it can be
+copied between machines or tracked by dotfile tooling. A restored file is
+noticed within five seconds, or immediately with **Reload file**. Track the
+real file rather than a symlink: the preference boundary deliberately refuses
+symlinks and non-regular files.
+
+```json
+{
+  "schemaVersion": 1,
+  "outgoingBubbleColor": "theme",
+  "incomingBubbleColor": "theme",
+  "backgroundOpacity": 0.7,
+  "fontScale": 1,
+  "density": 1,
+  "sidebarWidth": 320,
+  "avatarSize": 30,
+  "cornerScale": 1,
+  "hideShortCodeConversations": true,
+  "use12HourConversationTimes": true
+}
+```
+
+Bubble colors accept `"theme"`, `#rrggbb`, or `#rrggbbaa`. The GUI exposes
+every field: app-window opacity, font scale, density, sidebar width, avatar
+size, corner roundness, short-code visibility, and 12/24-hour conversation-list
+times. Writes are atomic and owner-only; malformed,
+oversized, symlinked, or out-of-range files are rejected with an error in the
+settings view instead of being loaded into the long-lived shell.
+
+Settings has separate **Contacts** and **Appearance** tabs, so contact work
+does not share one long scroll with visual preferences. The Contacts tab lists
+direct conversations that are still shown by phone number or email, explains
+why each one is present, and hides short-code/service senders by default with a
+portable toggle to reveal them. Opening one
+replaces the list with a focused detail view; use **All conversations** or
+Escape to return. The detail view then separates two independent tasks.
+
+**Find Contacts cleanup opportunities** runs one read-only scan across the
+phone and email conversations in that queue. It groups the results into no
+matching card, one-card matches, same-name multi-card duplicate candidates,
+and handles attached to conflicting names. The result can filter the full list
+down to Contacts matches and provides direct review buttons for duplicates and
+conflicts. A shared handle or an iCloud/Google pairing is only evidence: the
+scan never changes a display name or contact, and Blip deliberately does not
+offer a blind bulk merge. Every upstream edit, deletion, link, or consolidation
+still gets a person-specific preview and confirmation.
+
+**Manage Mac Contacts** is the normal path for comparing, editing, deleting,
+linking, or consolidating duplicate source cards. It selects the matching
+person only for the current UI session and never writes
+`~/.config/blip/identities.json`. When Contacts returns one person, Blip can
+open that workspace directly; when several people share the handle, the user
+must select the intended person for that session before managing cards.
+
+**Set a Blip display preference** is optional and is not part of contact
+deduplication. Use it only when Blip otherwise shows a number or an unwanted
+name. Saving a Contacts name writes an explicit portable display rule to
+`~/.config/blip/identities.json` without editing Contacts. A name typed into the
+custom field is a custom Blip-only rule. Both kinds of preference apply to
+pinned tiles, the thread list, notifications, and sender labels. The file is
+portable and safe to restore alongside `preferences.json`, but it contains
+personal names and handles, so only put it in a private dotfiles repository.
+
+The contact-management workspace lists every
+active matching source card separately, with large duplicate sets collapsed
+again. Raw account databases sometimes retain historical cache rows that the
+Contacts object layer no longer exposes; Blip verifies and omits those rows so
+they cannot be mistaken for editable cards. **Manage N cards…** loads a
+bounded view of each active card's discovered name, organization,
+phone, email, address, URL, birthday, and notes, plus a de-duplicated combined
+view and a short missing-details checklist. Each card carries its bounded
+macOS source label—such as iCloud, Google, or On My Mac—while raw account IDs
+remain on the Mac.
+
+Each source card now has an **Edit in Blip…** workspace for names, organization
+and job fields, birthday, notes, labeled phone numbers, email addresses,
+websites, and postal addresses. Edits and whole-card deletions are first shown
+as a read-only change preview. The Mac bridge then re-resolves the opaque card
+token and requires the card's content revision to be unchanged before it
+saves. The card photo is retained on edit but is not editable in Blip.
+
+For duplicates, choose **Merge into card N…** to build an editable combined
+card. The selected card and its account remain authoritative; its scalar
+choices win, blanks are filled from the other cards, and unique collection
+values are combined. After a destructive confirmation, Blip batches the target
+update and same-account source-card deletions in one save through Apple's
+current Contacts framework. When source cards cross account stores, Blip first
+saves the complete surviving card and then deletes sources in account-scoped
+requests; this avoids Contacts' unsupported cross-store save while keeping the
+merged data safe before any source is removed. This deterministic path does not
+depend on Apple's menu item being enabled.
+
+From that comparison Blip can ask Contacts to select the exact cards and report
+Apple's currently enabled **Link Selected Cards** or **Merge Selected Cards**
+action. Nothing happens until a second confirmation names that exact action.
+The action is pinned through the SSH bridge and refused if it changes before
+the click. It changes Contacts and may sync upstream; unlike the narrow
+phone/email repair below, Blip cannot provide an automatic unlink receipt.
+This handoff needs Automation → Contacts and Accessibility for
+`/usr/libexec/sshd-keygen-wrapper` on the Mac.
+
+For a handle attached to the wrong person, Blip can also inspect the exact
+card, show a destructive confirmation, remove only that verified phone/email
+through Contacts.app, and offer an immediate undo; its private receipt expires
+after seven days. Edits, deletions, consolidations, and narrow field removals
+all require `contact_writes=on` plus the
+separate owner-only Mac gate. Whole-card deletion uses Apple's public Contacts
+framework. Blip never writes the private Contacts SQLite database or deletes a
+possibly shared number without confirmation. Edit undo
+restores the exact card fields if the card has not changed again. Delete and
+consolidation undo can recreate the text fields as new cards, but Contacts does
+not expose a supported way to restore their original synced-account placement,
+links, or photos; the confirmation says this explicitly. A custom Blip-only
+name is available when no source card exists.
+
 ## Keyboard
 
 | where | key | does |
@@ -355,6 +481,7 @@ IPC, for scripts and other plugins:
 
 ```sh
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip status
+qs -p /usr/share/omarchy/shell ipc call nixfred.blip settings
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip goto 15551234567   # bare digits
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip read               # mark all read
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip share https://example.com   # share sheet for a URL
@@ -364,7 +491,7 @@ Everything that sends or reads message content over IPC (`goto`, `compose`,
 `bubbles`, `threads`, `find`, `newchat`, `read`) is **off by default** — any
 local process could otherwise send as you. Turn it on with `automation=on`
 in `~/.config/blip/bridge.conf` (re-read live). `status`, `open`, `close`,
-`toggle`, `window`, `app` are always available.
+`toggle`, `window`, `app`, `settings` are always available.
 
 ## Design notes worth knowing
 
@@ -423,7 +550,7 @@ The 273,000-message history stays on the Mac where it lives.
 ## Development
 
 ```sh
-bun test                                     # 282 tests, ~130 ms
+bun test                                     # 350 tests, ~200 ms
 bun collector.ts --deep | jq '.unread, (.threads|length)'
 bun thread.ts +15551234567 40 | jq '.bubbles[-1]'
 scripts/demo/blip-shots                      # regenerate docs/img/*.png

--- a/bridge/BRIDGE-VERSION
+++ b/bridge/BRIDGE-VERSION
@@ -1,4 +1,5 @@
 claude-on-mac f3612e8 (v1.11.0, 2026-08-31)
 vendored: imsg imsg-send contacts tcc-check
 blip-only (NOT upstream): imsg-read blip-check blip-dispatch
+blip extensions: Messages pin order; bounded identity candidates/card compare; gated contact repair/link
 sync: scripts/sync-bridge.sh <sha-or-tag>

--- a/bridge/linux/blip-shim
+++ b/bridge/linux/blip-shim
@@ -12,7 +12,7 @@
 # key=value — keys: host (ssh target), key (dedicated identity, default
 # ~/.ssh/blip_ed25519; absent → general ssh), remote_bin (dir on the Mac
 # holding the tools; default ~/.blip/bin), python (default python3),
-# automation (on|off — read by the plugin, not the shim).
+# automation and contact_writes (on|off — read by the plugin, not the shim).
 #
 # The connectivity probe MUST be `ssh -n`: a bare probe eats stdin and
 # silently empties `imsg-send --file-stdin` payloads (learned the hard way).

--- a/bridge/mac/contact-delete.swift
+++ b/bridge/mac/contact-delete.swift
@@ -1,0 +1,670 @@
+#!/usr/bin/env swift
+import Contacts
+import Foundation
+
+private let maxInputBytes = 48 * 1024
+private let maxPersonIds = 7
+private let maxValues = 16
+private let maxNameHandles = 128
+private let maxVCardBytes = 2 * 1024 * 1024
+private let maxVCardResponseBytes = 3 * 1024 * 1024
+private let allowedId = try! NSRegularExpression(pattern: "^[A-Za-z0-9._:-]{1,200}$")
+private let forbiddenDirectionals = Set<UInt32>(
+    Array(0x202A...0x202E) + Array(0x2066...0x2069)
+)
+
+private struct LabeledValue: Decodable {
+    let label: String
+    let value: String
+}
+
+private struct PostalAddress: Decodable {
+    let label: String
+    let street: String
+    let city: String
+    let state: String
+    let postalCode: String
+    let country: String
+    let countryCode: String
+}
+
+private struct Card: Decodable {
+    let firstName: String
+    let middleName: String
+    let lastName: String
+    let nickname: String
+    let organization: String
+    let department: String
+    let jobTitle: String
+    let birthday: String
+    let note: String
+    let phones: [LabeledValue]
+    let emails: [LabeledValue]
+    let urls: [LabeledValue]
+    let addresses: [PostalAddress]
+}
+
+private struct Request: Decodable {
+    let operation: String
+    let personUids: [String]?
+    let targetUid: String?
+    let sourceUids: [String]?
+    let card: Card?
+    let handles: [String]?
+}
+
+private struct ResolvedName: Encodable {
+    let handle: String
+    let name: String
+    let shortName: String
+}
+
+private struct CardCounts: Encodable {
+    let uid: String
+    let phones: Int
+    let emails: Int
+    let urls: Int
+    let addresses: Int
+}
+
+private struct Response: Encodable {
+    let ok: Bool
+    let availableCount: Int?
+    let deletedCount: Int?
+    let updated: Bool?
+    let error: String?
+    let names: [ResolvedName]?
+    // Failure stage, machine-readable: callers pick recovery per stage
+    // instead of parsing the human message.
+    var stage: String? = nil
+    // "counts" op only: fresh CNContactStore collection sizes per card, the
+    // staleness cross-check for Contacts.app's describe view.
+    var counts: [CardCounts]? = nil
+}
+
+private struct VCardResponse: Encodable {
+    let ok: Bool
+    let name: String
+    let vcard: String
+}
+
+private func failure(_ message: String, code: Int) -> NSError {
+    NSError(domain: "BlipContacts", code: code,
+            userInfo: [NSLocalizedDescriptionKey: message])
+}
+
+private func emit<T: Encodable>(_ response: T, maximum: Int = 4096) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(response), data.count <= maximum else {
+        FileHandle.standardOutput.write(Data("{\"error\":\"Contacts mutation response failed\",\"ok\":false}".utf8))
+        return
+    }
+    FileHandle.standardOutput.write(data)
+}
+
+private func boundedInput() throws -> Data {
+    var result = Data()
+    while true {
+        let chunk = try FileHandle.standardInput.read(upToCount: 4096) ?? Data()
+        if chunk.isEmpty { return result }
+        if result.count + chunk.count > maxInputBytes {
+            throw failure("Contacts mutation request is too large", code: 1)
+        }
+        result.append(chunk)
+    }
+}
+
+private func validId(_ identifier: String) -> Bool {
+    let range = NSRange(identifier.startIndex..<identifier.endIndex, in: identifier)
+    return allowedId.firstMatch(in: identifier, range: range)?.range == range
+}
+
+private func validateIds(_ identifiers: [String], minimum: Int = 1,
+                         maximum: Int = maxPersonIds) throws {
+    guard identifiers.count >= minimum, identifiers.count <= maximum,
+          Set(identifiers).count == identifiers.count else {
+        throw failure("Contacts mutation card list is invalid", code: 2)
+    }
+    guard identifiers.allSatisfy(validId) else {
+        throw failure("Contacts mutation card id is invalid", code: 3)
+    }
+}
+
+private func validateText(_ value: String, maximum: Int, required: Bool = false) throws {
+    guard value.count <= maximum, (!required || !value.isEmpty),
+          value.unicodeScalars.allSatisfy({
+              !CharacterSet.controlCharacters.contains($0)
+                  && !forbiddenDirectionals.contains($0.value)
+          }) else {
+        throw failure("Contacts mutation contains an invalid field", code: 4)
+    }
+}
+
+private func resolvedNames(_ handles: [String], in store: CNContactStore) throws -> [ResolvedName] {
+    guard !handles.isEmpty, handles.count <= maxNameHandles,
+          Set(handles).count == handles.count else {
+        throw failure("Contacts name request is invalid", code: 21)
+    }
+    let keys: [CNKeyDescriptor] = [
+        CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+        CNContactNicknameKey as CNKeyDescriptor,
+        CNContactOrganizationNameKey as CNKeyDescriptor,
+        CNContactPhoneNumbersKey as CNKeyDescriptor,
+        CNContactEmailAddressesKey as CNKeyDescriptor,
+    ]
+    func normalized(_ value: String) -> String {
+        if value.contains("@") { return value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        let digits = value.filter(\.isNumber)
+        return digits.count >= 10 ? String(digits.suffix(10)) : digits
+    }
+    var wanted: [String: String] = [:]
+    for handle in handles where wanted[normalized(handle)] == nil {
+        wanted[normalized(handle)] = handle
+    }
+    var found: [String: ResolvedName] = [:]
+    let request = CNContactFetchRequest(keysToFetch: keys)
+    request.unifyResults = true
+    try store.enumerateContacts(with: request) { contact, _ in
+        let keys = contact.phoneNumbers.map { normalized($0.value.stringValue) }
+            + contact.emailAddresses.map { normalized($0.value as String) }
+        let hits = Set(keys).intersection(wanted.keys)
+        if hits.isEmpty { return }
+        let formatted = CNContactFormatter.string(from: contact, style: .fullName) ?? ""
+        let full = !formatted.isEmpty ? formatted
+            : (!contact.organizationName.isEmpty ? contact.organizationName : contact.nickname)
+        if full.isEmpty { return }
+        let short = !contact.givenName.isEmpty ? contact.givenName
+            : (!contact.nickname.isEmpty ? contact.nickname : full)
+        for key in hits where found[key] == nil {
+            found[key] = ResolvedName(handle: wanted[key]!, name: full, shortName: short)
+        }
+    }
+    var result: [ResolvedName] = []
+    for handle in handles {
+        try validateText(handle, maximum: 320, required: true)
+        if let name = found[normalized(handle)] {
+            result.append(ResolvedName(handle: handle, name: name.name, shortName: name.shortName))
+        }
+    }
+    return result
+}
+
+private func validateLabeled(_ values: [LabeledValue]) throws {
+    guard values.count <= maxValues else {
+        throw failure("Contacts mutation has too many field values", code: 5)
+    }
+    for item in values {
+        try validateText(item.label, maximum: 80)
+        try validateText(item.value, maximum: 320, required: true)
+    }
+}
+
+private func validateCard(_ card: Card) throws {
+    for value in [card.firstName, card.middleName, card.lastName, card.nickname] {
+        try validateText(value, maximum: 160)
+    }
+    for value in [card.organization, card.department, card.jobTitle] {
+        try validateText(value, maximum: 320)
+    }
+    try validateText(card.birthday, maximum: 10)
+    try validateText(card.note, maximum: 1000)
+    guard !card.firstName.isEmpty || !card.lastName.isEmpty
+            || !card.nickname.isEmpty || !card.organization.isEmpty else {
+        throw failure("Contact needs a name, nickname, or organization", code: 6)
+    }
+    try validateLabeled(card.phones)
+    try validateLabeled(card.emails)
+    try validateLabeled(card.urls)
+    guard card.addresses.count <= maxValues else {
+        throw failure("Contacts mutation has too many postal addresses", code: 7)
+    }
+    for address in card.addresses {
+        try validateText(address.label, maximum: 80)
+        try validateText(address.street, maximum: 320)
+        try validateText(address.city, maximum: 320)
+        try validateText(address.state, maximum: 320)
+        try validateText(address.postalCode, maximum: 80)
+        try validateText(address.country, maximum: 160)
+        try validateText(address.countryCode, maximum: 8)
+        guard !address.street.isEmpty || !address.city.isEmpty || !address.state.isEmpty
+                || !address.postalCode.isEmpty || !address.country.isEmpty else {
+            throw failure("Contacts mutation contains an empty postal address", code: 8)
+        }
+    }
+}
+
+private let mutationKeys: [CNKeyDescriptor] = [
+    CNContactIdentifierKey as CNKeyDescriptor,
+    CNContactGivenNameKey as CNKeyDescriptor,
+    CNContactMiddleNameKey as CNKeyDescriptor,
+    CNContactFamilyNameKey as CNKeyDescriptor,
+    CNContactNicknameKey as CNKeyDescriptor,
+    CNContactOrganizationNameKey as CNKeyDescriptor,
+    CNContactDepartmentNameKey as CNKeyDescriptor,
+    CNContactJobTitleKey as CNKeyDescriptor,
+    CNContactBirthdayKey as CNKeyDescriptor,
+    CNContactPhoneNumbersKey as CNKeyDescriptor,
+    CNContactEmailAddressesKey as CNKeyDescriptor,
+    CNContactUrlAddressesKey as CNKeyDescriptor,
+    CNContactPostalAddressesKey as CNKeyDescriptor
+]
+
+private func exactContacts(_ identifiers: [String], in store: CNContactStore,
+                           keys: [CNKeyDescriptor]) throws -> [CNContact] {
+    let request = CNContactFetchRequest(keysToFetch: keys)
+    request.predicate = CNContact.predicateForContacts(withIdentifiers: identifiers)
+    request.unifyResults = false
+    var byIdentifier: [String: CNContact] = [:]
+    try store.enumerateContacts(with: request) { contact, _ in
+        guard identifiers.contains(contact.identifier), byIdentifier[contact.identifier] == nil else {
+            return
+        }
+        byIdentifier[contact.identifier] = contact
+    }
+    return identifiers.compactMap { byIdentifier[$0] }
+}
+
+private func exactContact(_ identifier: String, in store: CNContactStore,
+                          keys: [CNKeyDescriptor]) throws -> CNContact {
+    let contacts = try exactContacts([identifier], in: store, keys: keys)
+    guard contacts.count == 1, contacts[0].identifier == identifier else {
+        throw failure("A selected Contacts source card no longer exists", code: 9)
+    }
+    return contacts[0]
+}
+
+private func containerIdentifier(for contact: CNContact, in store: CNContactStore) throws -> String {
+    let predicate = CNContainer.predicateForContainerOfContact(withIdentifier: contact.identifier)
+    let containers = try store.containers(matching: predicate)
+    guard containers.count == 1 else {
+        throw failure("Contacts could not identify a selected card's account", code: 20)
+    }
+    return containers[0].identifier
+}
+
+private func requireMissing(_ identifiers: [String], in store: CNContactStore) throws {
+    let remaining = try exactContacts(
+        identifiers, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor]
+    )
+    if !remaining.isEmpty {
+        throw failure("Contacts did not delete every selected source card", code: 19)
+    }
+}
+
+private func dateComponents(_ value: String) throws -> DateComponents? {
+    if value.isEmpty { return nil }
+    let yearless = value.hasPrefix("--")
+    let pattern = yearless ? "^--[0-9]{2}-[0-9]{2}$" : "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    guard value.range(of: pattern, options: .regularExpression) != nil else {
+        throw failure("Contact birthday is invalid", code: 10)
+    }
+    let parts = value.split(separator: "-").compactMap { Int($0) }
+    let month = yearless ? parts[0] : parts[1]
+    let day = yearless ? parts[1] : parts[2]
+    guard (1...12).contains(month), (1...31).contains(day) else {
+        throw failure("Contact birthday is invalid", code: 10)
+    }
+    var result = DateComponents()
+    if !yearless { result.year = parts[0] }
+    result.month = month
+    result.day = day
+    return result
+}
+
+// Reuse the contact's own CNLabeledValue objects for unchanged label+value
+// pairs instead of rebuilding every collection. Replacing a value Contacts
+// already has forces contactsd to fault the old row out and delete it — and
+// one dangling stored row then fails the WHOLE save with Cocoa 134092
+// ("Unhandled error occurred during faulting"), persistently, even when the
+// new values are identical. Verified live 2026-09-03: an update sending a
+// card's exact current values failed on every attempt until unchanged rows
+// were left untouched. (The JXA editor learned the same lesson earlier:
+// unchanged collections retain their source fields.)
+// Contacts.app's scripting layer reports an UNLABELED value under a default
+// kind name — an email stored with label "" comes back as "Email", an
+// unlabeled phone as "Phone" (observed live 2026-09-03). Drafts built from
+// that view must not write those names back as literal custom labels, and
+// must still MATCH the unlabeled source rows, so kind-default names
+// normalize to nil on both sides of the comparison.
+private func normalizedLabel(_ label: String?, defaults: [String]) -> String? {
+    guard let label = label, !label.isEmpty, !defaults.contains(label) else { return nil }
+    return label
+}
+
+private func reuseLabeled<T: NSCopying & NSSecureCoding>(
+    _ existing: [CNLabeledValue<T>], desired: [LabeledValue], kindDefaults: [String],
+    matches: (T, String) -> Bool, build: (String) -> T
+) -> [CNLabeledValue<T>] {
+    var pool = existing
+    return desired.map { item in
+        let label = normalizedLabel(item.label, defaults: kindDefaults)
+        if let index = pool.firstIndex(where: {
+            normalizedLabel($0.label, defaults: kindDefaults) == label && matches($0.value, item.value)
+        }) {
+            return pool.remove(at: index)
+        }
+        return CNLabeledValue(label: label, value: build(item.value))
+    }
+}
+
+private func sameAddress(_ value: CNPostalAddress, _ desired: PostalAddress) -> Bool {
+    value.street == desired.street && value.city == desired.city
+        && value.state == desired.state && value.postalCode == desired.postalCode
+        && value.country == desired.country && value.isoCountryCode == desired.countryCode
+}
+
+private func apply(_ card: Card, to contact: CNMutableContact) throws {
+    if contact.givenName != card.firstName { contact.givenName = card.firstName }
+    if contact.middleName != card.middleName { contact.middleName = card.middleName }
+    if contact.familyName != card.lastName { contact.familyName = card.lastName }
+    if contact.nickname != card.nickname { contact.nickname = card.nickname }
+    if contact.organizationName != card.organization { contact.organizationName = card.organization }
+    if contact.departmentName != card.department { contact.departmentName = card.department }
+    if contact.jobTitle != card.jobTitle { contact.jobTitle = card.jobTitle }
+    // A synced birthday carries calendar/timeZone/era the draft's bare
+    // year-month-day components lack; leave an equal birthday untouched
+    // rather than rewriting it in a different encoding.
+    let birthday = try dateComponents(card.birthday)
+    let sameBirthday = (birthday == nil) == (contact.birthday == nil)
+        && birthday?.year == contact.birthday?.year
+        && birthday?.month == contact.birthday?.month
+        && birthday?.day == contact.birthday?.day
+    if !sameBirthday { contact.birthday = birthday }
+    let phones = reuseLabeled(contact.phoneNumbers, desired: card.phones,
+                              kindDefaults: ["Phone"],
+                              matches: { $0.stringValue == $1 },
+                              build: { CNPhoneNumber(stringValue: $0) })
+    if phones != contact.phoneNumbers { contact.phoneNumbers = phones }
+    let emails = reuseLabeled(contact.emailAddresses, desired: card.emails,
+                              kindDefaults: ["Email"],
+                              matches: { ($0 as String) == $1 },
+                              build: { $0 as NSString })
+    if emails != contact.emailAddresses { contact.emailAddresses = emails }
+    let urls = reuseLabeled(contact.urlAddresses, desired: card.urls,
+                            kindDefaults: ["Url", "URL", "Website"],
+                            matches: { ($0 as String) == $1 },
+                            build: { $0 as NSString })
+    if urls != contact.urlAddresses { contact.urlAddresses = urls }
+    var addressPool = contact.postalAddresses
+    let addresses = card.addresses.map { desired -> CNLabeledValue<CNPostalAddress> in
+        let label = normalizedLabel(desired.label, defaults: ["Address"])
+        if let index = addressPool.firstIndex(where: {
+            normalizedLabel($0.label, defaults: ["Address"]) == label && sameAddress($0.value, desired)
+        }) {
+            return addressPool.remove(at: index)
+        }
+        let address = CNMutablePostalAddress()
+        address.street = desired.street
+        address.city = desired.city
+        address.state = desired.state
+        address.postalCode = desired.postalCode
+        address.country = desired.country
+        address.isoCountryCode = desired.countryCode
+        return CNLabeledValue(label: label, value: address.copy() as! CNPostalAddress)
+    }
+    if addresses != contact.postalAddresses { contact.postalAddresses = addresses }
+}
+
+private func safeMessage(_ error: Error, stage: String) -> String {
+    let nsError = error as NSError
+    let raw: String
+    if nsError.domain == NSCocoaErrorDomain && nsError.code == 134092 {
+        raw = stage == "delete sources"
+            ? "Contacts saved the merged contact but could not delete an old source card; reload the cards and try again"
+            : "Contacts could not commit this save after several attempts; the card may have a damaged stored value — open it once in Contacts on the Mac, then retry"
+    } else {
+        raw = nsError.localizedDescription
+    }
+    // The stage and code make a report diagnosable without exposing content.
+    let suffix = stage.isEmpty ? "" : " (stage: \(stage), code \(nsError.code))"
+    let cleaned = raw.unicodeScalars.map { scalar -> Character in
+        if CharacterSet.controlCharacters.contains(scalar) { return " " }
+        return Character(String(scalar))
+    }
+    let body = String(cleaned).split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+    return String(body.prefix(180 - min(suffix.count, 60))) + suffix
+}
+
+var mutationStage = ""
+
+private func isTransientSaveError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == NSCocoaErrorDomain && nsError.code == 134092
+}
+
+/// Contacts throws Cocoa 134092 when a save lands while contactsd is
+/// rebuilding its unified graph or mid-account refresh — and Blip's own
+/// preflight launches Contacts.app moments earlier, which kicks off CardDAV
+/// refreshes of every account. Each retry therefore waits briefly and runs
+/// the whole stage again against a FRESH store session, refetching every
+/// object by its pinned identifier (the same medicine the cross-account
+/// delete path always needed). Anything else still fails immediately.
+private func withFreshStoreRetry(_ stage: String, attempts: Int = 3,
+                                 _ body: (CNContactStore) throws -> Void) throws {
+    for attempt in 1...attempts {
+        mutationStage = stage
+        do {
+            try body(CNContactStore())
+            return
+        } catch {
+            guard isTransientSaveError(error), attempt < attempts else { throw error }
+            usleep(attempt == 1 ? 700_000 : 1_500_000)
+        }
+    }
+}
+
+private func mutableCard(_ card: Card, uid: String, in session: CNContactStore) throws -> CNMutableContact {
+    let target = try exactContact(uid, in: session, keys: mutationKeys)
+    guard let mutable = target.mutableCopy() as? CNMutableContact else {
+        throw failure("Contacts returned a read-only target card", code: 17)
+    }
+    try apply(card, to: mutable)
+    return mutable
+}
+do {
+    let request = try JSONDecoder().decode(Request.self, from: boundedInput())
+    guard ["available", "delete", "update", "consolidate", "names", "vcard", "counts"].contains(request.operation) else {
+        throw failure("Contacts mutation operation is invalid", code: 11)
+    }
+    guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+        throw failure("Contacts access is not authorized on the Mac", code: 12)
+    }
+    let store = CNContactStore()
+
+    if request.operation == "names" {
+        guard let handles = request.handles else {
+            throw failure("Contacts name request is missing", code: 22)
+        }
+        emit(Response(ok: true, availableCount: nil, deletedCount: nil,
+                      updated: nil, error: nil,
+                      names: try resolvedNames(handles, in: store)))
+        exit(0)
+    }
+
+    if request.operation == "vcard" {
+        guard let targetUid = request.targetUid, validId(targetUid), let card = request.card else {
+            throw failure("Contacts vCard request is incomplete", code: 23)
+        }
+        try validateCard(card)
+        let keys: [CNKeyDescriptor] = [
+            CNContactIdentifierKey as CNKeyDescriptor,
+            CNContactVCardSerialization.descriptorForRequiredKeys()
+        ]
+        let target = try exactContact(targetUid, in: store, keys: keys)
+        guard let mutable = target.mutableCopy() as? CNMutableContact else {
+            throw failure("Contacts returned a read-only vCard", code: 24)
+        }
+        try apply(card, to: mutable)
+        let data = try CNContactVCardSerialization.data(with: [mutable])
+        guard !data.isEmpty, data.count <= maxVCardBytes else {
+            throw failure("The contact vCard is too large to copy", code: 25)
+        }
+        let display = [card.firstName, card.middleName, card.lastName]
+            .filter { !$0.isEmpty }.joined(separator: " ")
+        let name = !display.isEmpty ? display
+            : (!card.organization.isEmpty ? card.organization : card.nickname)
+        emit(VCardResponse(ok: true, name: name, vcard: data.base64EncodedString()),
+             maximum: maxVCardResponseBytes)
+        exit(0)
+    }
+
+    if request.operation == "update" {
+        guard let targetUid = request.targetUid, validId(targetUid), let card = request.card else {
+            throw failure("Contacts update request is incomplete", code: 26)
+        }
+        try validateCard(card)
+        _ = try exactContact(targetUid, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+        try withFreshStoreRetry("update contact") { session in
+            let save = CNSaveRequest()
+            save.update(try mutableCard(card, uid: targetUid, in: session))
+            try session.execute(save)
+        }
+        _ = try exactContact(targetUid, in: store,
+                             keys: [CNContactIdentifierKey as CNKeyDescriptor])
+        emit(Response(ok: true, availableCount: nil, deletedCount: nil,
+                      updated: true, error: nil, names: nil))
+        exit(0)
+    }
+
+    if request.operation == "counts" {
+        guard let identifiers = request.personUids else {
+            throw failure("Contacts mutation card list is missing", code: 13)
+        }
+        try validateIds(identifiers, maximum: 8)
+        let keys: [CNKeyDescriptor] = [
+            CNContactIdentifierKey as CNKeyDescriptor,
+            CNContactPhoneNumbersKey as CNKeyDescriptor,
+            CNContactEmailAddressesKey as CNKeyDescriptor,
+            CNContactUrlAddressesKey as CNKeyDescriptor,
+            CNContactPostalAddressesKey as CNKeyDescriptor
+        ]
+        let contacts = try exactContacts(identifiers, in: store, keys: keys)
+        guard contacts.count == identifiers.count else {
+            throw failure("A selected Contacts source card no longer exists", code: 9)
+        }
+        emit(Response(ok: true, availableCount: nil, deletedCount: nil,
+                      updated: nil, error: nil, names: nil,
+                      counts: contacts.map { CardCounts(
+                          uid: $0.identifier,
+                          phones: $0.phoneNumbers.count,
+                          emails: $0.emailAddresses.count,
+                          urls: $0.urlAddresses.count,
+                          addresses: $0.postalAddresses.count) }),
+             maximum: 8192)
+        exit(0)
+    }
+
+    if request.operation == "available" || request.operation == "delete" {
+        guard let identifiers = request.personUids else {
+            throw failure("Contacts mutation card list is missing", code: 13)
+        }
+        try validateIds(identifiers)
+        let contacts = try exactContacts(
+            identifiers, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor]
+        )
+        guard contacts.count == identifiers.count else {
+            throw failure("A selected Contacts source card no longer exists", code: 9)
+        }
+        if request.operation == "available" {
+            emit(Response(ok: true, availableCount: contacts.count, deletedCount: nil,
+                          updated: nil, error: nil, names: nil))
+            exit(0)
+        }
+        let save = CNSaveRequest()
+        for contact in contacts {
+            guard let mutable = contact.mutableCopy() as? CNMutableContact else {
+                throw failure("Contacts returned a read-only card", code: 14)
+            }
+            save.delete(mutable)
+        }
+        mutationStage = "delete sources"
+        try store.execute(save)
+        try requireMissing(identifiers, in: store)
+        emit(Response(ok: true, availableCount: nil, deletedCount: contacts.count,
+                      updated: nil, error: nil, names: nil))
+        exit(0)
+    }
+
+    guard let targetUid = request.targetUid, validId(targetUid),
+          let sourceUids = request.sourceUids, let card = request.card else {
+        throw failure("Contacts consolidation request is incomplete", code: 15)
+    }
+    try validateIds(sourceUids)
+    guard !sourceUids.contains(targetUid) else {
+        throw failure("Contacts consolidation target is also a source", code: 16)
+    }
+    try validateCard(card)
+    let target = try exactContact(targetUid, in: store,
+                                  keys: [CNContactIdentifierKey as CNKeyDescriptor])
+    let sources = try sourceUids.map {
+        try exactContact($0, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+    }
+    let targetContainer = try containerIdentifier(for: target, in: store)
+    let sourceContainers = try sources.map { try containerIdentifier(for: $0, in: store) }
+    if sourceContainers.allSatisfy({ $0 == targetContainer }) {
+        // One atomic request: survivor update and source deletes together. A
+        // retry refetches everything in its fresh session and deletes only the
+        // sources still present — a "failed" save can turn out to have
+        // committed; requireMissing below stays the authoritative check.
+        try withFreshStoreRetry("save same-account merge") { session in
+            let save = CNSaveRequest()
+            save.update(try mutableCard(card, uid: targetUid, in: session))
+            let present = try exactContacts(
+                sourceUids, in: session, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+            for source in present {
+                guard let mutable = source.mutableCopy() as? CNMutableContact else {
+                    throw failure("Contacts returned a read-only source card", code: 18)
+                }
+                save.delete(mutable)
+            }
+            try session.execute(save)
+        }
+    } else {
+        // Contacts can reject a single CNSaveRequest that spans account-backed
+        // persistent stores. Save the complete survivor first so no source data
+        // is lost, then delete sources in one request per backing container.
+        try withFreshStoreRetry("update survivor") { session in
+            let update = CNSaveRequest()
+            update.update(try mutableCard(card, uid: targetUid, in: session))
+            try session.execute(update)
+        }
+
+        // Saving the survivor can cause Contacts to rebuild its unified-contact
+        // graph. Objects fetched before that save may then retain stale backing-
+        // store relationships and fail with Cocoa 134092 when deleted, so every
+        // attempt refetches the source cards by their pinned identifiers in its
+        // own fresh session. The fetch is lenient — an earlier partial attempt
+        // may already have removed some sources; requireMissing below stays the
+        // authoritative check that every one is gone.
+        try withFreshStoreRetry("delete sources") { session in
+            let present = try exactContacts(
+                sourceUids, in: session, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+            var grouped: [String: [CNContact]] = [:]
+            for source in present {
+                let container = try containerIdentifier(for: source, in: session)
+                grouped[container, default: []].append(source)
+            }
+            for contacts in grouped.values {
+                let deletion = CNSaveRequest()
+                for source in contacts {
+                    guard let mutable = source.mutableCopy() as? CNMutableContact else {
+                        throw failure("Contacts returned a read-only source card", code: 18)
+                    }
+                    deletion.delete(mutable)
+                }
+                try session.execute(deletion)
+            }
+        }
+    }
+    _ = try exactContact(targetUid, in: store,
+                         keys: [CNContactIdentifierKey as CNKeyDescriptor])
+    try requireMissing(sourceUids, in: store)
+    emit(Response(ok: true, availableCount: nil, deletedCount: sources.count,
+                  updated: true, error: nil, names: nil))
+} catch {
+    emit(Response(ok: false, availableCount: nil, deletedCount: nil,
+                  updated: nil, error: safeMessage(error, stage: mutationStage), names: nil,
+                  stage: mutationStage.isEmpty ? nil : mutationStage))
+    exit(1)
+}

--- a/bridge/mac/contact-link.applescript
+++ b/bridge/mac/contact-link.applescript
@@ -1,0 +1,98 @@
+-- Blip's narrowly scoped Contacts UI handoff.
+--
+-- Contacts exposes multi-card selection to AppleScript, but no link command.
+-- This helper selects exact, revalidated card ids and either reports the one
+-- Apple-provided link/merge menu action or clicks it after Blip's separate
+-- confirmation. It accepts only a fixed mode and card ids supplied by the
+-- owner-controlled Python bridge.
+
+on jsonError(messageText)
+  set cleaned to my oneLine(messageText)
+  return "{\"ok\":false,\"error\":\"" & cleaned & "\"}"
+end jsonError
+
+on oneLine(valueText)
+  set sourceText to valueText as text
+  set AppleScript's text item delimiters to {return, linefeed, tab, "\"", "\\"}
+  set pieces to text items of sourceText
+  set AppleScript's text item delimiters to " "
+  set joined to pieces as text
+  set AppleScript's text item delimiters to ""
+  if (count joined) > 160 then set joined to text 1 thru 160 of joined
+  return joined
+end oneLine
+
+on trimSpaces(valueText)
+  set resultText to valueText as text
+  repeat while resultText begins with " "
+    if (count resultText) = 1 then return ""
+    set resultText to text 2 thru -1 of resultText
+  end repeat
+  repeat while resultText ends with " "
+    if (count resultText) = 1 then return ""
+    set resultText to text 1 thru -2 of resultText
+  end repeat
+  return resultText
+end trimSpaces
+
+on run argv
+  try
+    if (count argv) < 3 or (count argv) > 10 then return my jsonError("invalid card selection")
+    set operation to item 1 of argv
+    if operation is not "prepare" and operation is not "link" then return my jsonError("invalid link operation")
+    set firstCardIndex to 2
+    set expectedAction to ""
+    if operation is "link" then
+      if (count argv) < 4 then return my jsonError("invalid card selection")
+      set expectedAction to item 2 of argv
+      if expectedAction is not "Link Selected Cards" and expectedAction is not "Merge Selected Cards" and expectedAction is not "Merge and Link Selected Cards" then return my jsonError("invalid expected link action")
+      set firstCardIndex to 3
+    end if
+
+    tell application "Contacts"
+      if unsaved then return my jsonError("Contacts has unsaved changes; finish or discard them first")
+      set selectedCards to {}
+      repeat with itemNumber from firstCardIndex to count argv
+        set personId to item itemNumber of argv
+        if not (exists person id personId) then return my jsonError("an exact Contacts card is unavailable")
+        set end of selectedCards to person id personId
+      end repeat
+      set selection to selectedCards
+      activate
+      delay 0.4
+      if (count selection) is not ((count argv) - firstCardIndex + 1) then return my jsonError("Contacts did not select every requested card")
+    end tell
+
+    tell application "System Events"
+      if UI elements enabled is false then return my jsonError("Accessibility is required for linking Contacts cards")
+      tell process "Contacts"
+        set cardMenu to menu 1 of menu bar item "Card" of menu bar 1
+        set actionItem to missing value
+        set actionName to ""
+        repeat with candidateItem in every menu item of cardMenu
+          try
+            set candidateName to my trimSpaces(name of candidateItem)
+            if candidateName is "Link Selected Cards" or candidateName is "Merge Selected Cards" or candidateName is "Merge and Link Selected Cards" then
+              set actionItem to candidateItem
+              set actionName to candidateName
+              exit repeat
+            end if
+          end try
+        end repeat
+        if actionItem is missing value then return my jsonError("Contacts does not expose a link or merge action")
+        if enabled of actionItem is false then
+          return "{\"ok\":true,\"ready\":false,\"action\":\"" & actionName & "\"}"
+        end if
+        if operation is "prepare" then
+          return "{\"ok\":true,\"ready\":true,\"action\":\"" & actionName & "\"}"
+        end if
+        if actionName is not expectedAction then return my jsonError("Contacts link action changed; review the cards again")
+        click actionItem
+      end tell
+    end tell
+    delay 0.8
+    return "{\"ok\":true,\"linked\":true,\"action\":\"" & actionName & "\"}"
+  on error messageText
+    return my jsonError(messageText)
+  end try
+end run

--- a/bridge/mac/contact-repair.js
+++ b/bridge/mac/contact-repair.js
@@ -1,0 +1,630 @@
+#!/usr/bin/osascript -l JavaScript
+/*
+ * Supported Contacts.app mutation boundary for Blip.
+ *
+ * The Python bridge sends one bounded JSON request on stdin. Raw Contacts
+ * identifiers and field values never appear in argv, and this helper emits a
+ * small JSON result only. It deliberately refuses to save while Contacts has
+ * unrelated unsaved changes.
+ */
+ObjC.import("Foundation");
+
+const MAX_INPUT_BYTES = 48 * 1024;
+const MAX_OUTPUT_BYTES = 48 * 1024;
+const MAX_FIELDS = 8;
+const MAX_PERSON_IDS = 64;
+const MAX_COMPARE_CARDS = 8;
+const MAX_VALUES_PER_KIND = 16;
+const UNSAFE = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g;
+
+function boundedString(value, label, maximum) {
+  if (typeof value !== "string" || value.length === 0 || value.length > maximum)
+    throw new Error(label + " is invalid");
+  const cleaned = value.replace(UNSAFE, " ").replace(/\s+/g, " ").trim();
+  if (!cleaned) throw new Error(label + " is invalid");
+  return cleaned;
+}
+
+function normalizePhone(value) {
+  const digits = boundedString(value, "phone value", 320).replace(/\D/g, "");
+  return digits.length >= 10 ? digits.slice(-10) : digits;
+}
+
+function normalizeEmail(value) {
+  return boundedString(value, "email value", 320).toLowerCase();
+}
+
+function readRequest() {
+  const data = $.NSFileHandle.fileHandleWithStandardInput.readDataToEndOfFile;
+  if (Number(data.length) > MAX_INPUT_BYTES) throw new Error("repair request is too large");
+  const source = ObjC.unwrap($.NSString.alloc.initWithDataEncoding(data, $.NSUTF8StringEncoding));
+  let parsed;
+  try { parsed = JSON.parse(String(source)); }
+  catch (_) { throw new Error("repair request is not valid JSON"); }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    throw new Error("repair request must be an object");
+  return parsed;
+}
+
+function normalizeRequest(value) {
+  const operation = value.operation === "available" || value.operation === "describe"
+    || value.operation === "inspect" || value.operation === "remove"
+    || value.operation === "undo" || value.operation === "edit"
+    || value.operation === "delete" || value.operation === "restore"
+    || value.operation === "consolidate" || value.operation === "undo-consolidate"
+    || value.operation === "discard-unsaved" || value.operation === "delete-fallback"
+    ? value.operation : "";
+  if (!operation) throw new Error("repair operation is invalid");
+  if (operation === "discard-unsaved") return { operation: operation };
+  if (operation === "available" || operation === "delete-fallback") {
+    if (!Array.isArray(value.personUids) || value.personUids.length < 1
+        || value.personUids.length > MAX_PERSON_IDS)
+      throw new Error("person id list is invalid");
+    const seen = {};
+    const personUids = value.personUids.map(function(uid) {
+      const normalized = boundedString(uid, "person id", 200);
+      if (seen[normalized]) throw new Error("person id list contains a duplicate");
+      seen[normalized] = true;
+      return normalized;
+    });
+    return { operation: operation, personUids: personUids };
+  }
+  if (operation === "describe") {
+    if (!Array.isArray(value.personUids) || value.personUids.length < 1
+        || value.personUids.length > MAX_COMPARE_CARDS)
+      throw new Error("comparison card list is invalid");
+    const seen = {};
+    const personUids = value.personUids.map(function(uid) {
+      const normalized = boundedString(uid, "person id", 200);
+      if (seen[normalized]) throw new Error("comparison card list contains a duplicate");
+      seen[normalized] = true;
+      return normalized;
+    });
+    return { operation: operation, personUids: personUids };
+  }
+  if (operation === "restore") {
+    return { operation: operation, card: normalizeCard(value.card, false) };
+  }
+  if (operation === "undo-consolidate") {
+    const targetUid = boundedString(value.targetUid, "target person id", 200);
+    if (!Array.isArray(value.restoreCards) || value.restoreCards.length < 1
+        || value.restoreCards.length >= MAX_COMPARE_CARDS)
+      throw new Error("restore card list is invalid");
+    return {
+      operation: operation,
+      targetUid: targetUid,
+      expectedCard: normalizeCard(value.expectedCard, true),
+      card: normalizeCard(value.card, false),
+      restoreCards: value.restoreCards.map(function(card) { return normalizeCard(card, false); })
+    };
+  }
+  if (operation === "consolidate") {
+    const targetUid = boundedString(value.targetUid, "target person id", 200);
+    if (!Array.isArray(value.sourceUids) || value.sourceUids.length < 1
+        || value.sourceUids.length >= MAX_COMPARE_CARDS)
+      throw new Error("source person id list is invalid");
+    if (!Array.isArray(value.expectedCards)
+        || value.expectedCards.length !== value.sourceUids.length + 1)
+      throw new Error("expected card list is invalid");
+    const sourceUids = value.sourceUids.map(function(uid) {
+      const normalized = boundedString(uid, "source person id", 200);
+      if (normalized === targetUid) throw new Error("target cannot also be a source card");
+      return normalized;
+    });
+    if (new Set(sourceUids).size !== sourceUids.length)
+      throw new Error("source person id list contains a duplicate");
+    const request = {
+      operation: operation,
+      targetUid: targetUid,
+      sourceUids: sourceUids,
+      expectedCards: value.expectedCards.map(function(card) { return normalizeCard(card, true); }),
+      card: normalizeCard(value.card, false)
+    };
+    return request;
+  }
+  if (operation === "edit" || operation === "delete") {
+    const request = {
+      operation: operation,
+      personUid: boundedString(value.personUid, "person id", 200),
+      expectedCard: normalizeCard(value.expectedCard, true)
+    };
+    if (operation === "edit") request.card = normalizeCard(value.card, false);
+    return request;
+  }
+  const uid = boundedString(value.personUid, "person id", 200);
+  const kind = value.kind === "phone" || value.kind === "email" ? value.kind : "";
+  if (!kind) throw new Error("repair kind is invalid");
+  const key = boundedString(value.key, "handle key", 320);
+  const request = { operation: operation, personUid: uid, kind: kind, key: key, fields: [] };
+  if (operation === "remove" || operation === "undo") {
+    if (!Array.isArray(value.fields) || value.fields.length < 1 || value.fields.length > MAX_FIELDS)
+      throw new Error("repair field list is invalid");
+    request.fields = value.fields.map(function(field) {
+      if (!field || typeof field !== "object" || Array.isArray(field))
+        throw new Error("repair field is invalid");
+      return {
+        id: operation === "remove" ? boundedString(field.id, "field id", 200) : "",
+        value: boundedString(field.value, "field value", 320),
+        label: typeof field.label === "string"
+          ? field.label.replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 80) : ""
+      };
+    });
+  }
+  return request;
+}
+
+function peopleForId(contacts, uid) {
+  const people = contacts.people.whose({ id: uid })();
+  if (!Array.isArray(people) || people.length !== 1)
+    throw new Error("the exact Contacts card is unavailable");
+  return people[0];
+}
+
+function normalizedValue(kind, value) {
+  return kind === "email" ? normalizeEmail(value) : normalizePhone(value);
+}
+
+function matchingFields(person, kind, key) {
+  const entries = kind === "email" ? person.emails() : person.phones();
+  const matches = [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    let value;
+    try { value = boundedString(entry.value(), "field value", 320); }
+    catch (_) { continue; }
+    if (normalizedValue(kind, value) !== key) continue;
+    const id = boundedString(entry.id(), "field id", 200);
+    let label = "";
+    try {
+      const rawLabel = entry.label();
+      if (typeof rawLabel === "string")
+        label = rawLabel.replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 80);
+    } catch (_) { /* labels are optional */ }
+    matches.push({ specifier: entry, id: id, value: value, label: label });
+    if (matches.length > MAX_FIELDS) throw new Error("too many matching fields on this card");
+  }
+  return matches;
+}
+
+function publicFields(fields) {
+  return fields.map(function(field) {
+    return { id: field.id, value: field.value, label: field.label };
+  });
+}
+
+function optionalString(value, label, maximum) {
+  if (value === null || value === undefined) return "";
+  if (typeof value !== "string") throw new Error(label + " is invalid");
+  if (value.length > maximum) throw new Error(label + " is too long");
+  return value.replace(UNSAFE, " ").replace(/\s+/g, " ").trim();
+}
+
+function normalizeLabeledInput(value, label) {
+  if (!Array.isArray(value) || value.length > MAX_VALUES_PER_KIND)
+    throw new Error(label + " list is invalid");
+  return value.map(function(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry))
+      throw new Error(label + " is invalid");
+    const item = {
+      label: optionalString(entry.label, label + " label", 80),
+      value: optionalString(entry.value, label + " value", 320)
+    };
+    if (!item.value) throw new Error(label + " value is empty");
+    return item;
+  });
+}
+
+function normalizeAddressInput(value) {
+  if (!Array.isArray(value) || value.length > MAX_VALUES_PER_KIND)
+    throw new Error("address list is invalid");
+  return value.map(function(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry))
+      throw new Error("address is invalid");
+    const address = {
+      label: optionalString(entry.label, "address label", 80),
+      street: optionalString(entry.street, "street", 320),
+      city: optionalString(entry.city, "city", 320),
+      state: optionalString(entry.state, "state", 320),
+      postalCode: optionalString(entry.postalCode, "postal code", 80),
+      country: optionalString(entry.country, "country", 160),
+      countryCode: optionalString(entry.countryCode, "country code", 8)
+    };
+    if (!address.street && !address.city && !address.state && !address.postalCode && !address.country)
+      throw new Error("address is empty");
+    return address;
+  });
+}
+
+function normalizeCard(value, includeDisplayName) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error("contact card is invalid");
+  const birthday = optionalString(value.birthday, "birthday", 10);
+  if (birthday && !/^(?:\d{4}\-|--)\d{2}\-\d{2}$/.test(birthday))
+    throw new Error("birthday is invalid");
+  const card = {
+    firstName: optionalString(value.firstName, "first name", 160),
+    middleName: optionalString(value.middleName, "middle name", 160),
+    lastName: optionalString(value.lastName, "last name", 160),
+    nickname: optionalString(value.nickname, "nickname", 160),
+    organization: optionalString(value.organization, "organization", 320),
+    department: optionalString(value.department, "department", 320),
+    jobTitle: optionalString(value.jobTitle, "job title", 320),
+    birthday: birthday,
+    note: optionalString(value.note, "note", 1000),
+    phones: normalizeLabeledInput(value.phones, "phone"),
+    emails: normalizeLabeledInput(value.emails, "email"),
+    urls: normalizeLabeledInput(value.urls, "URL"),
+    addresses: normalizeAddressInput(value.addresses)
+  };
+  if (!card.firstName && !card.lastName && !card.nickname && !card.organization)
+    throw new Error("contact card needs a name, nickname, or organization");
+  if (includeDisplayName)
+    card.displayName = optionalString(value.displayName, "display name", 160);
+  return card;
+}
+
+function personString(person, property, label, maximum) {
+  try { return optionalString(person[property](), label, maximum); }
+  catch (error) {
+    if (String(error).indexOf("is too long") >= 0) throw error;
+    return "";
+  }
+}
+
+function labeledValues(person, property, label) {
+  const entries = person[property]();
+  if (!Array.isArray(entries) || entries.length > MAX_VALUES_PER_KIND)
+    throw new Error("too many " + label + " values on one card");
+  return entries.map(function(entry) {
+    const value = optionalString(entry.value(), label + " value", 320);
+    let entryLabel = "";
+    try { entryLabel = optionalString(entry.label(), label + " label", 80); }
+    catch (_) { entryLabel = ""; }
+    return { label: entryLabel, value: value };
+  }).filter(function(entry) { return entry.value !== ""; });
+}
+
+function addressValues(person) {
+  const entries = person.addresses();
+  if (!Array.isArray(entries) || entries.length > MAX_VALUES_PER_KIND)
+    throw new Error("too many address values on one card");
+  return entries.map(function(entry) {
+    function piece(property, label) {
+      try { return optionalString(entry[property](), label, 320); }
+      catch (_) { return ""; }
+    }
+    return {
+      label: piece("label", "address label"),
+      street: piece("street", "street"),
+      city: piece("city", "city"),
+      state: piece("state", "state"),
+      postalCode: piece("zip", "postal code"),
+      country: piece("country", "country"),
+      countryCode: piece("countryCode", "country code")
+    };
+  }).filter(function(entry) {
+    return entry.street || entry.city || entry.state || entry.postalCode || entry.country;
+  });
+}
+
+function birthDateValue(person) {
+  let value;
+  try { value = person.birthDate(); } catch (_) { return ""; }
+  if (value === null || value === undefined) return "";
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return "";
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getFullYear();
+  return year < 1800 ? "--" + month + "-" + day : String(year).padStart(4, "0") + "-" + month + "-" + day;
+}
+
+function describePerson(person) {
+  return {
+    displayName: personString(person, "name", "display name", 160),
+    firstName: personString(person, "firstName", "first name", 160),
+    middleName: personString(person, "middleName", "middle name", 160),
+    lastName: personString(person, "lastName", "last name", 160),
+    nickname: personString(person, "nickname", "nickname", 160),
+    organization: personString(person, "organization", "organization", 320),
+    department: personString(person, "department", "department", 320),
+    jobTitle: personString(person, "jobTitle", "job title", 320),
+    birthday: birthDateValue(person),
+    note: personString(person, "note", "note", 1000),
+    phones: labeledValues(person, "phones", "phone"),
+    emails: labeledValues(person, "emails", "email"),
+    urls: labeledValues(person, "urls", "URL"),
+    addresses: addressValues(person)
+  };
+}
+
+function sameCard(person, expected) {
+  const actual = describePerson(person);
+  const keys = ["displayName", "firstName", "middleName", "lastName", "nickname",
+    "organization", "department", "jobTitle", "birthday", "note", "phones",
+    "emails", "urls", "addresses"];
+  for (let i = 0; i < keys.length; i++) {
+    if (JSON.stringify(actual[keys[i]]) !== JSON.stringify(expected[keys[i]])) return false;
+  }
+  return true;
+}
+
+function removeAll(contacts, person, property) {
+  // The remove-from-person Apple event errors with "Message not understood"
+  // on current macOS (verified live 2026-09-03); deleting the entry
+  // specifier is the pattern that works.
+  const entries = person[property]();
+  for (let i = entries.length - 1; i >= 0; i--)
+    contacts.delete(entries[i]);
+}
+
+// When every existing entry survives the edit, return just the additions so
+// setCard can skip the removal pass entirely — removing a damaged stored row
+// fails ("Message not understood") where additions still work, and existing
+// entries keep their stable field ids. Returns null when anything is removed
+// or relabeled, which forces the full replace path.
+function addedEntries(existing, desired) {
+  const pool = existing.map(function(entry) { return entry.label + "\u0000" + entry.value; });
+  const added = [];
+  for (let i = 0; i < desired.length; i++) {
+    const key = desired[i].label + "\u0000" + desired[i].value;
+    const at = pool.indexOf(key);
+    if (at >= 0) pool.splice(at, 1);
+    else added.push(desired[i]);
+  }
+  return pool.length === 0 ? added : null;
+}
+
+function sameCollection(actual, desired) {
+  return JSON.stringify(actual) === JSON.stringify(desired);
+}
+
+function birthdayDate(value) {
+  if (!value) return null;
+  const yearless = value.slice(0, 2) === "--";
+  const year = yearless ? 1604 : Number(value.slice(0, 4));
+  const month = Number(value.slice(yearless ? 2 : 5, yearless ? 4 : 7));
+  const day = Number(value.slice(yearless ? 5 : 8, yearless ? 7 : 10));
+  const date = new Date(year, month - 1, day, 12, 0, 0);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day)
+    throw new Error("birthday is invalid");
+  return date;
+}
+
+function cardStep(label, action) {
+  try {
+    action();
+  } catch (error) {
+    const detail = String(error && error.message ? error.message : error)
+      .replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 120);
+    throw new Error("Contacts could not update " + label + (detail ? ": " + detail : ""));
+  }
+}
+
+function setCard(contacts, person, card) {
+  const scalar = ["firstName", "middleName", "lastName", "nickname", "organization",
+    "department", "jobTitle", "note"];
+  for (let i = 0; i < scalar.length; i++) {
+    const property = scalar[i];
+    cardStep(property, function() { person[property].set(card[property]); });
+  }
+  cardStep("birthday", function() { person.birthDate.set(birthdayDate(card.birthday)); });
+  // Preserve collection objects (and their stable field ids) when an edit
+  // changes only a scalar such as middle name. When replacement is needed,
+  // remove the concrete specifiers returned by Contacts; calling `.at()` on
+  // the property function produces a malformed Apple event on current macOS.
+  const existingPhones = labeledValues(person, "phones", "phone");
+  const existingEmails = labeledValues(person, "emails", "email");
+  const phonesChanged = !sameCollection(existingPhones, card.phones);
+  const emailsChanged = !sameCollection(existingEmails, card.emails);
+  const urlsChanged = !sameCollection(labeledValues(person, "urls", "URL"), card.urls);
+  const addressesChanged = !sameCollection(addressValues(person), card.addresses);
+  const phonesAdded = phonesChanged ? addedEntries(existingPhones, card.phones) : [];
+  const emailsAdded = emailsChanged ? addedEntries(existingEmails, card.emails) : [];
+  if (phonesChanged && phonesAdded === null)
+    cardStep("phone numbers", function() { removeAll(contacts, person, "phones"); });
+  if (emailsChanged && emailsAdded === null)
+    cardStep("email addresses", function() { removeAll(contacts, person, "emails"); });
+  if (urlsChanged)
+    cardStep("websites", function() { removeAll(contacts, person, "urls"); });
+  if (addressesChanged)
+    cardStep("postal addresses", function() { removeAll(contacts, person, "addresses"); });
+  const phonesToWrite = phonesAdded === null ? card.phones : phonesAdded;
+  const emailsToWrite = emailsAdded === null ? card.emails : emailsAdded;
+  for (let i = 0; phonesChanged && i < phonesToWrite.length; i++) {
+    const field = phonesToWrite[i];
+    cardStep("phone number " + String(i + 1), function() { addField(contacts, person, "phone", field); });
+  }
+  for (let i = 0; emailsChanged && i < emailsToWrite.length; i++) {
+    const field = emailsToWrite[i];
+    cardStep("email address " + String(i + 1), function() { addField(contacts, person, "email", field); });
+  }
+  for (let i = 0; urlsChanged && i < card.urls.length; i++) {
+    const field = card.urls[i];
+    cardStep("website " + String(i + 1), function() {
+      const properties = { value: field.value };
+      if (field.label) properties.label = field.label;
+      person.urls.push(contacts.Url(properties));
+    });
+  }
+  for (let i = 0; addressesChanged && i < card.addresses.length; i++) {
+    const source = card.addresses[i];
+    cardStep("postal address " + String(i + 1), function() {
+      const properties = { street: source.street, city: source.city, state: source.state,
+        zip: source.postalCode, country: source.country, countryCode: source.countryCode };
+      if (source.label) properties.label = source.label;
+      person.addresses.push(contacts.Address(properties));
+    });
+  }
+}
+
+function createPerson(contacts, card) {
+  const person = contacts.Person({ firstName: card.firstName });
+  contacts.people.push(person);
+  setCard(contacts, person, card);
+  return person;
+}
+
+function sameFieldSet(actual, expected) {
+  if (actual.length !== expected.length) return false;
+  const left = actual.map(function(field) { return field.id; }).sort();
+  const right = expected.map(function(field) { return field.id; }).sort();
+  for (let i = 0; i < left.length; i++) if (left[i] !== right[i]) return false;
+  return true;
+}
+
+function addField(contacts, person, kind, field) {
+  const properties = { value: field.value };
+  if (field.label) properties.label = field.label;
+  const entry = kind === "email" ? contacts.Email(properties) : contacts.Phone(properties);
+  // The add-to-person Apple event errors with "No error. (0)" on
+  // current macOS; pushing onto the person's own collection is the pattern
+  // that works (verified live 2026-09-03, macOS 15.5).
+  person[kind === "email" ? "emails" : "phones"].push(entry);
+}
+
+function perform(request) {
+  if (request.operation === "available") {
+    // The object layer exposes only cards that Contacts can actually address;
+    // raw per-account databases can retain inactive cache rows.
+    ObjC.import("AddressBook");
+    const book = $.ABAddressBook.sharedAddressBook;
+    const available = request.personUids.filter(function(uid) {
+      try {
+        const person = book.recordForUniqueId($(uid));
+        const value = ObjC.unwrap(person);
+        return value !== undefined && value !== null;
+      } catch (_) {
+        return false;
+      }
+    });
+    return { ok: true, available: available };
+  }
+  const Contacts = Application("Contacts");
+  if (request.operation === "discard-unsaved") {
+    if (!Contacts.running() || !Contacts.unsaved())
+      return { ok: true, discarded: false };
+    // This is reachable only from Blip's explicit destructive confirmation.
+    // `saving: "no"` closes Contacts without committing its in-memory edit.
+    Contacts.quit({ saving: "no" });
+    return { ok: true, discarded: true };
+  }
+  if (request.operation === "describe") {
+    const cards = request.personUids.map(function(uid) {
+      return describePerson(peopleForId(Contacts, uid));
+    });
+    return { ok: true, cards: cards };
+  }
+  if (request.operation === "restore") {
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    const restored = createPerson(Contacts, request.card);
+    Contacts.save();
+    return { ok: true, restored: true, card: describePerson(restored) };
+  }
+  if (request.operation === "undo-consolidate") {
+    const target = peopleForId(Contacts, request.targetUid);
+    if (!sameCard(target, request.expectedCard))
+      throw new Error("the merged card changed; refresh before undoing");
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    setCard(Contacts, target, request.card);
+    for (let i = 0; i < request.restoreCards.length; i++) createPerson(Contacts, request.restoreCards[i]);
+    Contacts.save();
+    return { ok: true, restored: true, card: describePerson(target),
+      sourceCount: request.restoreCards.length };
+  }
+  if (request.operation === "delete-fallback") {
+    // CNContactStore deletion faults with Cocoa 134092 when a card holds a
+    // damaged stored row; Contacts.app itself can still remove it (verified
+    // live 2026-09-03). Native deletion stays the primary path — the caller
+    // reaches this only after it failed on exact, already-confirmed uids.
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    const doomed = request.personUids.map(function(uid) { return peopleForId(Contacts, uid); });
+    for (let i = 0; i < doomed.length; i++) Contacts.delete(doomed[i]);
+    Contacts.save();
+    return { ok: true, deletedCount: doomed.length };
+  }
+  if (request.operation === "consolidate") {
+    const people = [peopleForId(Contacts, request.targetUid)].concat(
+      request.sourceUids.map(function(uid) { return peopleForId(Contacts, uid); })
+    );
+    for (let i = 0; i < people.length; i++) {
+      if (!sameCard(people[i], request.expectedCards[i]))
+        throw new Error("a selected card changed; refresh before merging");
+    }
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    return { ok: true, readyToConsolidate: true, sourceCount: request.sourceUids.length };
+  }
+  if (request.operation === "edit" || request.operation === "delete") {
+    const editable = peopleForId(Contacts, request.personUid);
+    if (!sameCard(editable, request.expectedCard))
+      throw new Error("the selected card changed; refresh before saving");
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    if (request.operation === "delete") {
+      return { ok: true, readyToDelete: true };
+    }
+    const before = describePerson(editable);
+    try { setCard(Contacts, editable, request.card); Contacts.save(); }
+    catch (error) {
+      try { setCard(Contacts, editable, before); Contacts.save(); } catch (_) { /* original error wins */ }
+      throw error;
+    }
+    return { ok: true, edited: true, card: describePerson(editable) };
+  }
+  const person = peopleForId(Contacts, request.personUid);
+  const current = matchingFields(person, request.kind, request.key);
+
+  if (request.operation === "inspect") {
+    if (current.length < 1) throw new Error("this handle is no longer on the selected card");
+    return { ok: true, fieldCount: current.length, fields: publicFields(current) };
+  }
+
+  if (Contacts.unsaved())
+    throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+
+  if (request.operation === "remove") {
+    if (!sameFieldSet(current, request.fields))
+      throw new Error("the selected card changed; review it again before removing anything");
+    // delete-the-specifier: the remove-from-person event is broken on
+    // current macOS ("Message not understood")
+    for (let i = current.length - 1; i >= 0; i--)
+      Contacts.delete(current[i].specifier);
+    try {
+      Contacts.save();
+    } catch (error) {
+      for (let i = 0; i < request.fields.length; i++) addField(Contacts, person, request.kind, request.fields[i]);
+      try { Contacts.save(); } catch (_) { /* preserve the original failure */ }
+      throw error;
+    }
+    if (matchingFields(person, request.kind, request.key).length !== 0)
+      throw new Error("Contacts did not remove the selected handle");
+    return { ok: true, removed: true, fieldCount: current.length };
+  }
+
+  if (current.length > 0)
+    return { ok: true, restored: true, alreadyPresent: true, fieldCount: current.length };
+  for (let i = 0; i < request.fields.length; i++) addField(Contacts, person, request.kind, request.fields[i]);
+  Contacts.save();
+  const restored = matchingFields(person, request.kind, request.key);
+  if (restored.length < 1) throw new Error("Contacts did not restore the selected handle");
+  return { ok: true, restored: true, alreadyPresent: false, fieldCount: restored.length };
+}
+
+function run() {
+  try {
+    const result = perform(normalizeRequest(readRequest()));
+    const output = JSON.stringify(result);
+    if ($.NSString.alloc.initWithUTF8String(output).lengthOfBytesUsingEncoding($.NSUTF8StringEncoding) > MAX_OUTPUT_BYTES)
+      throw new Error("repair response is too large");
+    return output;
+  } catch (error) {
+    const message = String(error && error.message ? error.message : error)
+      .replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 180)
+      || "Contacts repair failed";
+    return JSON.stringify({ ok: false, error: message });
+  }
+}

--- a/bridge/mac/contacts
+++ b/bridge/mac/contacts
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-contacts: read-only Apple Contacts query tool
+contacts: bounded Apple Contacts query tool
 
 Reads ~/Library/Application Support/AddressBook/Sources/*/AddressBook-v22.abcddb
 (per-account SQLite stores). Each iCloud / CardDAV account gets its own source
@@ -11,6 +11,9 @@ Subcommands:
   find <query> [N], substring search across name/org/phone/email
   lookup <phone-or-email>, resolve to a contact (best-effort match);
                                 exit 0 + name on stdout, exit 1 if no match
+  resolve, bounded JSON identity resolver over stdin. Supports candidate
+                                lookup, opening one matching card, and an
+                                explicitly gated field-only repair with undo
   dump [--json], full dump of every contact
   sources, list configured Contacts sources
 
@@ -28,19 +31,53 @@ Examples:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import plistlib
 import re
+import secrets
+import selectors
 import sqlite3
+import stat
+import subprocess
 import sys
+import time
+import urllib.parse
 from glob import glob
 from typing import Iterable
 
 ADDRESSBOOK_DIR = os.path.expanduser(
     "~/Library/Application Support/AddressBook"
 )
+ACCOUNTS_DB = os.path.expanduser("~/Library/Accounts/Accounts4.sqlite")
 APPLE_EPOCH = 978307200  # 2001-01-01 UTC
+MAX_RESOLVE_INPUT_BYTES = 48 * 1024
+MAX_RESOLVE_OUTPUT_BYTES = 48 * 1024
+MAX_RESOLVE_SOURCES = 64
+MAX_MATCH_RECORDS = 64
+MAX_CANDIDATES = 8
+MAX_HANDLE_CHARS = 320
+MAX_NAME_CHARS = 160
+MAX_SOURCE_NAME_CHARS = 120
+MAX_REPAIR_FIELDS = 8
+MAX_AUDIT_HANDLES = 200
+MAX_REPAIR_INPUT_BYTES = 48 * 1024
+MAX_REPAIR_PROCESS_BYTES = 48 * 1024
+MAX_VCARD_BYTES = 2 * 1024 * 1024
+MAX_VCARD_RESPONSE_BYTES = 3 * 1024 * 1024
+MAX_UNDO_BYTES = 48 * 1024
+REPAIR_TIMEOUT_SECONDS = 25
+WRITE_GATE = os.path.expanduser("~/.blip/contact-writes-enabled")
+UNDO_DIR = os.path.expanduser("~/.blip/contact-undo")
+UNDO_FILE = "latest.json"
+UNDO_TTL_SECONDS = 7 * 24 * 60 * 60
+_UNSAFE_TEXT = re.compile(r"[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]")
+_CONTACT_TOKEN = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_REVISION = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_PLAN_HASH = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_UNDO_TOKEN = re.compile(r"undo:[0-9a-f]{32}\Z")
+_PERSON_UID = re.compile(r"[A-Za-z0-9._:-]{1,200}\Z")
 
 _ACCOUNTS_DB = os.path.expanduser("~/Library/Accounts/Accounts4.sqlite")
 
@@ -92,13 +129,27 @@ def _ab_sources() -> list[str]:
 
 def source_dbs() -> list[str]:
     """All AddressBook-v22.abcddb files (one per source/account), minus
-    Family Sharing child-delegate mirrors (see _child_delegate_sources)."""
+    Family Sharing child-delegate mirrors (see _child_delegate_sources).
+
+    Ordered by contact count, largest account first, so account numbering and
+    the compare/merge card order stay stable across contacts — the biggest
+    store is always card 1 instead of whichever store's folder name happens
+    to sort first. Ties and unreadable stores fall back to path order.
+    """
     paths = _ab_sources()
     # Also include the root db if non-trivial
     root = os.path.join(ADDRESSBOOK_DIR, "AddressBook-v22.abcddb")
     if os.path.exists(root):
         paths.append(root)
-    return paths
+
+    def record_count(path: str) -> int:
+        try:
+            with open_db(path) as con:
+                return int(con.execute("SELECT COUNT(*) FROM ZABCDRECORD").fetchone()[0])
+        except (sqlite3.Error, OSError, TypeError, ValueError):
+            return -1
+
+    return sorted(paths, key=lambda item: (-record_count(item), item))
 
 
 def open_db(path: str) -> sqlite3.Connection:
@@ -106,6 +157,58 @@ def open_db(path: str) -> sqlite3.Connection:
     con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
     con.row_factory = sqlite3.Row
     return con
+
+
+def source_identifier(path: str) -> str:
+    """Private stable id for one Contacts store; never emitted to Blip."""
+    parent = os.path.dirname(path)
+    if os.path.basename(os.path.dirname(parent)) == "Sources":
+        return os.path.basename(parent)
+    return "__on_my_mac__"
+
+
+def contact_source_names(paths: list[str]) -> dict[str, str]:
+    """Map private Contacts store ids to bounded user-facing account names."""
+    labels = {"__on_my_mac__": "On My Mac"}
+    wanted = {source_identifier(path) for path in paths}
+    if wanted == {"__on_my_mac__"}:
+        return labels
+    try:
+        info = os.lstat(ACCOUNTS_DB)
+        if (not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode)
+                or info.st_uid != os.getuid()):
+            return labels
+        with open_db(ACCOUNTS_DB) as con:
+            rows = con.execute(
+                """
+                SELECT a.ZIDENTIFIER AS identifier,
+                       a.ZACCOUNTDESCRIPTION AS description,
+                       a.ZUSERNAME AS username,
+                       p.ZACCOUNTDESCRIPTION AS parent_description,
+                       p.ZUSERNAME AS parent_username,
+                       t.ZACCOUNTTYPEDESCRIPTION AS account_type
+                FROM ZACCOUNT a
+                LEFT JOIN ZACCOUNTTYPE t ON t.Z_PK = a.ZACCOUNTTYPE
+                LEFT JOIN ZACCOUNT p ON p.Z_PK = a.ZPARENTACCOUNT
+                WHERE a.ZACTIVE = 1
+                """
+            ).fetchall()
+    except (OSError, sqlite3.DatabaseError):
+        return labels
+    for row in rows:
+        identifier = clean_text(row["identifier"], 200)
+        if identifier not in wanted:
+            continue
+        label = (
+            clean_text(row["parent_description"], MAX_SOURCE_NAME_CHARS)
+            or clean_text(row["description"], MAX_SOURCE_NAME_CHARS)
+            or clean_text(row["parent_username"], MAX_SOURCE_NAME_CHARS)
+            or clean_text(row["username"], MAX_SOURCE_NAME_CHARS)
+            or clean_text(row["account_type"], MAX_SOURCE_NAME_CHARS)
+        )
+        if label:
+            labels[identifier] = label
+    return labels
 
 
 def normalize_phone(s: str) -> str:
@@ -117,6 +220,1655 @@ def normalize_phone(s: str) -> str:
 
 def normalize_email(s: str) -> str:
     return (s or "").strip().lower()
+
+
+def clean_text(value: object, maximum: int) -> str:
+    """One-line, bounded text safe to retain in the long-lived QML host."""
+    text = _UNSAFE_TEXT.sub(" ", str(value or ""))
+    return re.sub(r"\s+", " ", text).strip()[:maximum]
+
+
+def normalize_resolve_handle(value: object) -> tuple[str, str, bool]:
+    handle = clean_text(value, MAX_HANDLE_CHARS + 1)
+    if not handle or len(handle) > MAX_HANDLE_CHARS:
+        raise ValueError("handle must be between 1 and 320 characters")
+    if "@" in handle:
+        key = normalize_email(handle)
+        if len(key) > 254 or not re.fullmatch(r"[^@\s]+@[^@\s]+", key):
+            raise ValueError("handle is not a valid email address")
+        return handle, key, True
+    if not re.fullmatch(r"\+?[0-9][0-9 ()./-]{2,39}", handle):
+        raise ValueError("handle is not a valid phone number")
+    key = normalize_phone(handle)
+    if len(key) < 5:
+        raise ValueError("phone handle is too short")
+    return handle, key, False
+
+
+def resolve_token(key: str, name: str) -> str:
+    digest = hashlib.sha256(
+        b"blip-contact-choice-v1\0" + key.encode("utf-8") + b"\0" + name.casefold().encode("utf-8")
+    ).hexdigest()
+    return "sha256:" + digest
+
+
+def card_token(key: str, source: str, uid: str) -> str:
+    """Opaque token for one exact source card; raw source ids never leave the Mac."""
+    digest = hashlib.sha256(
+        b"blip-contact-card-v1\0"
+        + key.encode("utf-8")
+        + b"\0"
+        + source.encode("utf-8")
+        + b"\0"
+        + uid.encode("utf-8")
+    ).hexdigest()
+    return "sha256:" + digest
+
+
+def bounded_source_dbs() -> list[str]:
+    paths = source_dbs()
+    if len(paths) > MAX_RESOLVE_SOURCES:
+        raise RuntimeError("Contacts has too many account stores to resolve safely")
+    accepted = []
+    for path in paths:
+        try:
+            info = os.lstat(path)
+        except OSError:
+            continue
+        if stat.S_ISREG(info.st_mode) and not stat.S_ISLNK(info.st_mode) and info.st_uid == os.getuid():
+            accepted.append(path)
+    return accepted
+
+
+def matching_records(handle: object) -> tuple[str, str, list[dict]]:
+    """Return a small metadata-only set; never load the complete address book."""
+    original, key, email = normalize_resolve_handle(handle)
+    matches: dict[tuple[str, str], dict] = {}
+    matched_fields = 0
+    paths = bounded_source_dbs()
+    source_names = contact_source_names(paths)
+    for path in paths:
+        if matched_fields >= MAX_MATCH_RECORDS:
+            raise RuntimeError("too many matching contact cards; refine them in Contacts")
+        try:
+            with open_db(path) as con:
+                if email:
+                    kind = "email"
+                    rows = con.execute(
+                        """
+                        SELECT r.ZUNIQUEID AS uid, r.ZFIRSTNAME AS first,
+                               r.ZLASTNAME AS last, r.ZNICKNAME AS nick,
+                               r.ZORGANIZATION AS org,
+                               r.ZMODIFICATIONDATE AS modified,
+                               CASE WHEN r.ZTHUMBNAILIMAGEDATA IS NOT NULL
+                                          OR r.ZIMAGEDATA IS NOT NULL THEN 1 ELSE 0 END AS photo,
+                               e.ZADDRESS AS value, e.ZUNIQUEID AS field_uid,
+                               e.ZLABEL AS label
+                        FROM ZABCDEMAILADDRESS e
+                        JOIN ZABCDRECORD r ON r.Z_PK = e.ZOWNER
+                        WHERE lower(e.ZADDRESS) = ?
+                        LIMIT ?
+                        """,
+                        (key, MAX_MATCH_RECORDS + 1),
+                    ).fetchall()
+                else:
+                    kind = "phone"
+                    rows = con.execute(
+                        """
+                        SELECT r.ZUNIQUEID AS uid, r.ZFIRSTNAME AS first,
+                               r.ZLASTNAME AS last, r.ZNICKNAME AS nick,
+                               r.ZORGANIZATION AS org,
+                               r.ZMODIFICATIONDATE AS modified,
+                               CASE WHEN r.ZTHUMBNAILIMAGEDATA IS NOT NULL
+                                          OR r.ZIMAGEDATA IS NOT NULL THEN 1 ELSE 0 END AS photo,
+                               p.ZFULLNUMBER AS value, p.ZUNIQUEID AS field_uid,
+                               p.ZLABEL AS label
+                        FROM ZABCDPHONENUMBER p
+                        JOIN ZABCDRECORD r ON r.Z_PK = p.ZOWNER
+                        WHERE p.ZLASTFOURDIGITS = ?
+                        LIMIT ?
+                        """,
+                        (key[-4:], MAX_MATCH_RECORDS + 1),
+                    ).fetchall()
+        except sqlite3.DatabaseError:
+            continue
+        for row in rows:
+            row_key = normalize_email(row["value"]) if email else normalize_phone(row["value"])
+            if row_key != key:
+                continue
+            matched_fields += 1
+            if matched_fields > MAX_MATCH_RECORDS:
+                raise RuntimeError("too many matching contact fields; refine them in Contacts")
+            name = clean_text(
+                " ".join(filter(None, [row["first"], row["last"]])).strip()
+                or row["org"] or row["nick"] or "",
+                MAX_NAME_CHARS,
+            )
+            uid = clean_text(row["uid"], 200)
+            if not name or not uid:
+                continue
+            source = source_identifier(path)
+            card_key = (source, uid)
+            record = matches.setdefault(card_key, {
+                "name": name,
+                "uid": uid,
+                "source": source,
+                "sourceName": source_names.get(source, "Contacts"),
+                "modified": float(row["modified"] or 0),
+                "photo": row["photo"] == 1,
+                "kind": kind,
+                "fields": [],
+            })
+            field_uid = clean_text(row["field_uid"], 200)
+            field_value = clean_text(row["value"], 320)
+            if field_uid and field_value and len(record["fields"]) < MAX_REPAIR_FIELDS:
+                record["fields"].append({
+                    "id": field_uid,
+                    "value": field_value,
+                    "label": clean_text(row["label"], 80),
+                })
+            elif len(record["fields"]) >= MAX_REPAIR_FIELDS:
+                raise RuntimeError("too many matching fields on one contact card")
+    return original, key, list(matches.values())
+
+
+def contact_candidates(handle: object) -> tuple[str, list[dict], dict[str, list[dict]]]:
+    original, key, records = matching_records(handle)
+    if records:
+        active = active_record_uids(records)
+        records = [record for record in records if record["uid"] in active]
+    by_name: dict[str, list[dict]] = {}
+    display_name: dict[str, str] = {}
+    for record in records:
+        folded = record["name"].casefold()
+        by_name.setdefault(folded, []).append(record)
+        display_name.setdefault(folded, record["name"])
+    if len(by_name) > MAX_CANDIDATES:
+        raise RuntimeError("too many possible names; refine the matching cards in Contacts")
+    candidates = []
+    # matching_records walks the stores in source_dbs() order — largest
+    # account first — so first appearance IS the global account order. Rank
+    # sources by it so account numbering and card order stay stable across
+    # every contact instead of following store UUIDs or photo recency.
+    source_rank: dict[str, int] = {}
+    for record in records:
+        source_rank.setdefault(record["source"], len(source_rank))
+    for folded, named_records in by_name.items():
+        name = display_name[folded]
+        source_numbers = {
+            source: index + 1
+            for index, source in enumerate(sorted(
+                {r["source"] for r in named_records},
+                key=lambda source: (source_rank.get(source, len(source_rank)), source),
+            ))
+        }
+        source_names = {
+            source: next((clean_text(record.get("sourceName"), MAX_SOURCE_NAME_CHARS)
+                          for record in named_records
+                          if record["source"] == source
+                          and clean_text(record.get("sourceName"), MAX_SOURCE_NAME_CHARS)), "")
+            for source in source_numbers
+        }
+        ordered_records = sorted(
+            named_records,
+            key=lambda r: (source_rank.get(r["source"], len(source_rank)),
+                           -int(r["photo"]), -r["modified"], r["uid"]),
+        )
+        # cards and the raw record list are consumed positionally together
+        # (owned_card, compare) — keep them in the SAME order
+        by_name[folded] = ordered_records
+        candidates.append({
+            "token": resolve_token(key, name),
+            "name": name,
+            "recordCount": len(named_records),
+            "sourceCount": len({r["source"] for r in named_records}),
+            "hasPhoto": any(r["photo"] for r in named_records),
+            "cards": [
+                {
+                    "token": card_token(key, record["source"], record["uid"]),
+                    "accountNumber": source_numbers[record["source"]],
+                    "sourceName": source_names[record["source"]]
+                        or f"Contact source {source_numbers[record['source']]}",
+                    "hasPhoto": record["photo"],
+                    "matchCount": max(1, len(record.get("fields", []))),
+                }
+                for record in ordered_records
+            ],
+            "_modified": max(r["modified"] for r in named_records),
+        })
+    candidates.sort(key=lambda c: (-int(c["hasPhoto"]), -c["_modified"], c["name"].casefold()))
+    for candidate in candidates:
+        del candidate["_modified"]
+    return original, candidates, by_name
+
+
+def store_fingerprint() -> str:
+    """Cheap change detector for the whole Contacts dataset: per store, the
+    row count and newest modification stamp. Any add/edit/delete moves it
+    (sync churn may too — a false miss only costs a re-scan). Lets callers
+    reuse cached cleanup-scan results when nothing changed on the Mac."""
+    parts = []
+    for path in bounded_source_dbs():
+        count, newest = -1, -1.0
+        try:
+            with open_db(path) as con:
+                row = con.execute(
+                    "SELECT COUNT(*), COALESCE(MAX(ZMODIFICATIONDATE), 0) FROM ZABCDRECORD"
+                ).fetchone()
+                count, newest = int(row[0]), float(row[1])
+        except (sqlite3.Error, OSError, TypeError, ValueError):
+            pass
+        parts.append([source_identifier(path), count, newest])
+    digest = hashlib.sha256(
+        ("blip-contact-store-v1\0" + json.dumps(parts, sort_keys=True)).encode("utf-8")
+    ).hexdigest()
+    return "sha256:" + digest
+
+
+def audit_contact_handles(value: object) -> dict:
+    """Classify a bounded handle list without changing Contacts or returning unmatched handles."""
+    if not isinstance(value, list) or not value or len(value) > MAX_AUDIT_HANDLES:
+        raise ValueError("contact audit handle list is invalid")
+    seen: set[str] = set()
+    single_cards = []
+    duplicates = []
+    conflicts = []
+    no_match_count = 0
+    for raw_handle in value:
+        original, key, _ = normalize_resolve_handle(raw_handle)
+        if key in seen:
+            raise ValueError("contact audit contains a duplicate handle")
+        seen.add(key)
+        resolved, candidates, _ = contact_candidates(original)
+        entry = {"handle": resolved, "candidates": candidates}
+        if not candidates:
+            no_match_count += 1
+        elif len(candidates) > 1:
+            conflicts.append(entry)
+        elif candidates[0]["recordCount"] > 1:
+            duplicates.append(entry)
+        else:
+            single_cards.append(entry)
+    return {
+        "handleCount": len(value),
+        "noMatchCount": no_match_count,
+        "singleCards": single_cards,
+        "duplicates": duplicates,
+        "conflicts": conflicts,
+    }
+
+
+def read_resolve_request() -> dict:
+    raw = sys.stdin.buffer.read(MAX_RESOLVE_INPUT_BYTES + 1)
+    if len(raw) > MAX_RESOLVE_INPUT_BYTES:
+        raise ValueError("identity request is too large")
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ValueError("identity request must be a JSON object")
+    if not isinstance(value, dict):
+        raise ValueError("identity request must be a JSON object")
+    return value
+
+
+def emit_resolve(value: dict, maximum: int = MAX_RESOLVE_OUTPUT_BYTES) -> None:
+    output = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if len(output.encode("utf-8")) > maximum:
+        raise RuntimeError("identity response exceeded its size contract")
+    print(output)
+
+
+def selected_card(handle: object, token: object) -> tuple[str, str, dict, dict, int, int]:
+    """Freshly resolve one opaque card token to Mac-only record metadata."""
+    token_text = clean_text(token, 80)
+    if not _CONTACT_TOKEN.fullmatch(token_text):
+        raise ValueError("the selected card token is invalid")
+    original, candidates, by_name = contact_candidates(handle)
+    _, key, _ = normalize_resolve_handle(original)
+    for candidate in candidates:
+        records = sorted(
+            by_name[candidate["name"].casefold()],
+            key=lambda record: (-int(record["photo"]), -record["modified"], record["uid"]),
+        )
+        for index, record in enumerate(records):
+            if card_token(key, record["source"], record["uid"]) != token_text:
+                continue
+            return (
+                original, key, candidate, record, index + 1,
+                candidate["cards"][index]["accountNumber"],
+            )
+    raise ValueError("the selected contact card is no longer a candidate")
+
+
+def selected_candidate(handle: object, token: object) -> tuple[str, str, dict, list[dict]]:
+    """Freshly resolve one candidate token and its ordered active cards."""
+    token_text = clean_text(token, 80)
+    if not _CONTACT_TOKEN.fullmatch(token_text):
+        raise ValueError("the selected contact token is invalid")
+    original, candidates, by_name = contact_candidates(handle)
+    _, key, _ = normalize_resolve_handle(original)
+    candidate = next((item for item in candidates if item["token"] == token_text), None)
+    if candidate is None:
+        raise ValueError("the selected contact is no longer a candidate")
+    # contact_candidates already ordered these to match candidate["cards"]
+    # (largest account first); re-sorting here would de-align the two lists
+    # that are consumed positionally together.
+    records = list(by_name[candidate["name"].casefold()])
+    if len(records) != candidate["recordCount"]:
+        raise RuntimeError("Contacts returned inconsistent candidate cards")
+    return original, key, candidate, records
+
+
+def selected_candidate_pair(
+    handle: object, token: object, other_token: object,
+) -> tuple[str, str, dict, list[dict]]:
+    """Explicitly combine TWO named candidates into one merge scope.
+
+    A person can appear under two names on one handle (a married-name change
+    is the common case). Cross-name consolidation is available only when the
+    caller presents BOTH owner tokens — nothing is ever guessed — and the
+    combined cards are renumbered over the union so account numbers stay
+    unique. Everything downstream (revisions, plan hash, undo receipt) works
+    on exact card tokens and is name-agnostic.
+    """
+    other_text = clean_text(other_token, 80)
+    if not _CONTACT_TOKEN.fullmatch(other_text):
+        raise ValueError("the other contact token is invalid")
+    original, key, candidate, records = selected_candidate(handle, token)
+    if candidate["token"] == other_text:
+        raise ValueError("the other person must be a different candidate")
+    _, _, other, other_records = selected_candidate(handle, other_text)
+    paired = []
+    for cand, recs in ((candidate, records), (other, other_records)):
+        for index, record in enumerate(recs):
+            paired.append((record, dict(cand["cards"][index])))
+    # The union follows the same global account order as every other view
+    # (largest store first), not selected-person-first; the stable sort keeps
+    # each person's internal card order within a source.
+    rank = {source_identifier(path): position
+            for position, path in enumerate(bounded_source_dbs())}
+    paired.sort(key=lambda item: rank.get(item[0]["source"], len(rank)))
+    combined_sources: dict[str, int] = {}
+    for record, _ in paired:
+        combined_sources.setdefault(record["source"], len(combined_sources) + 1)
+    cards = []
+    ordered_records = []
+    for record, card in paired:
+        card["accountNumber"] = combined_sources[record["source"]]
+        cards.append(card)
+        ordered_records.append(record)
+    combined = dict(candidate)
+    combined["recordCount"] = len(ordered_records)
+    combined["sourceCount"] = len(combined_sources)
+    combined["cards"] = cards
+    return original, key, combined, ordered_records
+
+
+def selected_candidate_from_unique_handle(
+    handle: object,
+) -> tuple[str, str, dict, list[dict]]:
+    """Resolve only when one person owns the handle; never guess for vCard export."""
+    original, candidates, by_name = contact_candidates(handle)
+    if not candidates:
+        raise ValueError("no Mac contact matches this conversation")
+    if len(candidates) != 1:
+        raise ValueError("more than one person matches this handle; use Edit contact to choose one")
+    _, key, _ = normalize_resolve_handle(original)
+    candidate = candidates[0]
+    records = list(by_name[candidate["name"].casefold()])
+    if len(records) != candidate["recordCount"]:
+        raise RuntimeError("Contacts returned inconsistent candidate cards")
+    return original, key, candidate, records
+
+
+def write_gate_enabled() -> bool:
+    """The restricted SSH key gains write authority only through this Mac-local gate."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(WRITE_GATE, flags)
+    except OSError:
+        return False
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_size > 64:
+            return False
+        if info.st_mode & 0o077:
+            return False
+        data = os.read(fd, 65)
+        return data == b"enabled-v1\n"
+    finally:
+        os.close(fd)
+
+
+def require_write_gate() -> None:
+    if not write_gate_enabled():
+        raise PermissionError(
+            "Mac contact writes are disabled; enable Blip's owner-only contact-writes gate first"
+        )
+
+
+def private_directory(path: str) -> int:
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    info = os.fstat(fd)
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid():
+        os.close(fd)
+        raise RuntimeError("contact undo directory is unsafe")
+    if info.st_mode & 0o077:
+        os.fchmod(fd, 0o700)
+    return fd
+
+
+def write_undo_receipt(receipt: dict) -> str:
+    token = "undo:" + secrets.token_hex(16)
+    value = {"version": 1, "token": token, "created": int(time.time()), **receipt}
+    data = (json.dumps(value, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+    if len(data) > MAX_UNDO_BYTES:
+        raise RuntimeError("contact undo receipt is too large")
+    directory = private_directory(UNDO_DIR)
+    temp = ".latest." + secrets.token_hex(8)
+    fd = -1
+    published = False
+    try:
+        fd = os.open(
+            temp,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=directory,
+        )
+        offset = 0
+        while offset < len(data):
+            offset += os.write(fd, data[offset:])
+        os.fchmod(fd, 0o600)
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        try:
+            target = os.stat(UNDO_FILE, dir_fd=directory, follow_symlinks=False)
+            if not stat.S_ISREG(target.st_mode) or target.st_uid != os.getuid():
+                raise RuntimeError("contact undo receipt target is unsafe")
+        except FileNotFoundError:
+            pass
+        os.replace(temp, UNDO_FILE, src_dir_fd=directory, dst_dir_fd=directory)
+        published = True
+        os.fsync(directory)
+        return token
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if not published:
+            try:
+                os.unlink(temp, dir_fd=directory)
+            except OSError:
+                pass
+        os.close(directory)
+
+
+def read_undo_receipt(token: object) -> dict:
+    token_text = clean_text(token, 40)
+    if not _UNDO_TOKEN.fullmatch(token_text):
+        raise ValueError("undo token is invalid")
+    directory = private_directory(UNDO_DIR)
+    fd = -1
+    try:
+        fd = os.open(
+            UNDO_FILE,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=directory,
+        )
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_size > MAX_UNDO_BYTES:
+            raise RuntimeError("contact undo receipt is unsafe")
+        if info.st_mode & 0o077:
+            raise RuntimeError("contact undo receipt permissions are unsafe")
+        raw = os.read(fd, MAX_UNDO_BYTES + 1)
+        if len(raw) > MAX_UNDO_BYTES:
+            raise RuntimeError("contact undo receipt is too large")
+        try:
+            value = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise RuntimeError("contact undo receipt is invalid")
+        if not isinstance(value, dict) or value.get("version") != 1 or value.get("token") != token_text:
+            raise ValueError("this undo action is no longer available")
+        created = value.get("created")
+        if not isinstance(created, int) or time.time() - created > UNDO_TTL_SECONDS:
+            raise ValueError("this contact undo action has expired")
+        return value
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        os.close(directory)
+
+
+def clear_undo_receipt(token: str) -> None:
+    # Re-read through the pinned descriptor before deleting so an old UI token
+    # cannot remove a newer receipt.
+    read_undo_receipt(token)
+    directory = private_directory(UNDO_DIR)
+    try:
+        os.unlink(UNDO_FILE, dir_fd=directory)
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def run_bounded_process(
+    argv: list[str], payload: bytes, output_limit: int = MAX_REPAIR_PROCESS_BYTES,
+) -> tuple[int, bytes, bytes]:
+    """Drain both pipes incrementally, kill at either cap, and keep a total deadline."""
+    process = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdin is not None and process.stdout is not None and process.stderr is not None
+    selector = None
+    try:
+        process.stdin.write(payload)
+        process.stdin.close()
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+        selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+        output = {"stdout": bytearray(), "stderr": bytearray()}
+        deadline = time.monotonic() + REPAIR_TIMEOUT_SECONDS
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                process.kill()
+                raise RuntimeError(
+                    "Contacts automation timed out; an Allow prompt may be waiting on the Mac"
+                )
+            for key, _ in selector.select(min(0.25, remaining)):
+                chunk = os.read(key.fd, 4096)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                target = output[key.data]
+                target.extend(chunk)
+                if len(target) > output_limit:
+                    process.kill()
+                    raise RuntimeError("Contacts automation returned too much data")
+        remaining = max(0.0, deadline - time.monotonic())
+        code = process.wait(timeout=remaining)
+        return code, bytes(output["stdout"]), bytes(output["stderr"])
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        if selector is not None:
+            selector.close()
+        if not process.stdin.closed:
+            process.stdin.close()
+        process.stdout.close()
+        process.stderr.close()
+
+
+def run_contact_repair(request: dict) -> dict:
+    script = os.path.join(os.path.dirname(os.path.realpath(__file__)), "contact-repair.js")
+    info = os.lstat(script)
+    if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode) or info.st_uid != os.getuid():
+        raise RuntimeError("Contacts repair helper is unsafe")
+    payload = json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(payload) > MAX_REPAIR_INPUT_BYTES:
+        raise RuntimeError("Contacts repair request is too large")
+    code, stdout, stderr = run_bounded_process(
+        ["/usr/bin/osascript", "-l", "JavaScript", script], payload
+    )
+    try:
+        response = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        message = clean_text(stderr.decode("utf-8", "replace"), 180)
+        raise RuntimeError(message or "Contacts automation returned invalid data")
+    if code != 0 or not isinstance(response, dict) or response.get("ok") is not True:
+        raise RuntimeError(clean_text(response.get("error") if isinstance(response, dict) else "", 180)
+                           or "Contacts automation failed")
+    return response
+
+
+class NativeMutationError(RuntimeError):
+    """A contact-delete failure carrying the machine-readable stage, so the
+    caller can pick a recovery path without parsing the human message."""
+
+    def __init__(self, message: str, stage: str = ""):
+        super().__init__(message)
+        self.stage = stage
+
+
+def run_native_contact_mutation(
+    request: dict, output_limit: int = MAX_REPAIR_PROCESS_BYTES,
+) -> dict:
+    helper = os.path.join(os.path.dirname(os.path.realpath(__file__)), "contact-delete")
+    info = os.lstat(helper)
+    if (not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode)
+            or info.st_uid != os.getuid() or info.st_mode & 0o022):
+        raise RuntimeError("Contacts deletion helper is unsafe")
+    payload = json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(payload) > MAX_REPAIR_INPUT_BYTES:
+        raise RuntimeError("Contacts deletion request is too large")
+    code, stdout, stderr = run_bounded_process([helper], payload, output_limit=output_limit)
+    try:
+        response = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        message = clean_text(stderr.decode("utf-8", "replace"), 180)
+        raise RuntimeError(message or "Contacts deletion returned invalid data")
+    if code != 0 or not isinstance(response, dict) or response.get("ok") is not True:
+        message = (clean_text(response.get("error") if isinstance(response, dict) else "", 180)
+                   or "Contacts deletion failed")
+        stage = clean_text(response.get("stage") if isinstance(response, dict) else "", 40)
+        raise NativeMutationError(message, stage)
+    return response
+
+
+def run_contact_delete(person_uids: list[str]) -> dict:
+    if (not 1 <= len(person_uids) <= 7 or len(set(person_uids)) != len(person_uids)
+            or any(not _PERSON_UID.fullmatch(uid) for uid in person_uids)):
+        raise RuntimeError("Contacts deletion card list is invalid")
+    response = run_native_contact_mutation({
+        "operation": "delete", "personUids": person_uids,
+    })
+    if response.get("deletedCount") != len(person_uids):
+        raise RuntimeError("Contacts did not confirm every source-card deletion")
+    return response
+
+
+def run_contact_update(target_uid: str, draft: dict) -> dict:
+    if not _PERSON_UID.fullmatch(target_uid):
+        raise RuntimeError("Contacts update card id is invalid")
+    response = run_native_contact_mutation({
+        "operation": "update", "targetUid": target_uid,
+        "card": validated_card_draft(draft),
+    })
+    if response.get("updated") is not True:
+        raise RuntimeError("Contacts did not confirm the card update")
+    return response
+
+
+def run_contact_consolidation(target_uid: str, source_uids: list[str], draft: dict) -> dict:
+    if (not _PERSON_UID.fullmatch(target_uid) or not 1 <= len(source_uids) <= 7
+            or len(set(source_uids)) != len(source_uids) or target_uid in source_uids
+            or any(not _PERSON_UID.fullmatch(uid) for uid in source_uids)):
+        raise RuntimeError("Contacts consolidation card list is invalid")
+    response = run_native_contact_mutation({
+        "operation": "consolidate", "targetUid": target_uid,
+        "sourceUids": source_uids, "card": validated_card_draft(draft),
+    })
+    if response.get("updated") is not True or response.get("deletedCount") != len(source_uids):
+        raise RuntimeError("Contacts did not confirm the card consolidation")
+    return response
+
+
+def merged_contact_draft(details: list[dict]) -> dict:
+    """Build one deterministic export card without mutating any source card."""
+    if not details:
+        raise RuntimeError("Contacts returned no card details")
+    result = card_draft(details[0])
+    scalar_keys = (
+        "firstName", "middleName", "lastName", "nickname", "organization",
+        "department", "jobTitle", "birthday",
+    )
+    for key in scalar_keys:
+        if result[key]:
+            continue
+        result[key] = next((detail[key] for detail in details if detail[key]), "")
+    # Notes are deliberately target-only, matching consolidation semantics.
+    for key in ("phones", "emails", "urls", "addresses"):
+        combined = []
+        seen = set()
+        for detail in details:
+            for item in detail[key]:
+                if key == "addresses":
+                    identity = tuple(str(item.get(field, "")).casefold() for field in (
+                        "street", "city", "state", "postalCode", "country", "countryCode",
+                    ))
+                else:
+                    identity = str(item.get("value", "")).casefold()
+                empty_identity = not any(identity) if isinstance(identity, tuple) else not identity
+                if empty_identity:
+                    continue
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                combined.append(item)
+        result[key] = combined
+    return validated_card_draft(result)
+
+
+def contact_vcard(handle: object) -> dict:
+    original, _, candidate, records = selected_candidate_from_unique_handle(handle)
+    details = describe_records(records)
+    draft = merged_contact_draft(details)
+    response = run_native_contact_mutation({
+        "operation": "vcard", "targetUid": records[0]["uid"], "card": draft,
+    }, MAX_VCARD_RESPONSE_BYTES)
+    encoded = response.get("vcard")
+    name = clean_text(response.get("name") or candidate["name"], MAX_NAME_CHARS)
+    if not isinstance(encoded, str) or not encoded or len(encoded) > MAX_VCARD_RESPONSE_BYTES:
+        raise RuntimeError("Contacts returned an invalid vCard")
+    return {"handle": original, "name": name, "vcard": encoded}
+
+
+def active_record_uids(records: list[dict]) -> set[str]:
+    """Cards addressable through Contacts, excluding inactive account caches."""
+    uids = list(dict.fromkeys(clean_text(record.get("uid"), 200) for record in records))
+    if not uids or len(uids) > MAX_MATCH_RECORDS or any(not uid for uid in uids):
+        raise RuntimeError("Contacts returned an invalid candidate-card list")
+    result = run_contact_repair({"operation": "available", "personUids": uids})
+    available = result.get("available")
+    if not isinstance(available, list) or len(available) > len(uids):
+        raise RuntimeError("Contacts returned an invalid active-card list")
+    accepted = set()
+    permitted = set(uids)
+    for raw in available:
+        uid = clean_text(raw, 200)
+        if not uid or uid not in permitted or uid in accepted:
+            raise RuntimeError("Contacts returned an invalid active-card id")
+        accepted.add(uid)
+    return accepted
+
+
+def optional_contact_text(value: object, label: str, maximum: int) -> str:
+    if not isinstance(value, str) or len(value) > maximum:
+        raise RuntimeError(f"Contacts returned an invalid {label}")
+    return clean_text(value, maximum)
+
+
+def validated_labeled_values(value: object, label: str) -> list[dict]:
+    if not isinstance(value, list) or len(value) > 16:
+        raise RuntimeError(f"Contacts returned an invalid {label} list")
+    result = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise RuntimeError(f"Contacts returned an invalid {label}")
+        item_value = optional_contact_text(item.get("value"), f"{label} value", 320)
+        item_label = optional_contact_text(item.get("label"), f"{label} label", 80)
+        if not item_value:
+            raise RuntimeError(f"Contacts returned an empty {label}")
+        result.append({"label": item_label, "value": item_value})
+    return result
+
+
+def validated_addresses(value: object) -> list[dict]:
+    if not isinstance(value, list) or len(value) > 16:
+        raise RuntimeError("Contacts returned an invalid address list")
+    limits = {
+        "label": 80, "street": 320, "city": 320, "state": 320,
+        "postalCode": 80, "country": 160, "countryCode": 8,
+    }
+    result = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise RuntimeError("Contacts returned an invalid address")
+        address = {
+            key: optional_contact_text(item.get(key), f"address {key}", maximum)
+            for key, maximum in limits.items()
+        }
+        if not any(address[key] for key in limits if key != "label"):
+            raise RuntimeError("Contacts returned an empty address")
+        result.append(address)
+    return result
+
+
+def validated_card_detail(value: object) -> dict:
+    if not isinstance(value, dict):
+        raise RuntimeError("Contacts returned an invalid card detail")
+    scalar_limits = {
+        "displayName": 160, "firstName": 160, "middleName": 160,
+        "lastName": 160, "nickname": 160, "organization": 320,
+        "department": 320, "jobTitle": 320, "birthday": 10, "note": 1000,
+    }
+    detail = {
+        key: optional_contact_text(value.get(key), key, maximum)
+        for key, maximum in scalar_limits.items()
+    }
+    if detail["birthday"] and not re.fullmatch(r"(?:[0-9]{4}-|--)[0-9]{2}-[0-9]{2}", detail["birthday"]):
+        raise RuntimeError("Contacts returned an invalid birthday")
+    detail["phones"] = validated_labeled_values(value.get("phones"), "phone")
+    detail["emails"] = validated_labeled_values(value.get("emails"), "email")
+    detail["urls"] = validated_labeled_values(value.get("urls"), "URL")
+    detail["addresses"] = validated_addresses(value.get("addresses"))
+    return detail
+
+
+def card_draft(detail: dict) -> dict:
+    """The writable subset of a described card; displayName is Contacts-derived."""
+    return {key: value for key, value in detail.items() if key != "displayName"}
+
+
+def validated_card_draft(value: object) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError("contact card draft is invalid")
+    # Reuse the strict detail validator with a derived-only placeholder.
+    draft = card_draft(validated_card_detail({"displayName": "", **value}))
+    if not any(draft[key] for key in ("firstName", "lastName", "nickname", "organization")):
+        raise ValueError("contact card needs a name, nickname, or organization")
+    return draft
+
+
+def card_revision(detail: dict) -> str:
+    payload = json.dumps(detail, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(
+        b"blip-contact-revision-v1\0" + payload.encode("utf-8")
+    ).hexdigest()
+
+
+def require_revision(value: object) -> str:
+    revision = clean_text(value, 80)
+    if not _REVISION.fullmatch(revision):
+        raise ValueError("contact card revision is invalid")
+    return revision
+
+
+def require_plan_hash(value: object) -> str:
+    plan = clean_text(value, 80)
+    if not _PLAN_HASH.fullmatch(plan):
+        raise ValueError("contact mutation plan is invalid")
+    return plan
+
+
+def mutation_plan_hash(action: str, value: dict) -> str:
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(
+        b"blip-contact-mutation-v1\0" + action.encode("ascii") + b"\0" + payload.encode("utf-8")
+    ).hexdigest()
+
+
+def native_collection_counts(person_uids: list[str]) -> dict[str, tuple[int, int, int, int]]:
+    """Fresh CNContactStore collection sizes per card — the authority the
+    Contacts.app describe view is checked against."""
+    response = run_native_contact_mutation({"operation": "counts", "personUids": person_uids})
+    raw = response.get("counts")
+    if not isinstance(raw, list) or len(raw) != len(person_uids):
+        raise RuntimeError("Contacts returned invalid card counts")
+    result: dict[str, tuple[int, int, int, int]] = {}
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise RuntimeError("Contacts returned invalid card counts")
+        uid = clean_text(entry.get("uid"), 200)
+        sizes = tuple(entry.get(key) for key in ("phones", "emails", "urls", "addresses"))
+        if uid == "" or not all(isinstance(size, int) and 0 <= size <= 64 for size in sizes):
+            raise RuntimeError("Contacts returned invalid card counts")
+        result[uid] = sizes  # type: ignore[assignment]
+    return result
+
+
+def describe_records(records: list[dict]) -> list[dict]:
+    """Describe cards via Contacts.app, cross-checked against CNContactStore.
+
+    The app process is long-lived and its person objects go STALE after
+    external store mutations — right after a merge it can report a card's
+    collections as empty while the scalars still read (seen live 2026-09-03;
+    an editor seeded from that view would draft field deletions). Retry the
+    describe until the app's collection sizes agree with the store, and fail
+    honestly if the view never settles.
+    """
+    if not 1 <= len(records) <= 8:
+        raise ValueError("card details require between one and eight active cards")
+    uids = [record["uid"] for record in records]
+    expected = native_collection_counts(uids)
+    details: list[dict] = []
+    for attempt in range(6):
+        if attempt:
+            time.sleep(0.5)
+        result = run_contact_repair({"operation": "describe", "personUids": uids})
+        raw_cards = result.get("cards")
+        if not isinstance(raw_cards, list) or len(raw_cards) != len(records):
+            raise RuntimeError("Contacts returned an invalid card description")
+        details = [validated_card_detail(raw) for raw in raw_cards]
+        if all(
+            (len(detail["phones"]), len(detail["emails"]),
+             len(detail["urls"]), len(detail["addresses"])) == expected.get(uid)
+            for uid, detail in zip(uids, details)
+        ):
+            return details
+    raise RuntimeError(
+        "Contacts.app is showing stale card data; give it a moment and try again")
+
+
+def same_card_content(left: dict, right: dict) -> bool:
+    """Field-for-field draft equality that ignores collection ORDER.
+
+    The native writer reuses a card's existing rows and appends additions, so
+    a merged card legitimately reads back with the same values in a different
+    sequence than the reviewed draft listed them (seen live 2026-09-03: a
+    two-email merge applied perfectly and still failed the byte-identical
+    check). The reviewed plan's contract is the content, not the sequence.
+    """
+    def canonical(detail: dict) -> dict:
+        result = {key: value for key, value in detail.items() if key != "displayName"}
+        for key in ("phones", "emails", "urls", "addresses"):
+            result[key] = sorted(
+                detail.get(key) or [],
+                key=lambda item: json.dumps(item, sort_keys=True, ensure_ascii=False),
+            )
+        return result
+    return canonical(left) == canonical(right)
+
+
+def settled_card_detail(uid: str, draft: dict) -> dict:
+    """Read a just-saved card back, tolerating Contacts.app's stale view.
+
+    Saves go through CNContactStore, but describe goes through Contacts.app,
+    whose in-memory people refresh asynchronously — an immediate read-back can
+    still show the pre-save card (verified live: a merged card that "failed"
+    verification matched the draft exactly one poll later). Poll briefly for
+    the saved draft; return the last view so the caller's equality check still
+    decides.
+    """
+    detail = None
+    last_error: Exception | None = None
+    for attempt in range(10):
+        if attempt:
+            time.sleep(0.6)
+        try:
+            detail = validated_card_detail(describe_records([{"uid": uid}])[0])
+        except (RuntimeError, ValueError) as error:
+            last_error = error
+            continue
+        if same_card_content(card_draft(detail), draft):
+            return detail
+    if detail is None:
+        raise last_error if last_error is not None else RuntimeError(
+            "Contacts returned no card details")
+    return detail
+
+
+def owned_card(
+    handle: object, owner_token: object, token: object
+) -> tuple[str, str, dict, list[dict], dict, int, int]:
+    """Resolve a card only within the selected person's current active source cards."""
+    original, key, candidate, records = selected_candidate(handle, owner_token)
+    token_text = clean_text(token, 80)
+    if not _CONTACT_TOKEN.fullmatch(token_text):
+        raise ValueError("the selected card token is invalid")
+    for index, record in enumerate(records):
+        if card_token(key, record["source"], record["uid"]) == token_text:
+            return (
+                original, key, candidate, records, record, index + 1,
+                candidate["cards"][index]["accountNumber"],
+            )
+    raise ValueError("the selected card is no longer part of this contact")
+
+
+def changed_card_fields(before: dict, after: dict) -> list[str]:
+    labels = {
+        "firstName": "first name", "middleName": "middle name", "lastName": "last name",
+        "nickname": "nickname", "organization": "organization", "department": "department",
+        "jobTitle": "job title", "birthday": "birthday", "note": "notes",
+        "phones": "phone numbers", "emails": "email addresses", "urls": "websites",
+        "addresses": "postal addresses",
+    }
+    return [labels[key] for key in labels if before.get(key) != after.get(key)]
+
+
+def contact_collections_changed(before: dict, after: dict) -> bool:
+    return any(before.get(key) != after.get(key) for key in (
+        "phones", "emails", "urls", "addresses",
+    ))
+
+
+def mutation_metadata(
+    action: str, original: str, candidate: dict, card_number: int, account_number: int,
+    source_name: str, changed: list[str], plan_hash: str, source_count: int = 0,
+) -> dict:
+    return {
+        "action": action, "handle": original, "name": candidate["name"],
+        "cardNumber": card_number, "cardCount": candidate["recordCount"],
+        "accountNumber": account_number, "sourceName": source_name,
+        "sourceCardCount": source_count,
+        "changedFields": changed, "planHash": plan_hash,
+        "writeEnabled": write_gate_enabled(),
+    }
+
+
+def compare_candidate(handle: object, owner_token: object,
+                      other_owner_token: object = None) -> dict:
+    if other_owner_token:
+        original, key, candidate, records = selected_candidate_pair(
+            handle, owner_token, other_owner_token)
+    else:
+        original, key, candidate, records = selected_candidate(handle, owner_token)
+    if not 1 <= len(records) <= 8:
+        raise ValueError("contact management requires between one and eight active cards")
+    details = describe_records(records)
+    cards = []
+    for index, (record, detail) in enumerate(zip(records, details)):
+        cards.append({
+            "token": card_token(key, record["source"], record["uid"]),
+            "revision": card_revision(detail),
+            "cardNumber": index + 1,
+            "accountNumber": candidate["cards"][index]["accountNumber"],
+            "sourceName": candidate["cards"][index]["sourceName"],
+            "hasPhoto": record["photo"],
+            **detail,
+        })
+    return {
+        "handle": original, "name": candidate["name"], "cardCount": len(cards),
+        "sourceCount": candidate["sourceCount"], "writeEnabled": write_gate_enabled(),
+        "cards": cards,
+    }
+
+
+def prepare_card_edit(
+    handle: object, owner_token: object, token: object, revision: object, draft_value: object
+) -> tuple[dict, dict]:
+    original, _, candidate, _, record, number, account = owned_card(handle, owner_token, token)
+    before = describe_records([record])[0]
+    expected = require_revision(revision)
+    if card_revision(before) != expected:
+        raise ValueError("this card changed on the Mac; refresh before saving")
+    draft = validated_card_draft(draft_value)
+    changed = changed_card_fields(card_draft(before), draft)
+    if not changed:
+        raise ValueError("this draft does not change the contact card")
+    public_plan = {
+        "token": clean_text(token, 80), "revision": expected, "card": draft,
+    }
+    plan_hash = mutation_plan_hash("edit", public_plan)
+    preview = mutation_metadata(
+        "edit", original, candidate, number, account,
+        candidate["cards"][number - 1]["sourceName"], changed, plan_hash,
+    )
+    private = {
+        "personUid": record["uid"], "before": before, "after": draft,
+        "handle": original, "name": candidate["name"], "cardToken": clean_text(token, 80),
+        "planHash": plan_hash,
+    }
+    return preview, private
+
+
+def apply_card_edit(
+    handle: object, owner_token: object, token: object, revision: object,
+    draft_value: object, expected_plan: object,
+) -> dict:
+    require_write_gate()
+    preview, private = prepare_card_edit(handle, owner_token, token, revision, draft_value)
+    if preview["planHash"] != require_plan_hash(expected_plan):
+        raise ValueError("the contact edit changed; preview it again before saving")
+    native_update = contact_collections_changed(private["before"], private["after"])
+    if native_update and private["before"]["note"] != private["after"]["note"]:
+        raise ValueError(
+            "save contact notes separately from phone, email, website, or address changes"
+        )
+    undo_token = write_undo_receipt({"action": "edit", **private})
+    if native_update:
+        run_contact_update(private["personUid"], private["after"])
+        after = settled_card_detail(private["personUid"], private["after"])
+    else:
+        result = run_contact_repair({
+            "operation": "edit", "personUid": private["personUid"],
+            "expectedCard": private["before"], "card": private["after"],
+        })
+        if result.get("edited") is not True:
+            raise RuntimeError("Contacts did not confirm the card edit")
+        after = validated_card_detail(result.get("card"))
+    if not same_card_content(card_draft(after), private["after"]):
+        raise RuntimeError("Contacts changed the contact card while saving it")
+    return {
+        **preview, "applied": True, "undoToken": undo_token,
+        "revision": card_revision(after), "displayName": after["displayName"],
+    }
+
+
+def prepare_card_delete(
+    handle: object, owner_token: object, token: object, revision: object
+) -> tuple[dict, dict]:
+    original, _, candidate, _, record, number, account = owned_card(handle, owner_token, token)
+    before = describe_records([record])[0]
+    expected = require_revision(revision)
+    if card_revision(before) != expected:
+        raise ValueError("this card changed on the Mac; refresh before deleting")
+    public_plan = {"token": clean_text(token, 80), "revision": expected}
+    plan_hash = mutation_plan_hash("delete", public_plan)
+    preview = mutation_metadata(
+        "delete", original, candidate, number, account,
+        candidate["cards"][number - 1]["sourceName"], ["entire source card"], plan_hash,
+    )
+    private = {
+        "personUid": record["uid"], "before": before, "handle": original,
+        "name": candidate["name"], "cardToken": clean_text(token, 80), "planHash": plan_hash,
+    }
+    return preview, private
+
+
+def apply_card_delete(
+    handle: object, owner_token: object, token: object, revision: object, expected_plan: object
+) -> dict:
+    require_write_gate()
+    preview, private = prepare_card_delete(handle, owner_token, token, revision)
+    if preview["planHash"] != require_plan_hash(expected_plan):
+        raise ValueError("the contact deletion changed; preview it again")
+    result = run_contact_repair({
+        "operation": "delete", "personUid": private["personUid"],
+        "expectedCard": private["before"],
+    })
+    if result.get("readyToDelete") is not True:
+        raise RuntimeError("Contacts did not confirm the deletion preflight")
+    undo_token = write_undo_receipt({"action": "delete", **private})
+    run_contact_delete([private["personUid"]])
+    return {**preview, "applied": True, "undoToken": undo_token}
+
+
+def prepare_consolidation(
+    handle: object, owner_token: object, target_token: object,
+    revisions_value: object, draft_value: object, other_owner_token: object = None,
+) -> tuple[dict, dict]:
+    if other_owner_token:
+        original, key, candidate, records = selected_candidate_pair(
+            handle, owner_token, other_owner_token)
+    else:
+        original, key, candidate, records = selected_candidate(handle, owner_token)
+    if not 2 <= len(records) <= 8:
+        raise ValueError("consolidation requires between two and eight active cards")
+    if not isinstance(revisions_value, list) or len(revisions_value) != len(records):
+        raise ValueError("contact card revision list is invalid")
+    supplied = {}
+    for item in revisions_value:
+        if not isinstance(item, dict):
+            raise ValueError("contact card revision is invalid")
+        token = clean_text(item.get("token"), 80)
+        revision = require_revision(item.get("revision"))
+        if not _CONTACT_TOKEN.fullmatch(token) or token in supplied:
+            raise ValueError("contact card revision is invalid")
+        supplied[token] = revision
+    details = describe_records(records)
+    entries = []
+    for index, (record, detail) in enumerate(zip(records, details)):
+        token = card_token(key, record["source"], record["uid"])
+        if supplied.get(token) != card_revision(detail):
+            raise ValueError("a source card changed on the Mac; refresh before merging")
+        entries.append({"token": token, "record": record, "detail": detail, "index": index})
+    target_text = clean_text(target_token, 80)
+    target = next((entry for entry in entries if entry["token"] == target_text), None)
+    if target is None:
+        raise ValueError("the merge target is no longer part of this contact")
+    draft = validated_card_draft(draft_value)
+    changed = changed_card_fields(card_draft(target["detail"]), draft)
+    if not changed:
+        changed = ["source-card consolidation"]
+    public_plan = {
+        "targetToken": target_text,
+        "revisions": [{"token": entry["token"], "revision": supplied[entry["token"]]}
+                      for entry in entries],
+        "card": draft,
+    }
+    plan_hash = mutation_plan_hash("consolidate", public_plan)
+    preview = mutation_metadata(
+        "consolidate", original, candidate, target["index"] + 1,
+        candidate["cards"][target["index"]]["accountNumber"],
+        candidate["cards"][target["index"]]["sourceName"], changed, plan_hash,
+        len(entries) - 1,
+    )
+    sources = [entry for entry in entries if entry is not target]
+    private = {
+        "targetUid": target["record"]["uid"], "targetBefore": target["detail"],
+        "targetAfter": draft, "sources": [
+            {"personUid": entry["record"]["uid"], "card": entry["detail"]} for entry in sources
+        ],
+        "handle": original, "name": candidate["name"], "planHash": plan_hash,
+    }
+    return preview, private
+
+
+def recover_consolidation_via_contacts_app(private: dict, error: NativeMutationError) -> None:
+    """Finish an approved consolidation through Contacts.app when the native
+    store path faults.
+
+    CNContactStore fails with Cocoa 134092 ("Unhandled error occurred during
+    faulting") on cards holding a damaged stored row — persistently, for any
+    real write — while Contacts.app's own write path still succeeds (verified
+    live 2026-09-03 on two real synced cards). The plan being recovered is the
+    exact reviewed one: the survivor draft is revalidated against the card's
+    current state, and only the already-confirmed source uids are removed.
+    """
+    if error.stage not in ("update contact", "update survivor",
+                           "save same-account merge", "delete sources"):
+        raise error
+    if error.stage != "delete sources":
+        current = validated_card_detail(
+            describe_records([{"uid": private["targetUid"]}])[0])
+        if card_draft(current) != private["targetAfter"]:
+            edited = run_contact_repair({
+                "operation": "edit", "personUid": private["targetUid"],
+                "expectedCard": current, "card": private["targetAfter"],
+            })
+            if edited.get("edited") is not True:
+                raise error
+    remaining = [source["personUid"] for source in private["sources"]]
+    try:
+        run_contact_delete(remaining)
+        return
+    except RuntimeError:
+        pass
+    removed = run_contact_repair({
+        "operation": "delete-fallback", "personUids": remaining,
+    })
+    if removed.get("deletedCount") != len(remaining):
+        raise error
+
+
+def apply_consolidation(
+    handle: object, owner_token: object, target_token: object, revisions: object,
+    draft: object, expected_plan: object, other_owner_token: object = None,
+) -> dict:
+    require_write_gate()
+    preview, private = prepare_consolidation(
+        handle, owner_token, target_token, revisions, draft, other_owner_token,
+    )
+    if preview["planHash"] != require_plan_hash(expected_plan):
+        raise ValueError("the merge plan changed; preview it again")
+    if private["targetBefore"]["note"] != private["targetAfter"]["note"]:
+        raise ValueError(
+            "contact notes cannot be changed during consolidation; keep the target note, "
+            "then edit it after the merge"
+        )
+    result = run_contact_repair({
+        "operation": "consolidate", "targetUid": private["targetUid"],
+        "sourceUids": [source["personUid"] for source in private["sources"]],
+        "expectedCards": [private["targetBefore"]]
+            + [source["card"] for source in private["sources"]],
+        "card": private["targetAfter"],
+    })
+    if (result.get("readyToConsolidate") is not True
+            or result.get("sourceCount") != len(private["sources"])):
+        raise RuntimeError("Contacts did not confirm the consolidation preflight")
+    undo_token = write_undo_receipt({"action": "consolidate", **private})
+    # The native helper saves and verifies the survivor before deleting source
+    # cards. For cross-account merges it issues one deletion request per source
+    # container, avoiding the CNSaveRequest cross-store failure.
+    try:
+        run_contact_consolidation(
+            private["targetUid"],
+            [source["personUid"] for source in private["sources"]],
+            private["targetAfter"],
+        )
+    except NativeMutationError as error:
+        recover_consolidation_via_contacts_app(private, error)
+    updated_card = settled_card_detail(private["targetUid"], private["targetAfter"])
+    if not same_card_content(card_draft(updated_card), private["targetAfter"]):
+        raise RuntimeError("Contacts changed the merged card while saving it")
+    after = updated_card
+    return {
+        **preview, "applied": True, "undoToken": undo_token,
+        "revision": card_revision(after), "displayName": after["displayName"],
+    }
+
+
+def run_contact_link(operation: str, records: list[dict], expected_action: object = "") -> dict:
+    if operation not in ("prepare", "link"):
+        raise ValueError("invalid contact link operation")
+    allowed = ("Link Selected Cards", "Merge Selected Cards", "Merge and Link Selected Cards")
+    expected = clean_text(expected_action, 80)
+    if operation == "link" and expected not in allowed:
+        raise ValueError("the confirmed Contacts action is invalid")
+    if operation == "prepare" and expected:
+        raise ValueError("a link preview cannot include an expected action")
+    if not 2 <= len(records) <= 8:
+        raise ValueError("linking requires between two and eight active cards")
+    uids = [clean_text(record.get("uid"), 200) for record in records]
+    if any(not _PERSON_UID.fullmatch(uid) for uid in uids) or len(set(uids)) != len(uids):
+        raise RuntimeError("Contacts returned an unsafe card identifier")
+    script = os.path.join(os.path.dirname(os.path.realpath(__file__)), "contact-link.applescript")
+    info = os.lstat(script)
+    if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode) or info.st_uid != os.getuid():
+        raise RuntimeError("Contacts link helper is unsafe")
+    argv = ["/usr/bin/osascript", script, operation]
+    if operation == "link":
+        argv.append(expected)
+    code, stdout, stderr = run_bounded_process([*argv, *uids], b"")
+    try:
+        result = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        message = clean_text(stderr.decode("utf-8", "replace"), 180)
+        raise RuntimeError(message or "Contacts link helper returned invalid data")
+    if code != 0 or not isinstance(result, dict) or result.get("ok") is not True:
+        raise RuntimeError(clean_text(result.get("error") if isinstance(result, dict) else "", 180)
+                           or "Contacts could not prepare these cards")
+    return result
+
+
+def link_candidate(
+    handle: object, owner_token: object, apply: bool, expected_action: object = ""
+) -> dict:
+    if apply:
+        require_write_gate()
+    original, _, candidate, records = selected_candidate(handle, owner_token)
+    result = run_contact_link(
+        "link" if apply else "prepare", records, expected_action if apply else ""
+    )
+    action = clean_text(result.get("action"), 80)
+    allowed = ("Link Selected Cards", "Merge Selected Cards", "Merge and Link Selected Cards")
+    if action not in allowed:
+        raise RuntimeError("Contacts returned an invalid link action")
+    if apply and action != clean_text(expected_action, 80):
+        raise RuntimeError("Contacts link action changed; review the cards again")
+    if apply and result.get("linked") is not True:
+        raise RuntimeError("Contacts did not confirm the link action")
+    if not apply and not isinstance(result.get("ready"), bool):
+        raise RuntimeError("Contacts returned an invalid link preview")
+    return {
+        "handle": original, "name": candidate["name"], "cardCount": len(records),
+        "sourceCount": candidate["sourceCount"], "writeEnabled": write_gate_enabled(),
+        "action": action,
+        **({"linked": True} if apply else {"ready": result["ready"]}),
+    }
+
+
+def validated_repair_fields(value: object, kind: str, key: str) -> list[dict]:
+    if not isinstance(value, list) or not 1 <= len(value) <= MAX_REPAIR_FIELDS:
+        raise RuntimeError("Contacts returned an invalid matching-field list")
+    fields = []
+    seen = set()
+    for raw in value:
+        if not isinstance(raw, dict):
+            raise RuntimeError("Contacts returned an invalid matching field")
+        field_id = clean_text(raw.get("id"), 200)
+        field_value = clean_text(raw.get("value"), 320)
+        label = clean_text(raw.get("label"), 80)
+        if not field_id or field_id in seen or not field_value:
+            raise RuntimeError("Contacts returned an invalid matching field")
+        normalized = normalize_email(field_value) if kind == "email" else normalize_phone(field_value)
+        if normalized != key:
+            raise RuntimeError("Contacts returned a different field value")
+        seen.add(field_id)
+        fields.append({"id": field_id, "value": field_value, "label": label})
+    return fields
+
+
+def inspect_repair(handle: object, token: object, owner_token: object) -> tuple[dict, dict, list[dict]]:
+    original, key, candidate, record, card_number, account_number = selected_card(handle, token)
+    owner_text = clean_text(owner_token, 80)
+    if not _CONTACT_TOKEN.fullmatch(owner_text):
+        raise ValueError("the selected owner token is invalid")
+    _, candidates, _ = contact_candidates(handle)
+    owner = next((option for option in candidates if option["token"] == owner_text), None)
+    if owner is None:
+        raise ValueError("the selected correct contact is no longer a candidate")
+    if owner["token"] == candidate["token"]:
+        raise ValueError("refusing to remove a handle from the selected correct contact")
+    kind = record.get("kind")
+    if kind not in ("phone", "email"):
+        raise RuntimeError("the selected card has no repairable field")
+    result = run_contact_repair({
+        "operation": "inspect", "personUid": record["uid"], "kind": kind, "key": key,
+    })
+    fields = validated_repair_fields(result.get("fields"), kind, key)
+    preview = {
+        "handle": original,
+        "name": candidate["name"],
+        "kind": kind,
+        "fieldCount": len(fields),
+        "labels": [field["label"] for field in fields],
+        "cardNumber": card_number,
+        "cardCount": candidate["recordCount"],
+        "accountNumber": account_number,
+        "sourceName": candidate["cards"][card_number - 1]["sourceName"],
+        "writeEnabled": write_gate_enabled(),
+    }
+    private = {
+        "personUid": record["uid"], "key": key, "kind": kind, "fields": fields,
+        "name": candidate["name"], "handle": original, "source": record["source"],
+        "cardToken": card_token(key, record["source"], record["uid"]),
+    }
+    return preview, private, fields
+
+
+def remove_from_contact(handle: object, token: object, owner_token: object) -> dict:
+    require_write_gate()
+    preview, private, fields = inspect_repair(handle, token, owner_token)
+    if not preview["writeEnabled"]:
+        raise PermissionError("Mac contact writes are disabled")
+    undo_token = write_undo_receipt(private)
+    result = run_contact_repair({
+        "operation": "remove",
+        "personUid": private["personUid"],
+        "kind": private["kind"],
+        "key": private["key"],
+        "fields": fields,
+    })
+    if result.get("removed") is not True or result.get("fieldCount") != len(fields):
+        raise RuntimeError("Contacts did not confirm the removal")
+    return {**preview, "removed": True, "undoToken": undo_token}
+
+
+def undo_contact_removal(token: object) -> dict:
+    require_write_gate()
+    receipt = read_undo_receipt(token)
+    action = clean_text(receipt.get("action"), 40)
+    if action == "edit":
+        before = validated_card_detail(receipt.get("before"))
+        after_draft = validated_card_draft(receipt.get("after"))
+        # The saved response's display name is derived from the applied draft.
+        current = describe_records([{"uid": clean_text(receipt.get("personUid"), 200)}])[0]
+        if card_draft(current) != after_draft:
+            raise ValueError("this card changed after the Blip edit; undo was not applied")
+        result = run_contact_repair({
+            "operation": "edit", "personUid": clean_text(receipt.get("personUid"), 200),
+            "expectedCard": current, "card": card_draft(before),
+        })
+        if result.get("edited") is not True:
+            raise RuntimeError("Contacts did not confirm the edit undo")
+        clear_undo_receipt(receipt["token"])
+        return {
+            "restored": True, "alreadyPresent": False, "action": "edit",
+            "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+            "name": clean_text(receipt.get("name"), MAX_NAME_CHARS), "cardCount": 1,
+            "fieldCount": max(1, len(changed_card_fields(after_draft, card_draft(before)))),
+        }
+    if action == "delete":
+        before = validated_card_detail(receipt.get("before"))
+        result = run_contact_repair({"operation": "restore", "card": card_draft(before)})
+        if result.get("restored") is not True:
+            raise RuntimeError("Contacts did not confirm the deleted-card restore")
+        clear_undo_receipt(receipt["token"])
+        return {
+            "restored": True, "alreadyPresent": False, "action": "delete",
+            "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+            "name": clean_text(receipt.get("name"), MAX_NAME_CHARS), "cardCount": 1,
+            "fieldCount": 1,
+        }
+    if action == "consolidate":
+        target_before = validated_card_detail(receipt.get("targetBefore"))
+        target_after = validated_card_draft(receipt.get("targetAfter"))
+        raw_sources = receipt.get("sources")
+        if not isinstance(raw_sources, list) or not 1 <= len(raw_sources) < 8:
+            raise RuntimeError("contact merge undo receipt is invalid")
+        restore_cards = []
+        for source in raw_sources:
+            if not isinstance(source, dict):
+                raise RuntimeError("contact merge undo receipt is invalid")
+            restore_cards.append(card_draft(validated_card_detail(source.get("card"))))
+        current = describe_records([{"uid": clean_text(receipt.get("targetUid"), 200)}])[0]
+        if card_draft(current) != target_after:
+            raise ValueError("the merged card changed after consolidation; undo was not applied")
+        result = run_contact_repair({
+            "operation": "undo-consolidate",
+            "targetUid": clean_text(receipt.get("targetUid"), 200),
+            "expectedCard": current, "card": card_draft(target_before),
+            "restoreCards": restore_cards,
+        })
+        if result.get("restored") is not True or result.get("sourceCount") != len(restore_cards):
+            raise RuntimeError("Contacts did not confirm the merge undo")
+        clear_undo_receipt(receipt["token"])
+        return {
+            "restored": True, "alreadyPresent": False, "action": "consolidate",
+            "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+            "name": clean_text(receipt.get("name"), MAX_NAME_CHARS),
+            "cardCount": len(restore_cards) + 1, "fieldCount": 1,
+        }
+    kind = receipt.get("kind")
+    key = clean_text(receipt.get("key"), 320)
+    fields = validated_repair_fields(receipt.get("fields"), kind, key)
+    result = run_contact_repair({
+        "operation": "undo",
+        "personUid": clean_text(receipt.get("personUid"), 200),
+        "kind": kind,
+        "key": key,
+        "fields": fields,
+    })
+    if result.get("restored") is not True:
+        raise RuntimeError("Contacts did not confirm the restore")
+    field_count = result.get("fieldCount")
+    if not isinstance(field_count, int) or not 1 <= field_count <= MAX_REPAIR_FIELDS:
+        raise RuntimeError("Contacts returned an invalid restored-field count")
+    clear_undo_receipt(receipt["token"])
+    return {
+        "restored": True,
+        "alreadyPresent": result.get("alreadyPresent") is True,
+        "action": "field-removal",
+        "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+        "name": clean_text(receipt.get("name"), MAX_NAME_CHARS),
+        "cardCount": 1,
+        "fieldCount": field_count,
+    }
+
+
+def _cmd_resolve(args):
+    request = read_resolve_request()
+    operation = request.get("operation")
+    if operation == "discard-unsaved":
+        require_write_gate()
+        result = run_contact_repair({"operation": "discard-unsaved"})
+        discarded = result.get("discarded")
+        if not isinstance(discarded, bool):
+            raise RuntimeError("Contacts returned an invalid unsaved-change result")
+        emit_resolve({"ok": True, "discarded": discarded})
+        return
+    if operation == "vcard":
+        result = contact_vcard(request.get("handle"))
+        emit_resolve({"ok": True, **result}, MAX_VCARD_RESPONSE_BYTES)
+        return
+    if operation == "candidates":
+        original, candidates, _ = contact_candidates(request.get("handle"))
+        emit_resolve({
+            "ok": True,
+            "handle": original,
+            "ambiguous": len(candidates) > 1,
+            "candidates": candidates,
+        })
+        return
+    if operation == "fingerprint":
+        emit_resolve({"ok": True, "fingerprint": store_fingerprint()})
+        return
+    if operation == "audit":
+        # fingerprint taken BEFORE the scan: a change landing mid-scan makes
+        # the next freshness check miss, which is the safe direction
+        fingerprint = store_fingerprint()
+        emit_resolve({"ok": True, "fingerprint": fingerprint,
+                      **audit_contact_handles(request.get("handles"))})
+        return
+    if operation == "open":
+        _, _, selected, selected_record, selected_card_number, selected_account_number = selected_card(
+            request.get("handle"), request.get("token")
+        )
+        url = "addressbook://" + urllib.parse.quote(selected_record["uid"], safe="")
+        result = subprocess.run(
+            ["/usr/bin/open", url], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+            text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            raise RuntimeError("Contacts.app could not open the selected card")
+        emit_resolve({
+            "ok": True,
+            "opened": True,
+            "name": selected["name"],
+            "cardNumber": selected_card_number,
+            "cardCount": selected["recordCount"],
+            "accountNumber": selected_account_number,
+            "sourceName": selected["cards"][selected_card_number - 1]["sourceName"],
+        })
+        return
+    if operation == "compare":
+        result = compare_candidate(request.get("handle"), request.get("ownerToken"),
+                                   request.get("otherOwnerToken"))
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "edit-prepare":
+        preview, _ = prepare_card_edit(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"), request.get("card"),
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "edit":
+        result = apply_card_edit(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"), request.get("card"), request.get("planHash"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "delete-prepare":
+        preview, _ = prepare_card_delete(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"),
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "delete":
+        result = apply_card_delete(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"), request.get("planHash"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "merge-prepare":
+        preview, _ = prepare_consolidation(
+            request.get("handle"), request.get("ownerToken"), request.get("targetToken"),
+            request.get("revisions"), request.get("card"), request.get("otherOwnerToken"),
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "merge":
+        result = apply_consolidation(
+            request.get("handle"), request.get("ownerToken"), request.get("targetToken"),
+            request.get("revisions"), request.get("card"), request.get("planHash"),
+            request.get("otherOwnerToken"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "link-prepare":
+        result = link_candidate(request.get("handle"), request.get("ownerToken"), False)
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "link":
+        result = link_candidate(
+            request.get("handle"), request.get("ownerToken"), True,
+            request.get("expectedAction"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "inspect":
+        preview, _, _ = inspect_repair(
+            request.get("handle"), request.get("token"), request.get("ownerToken")
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "remove":
+        result = remove_from_contact(
+            request.get("handle"), request.get("token"), request.get("ownerToken")
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "undo":
+        result = undo_contact_removal(request.get("undoToken"))
+        emit_resolve({"ok": True, **result})
+        return
+    raise ValueError(
+        "operation must be discard-unsaved, vcard, candidates, audit, open, compare, edit-prepare, edit, delete-prepare, "
+        "delete, merge-prepare, merge, link-prepare, link, inspect, remove, or undo"
+    )
+
+
+def cmd_resolve(args):
+    try:
+        _cmd_resolve(args)
+    except Exception as error:
+        message = clean_text(str(error), 180) or "contact identity operation failed"
+        try:
+            emit_resolve({"ok": False, "error": message})
+        finally:
+            raise SystemExit(1)
 
 
 def fetch_contacts(con: sqlite3.Connection) -> list[dict]:
@@ -290,24 +2042,27 @@ def cmd_dump(args):
 
 def cmd_sources(args):
     paths = source_dbs()
+    labels = contact_source_names(paths)
     if args.json:
         rows = []
         for p in paths:
+            source_name = labels.get(source_identifier(p), "Contacts")
             try:
                 with open_db(p) as con:
                     n = con.execute("SELECT COUNT(*) FROM ZABCDRECORD").fetchone()[0]
-                rows.append({"path": p, "records": n, "size": os.path.getsize(p)})
+                rows.append({"name": source_name, "records": n, "size": os.path.getsize(p)})
             except sqlite3.DatabaseError:
-                rows.append({"path": p, "error": "open failed"})
+                rows.append({"name": source_name, "error": "open failed"})
         print(json.dumps(rows, indent=2))
         return
     for p in paths:
+        source_name = labels.get(source_identifier(p), "Contacts")
         try:
             with open_db(p) as con:
                 n = con.execute("SELECT COUNT(*) FROM ZABCDRECORD").fetchone()[0]
-            print(f"{n:>6} records  {os.path.getsize(p):>12} bytes  {p}")
+            print(f"{n:>6} records  {os.path.getsize(p):>12} bytes  {source_name}")
         except sqlite3.DatabaseError as e:
-            print(f"  ERROR ({e})  {p}")
+            print(f"  ERROR ({e})  {source_name}")
 
 
 def main() -> None:
@@ -322,6 +2077,7 @@ def main() -> None:
     s = sub.add_parser("list");    s.add_argument("n", nargs="?", type=int, default=50); s.set_defaults(func=cmd_list)
     s = sub.add_parser("find");    s.add_argument("query"); s.add_argument("n", nargs="?", type=int, default=20); s.set_defaults(func=cmd_find)
     s = sub.add_parser("lookup");  s.add_argument("handle"); s.set_defaults(func=cmd_lookup)
+    s = sub.add_parser("resolve");  s.set_defaults(func=cmd_resolve)
     s = sub.add_parser("dump");    s.set_defaults(func=cmd_dump)
     s = sub.add_parser("sources"); s.set_defaults(func=cmd_sources)
 

--- a/bridge/mac/contacts_test.py
+++ b/bridge/mac/contacts_test.py
@@ -1,0 +1,980 @@
+#!/usr/bin/env python3
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "contacts")
+loader = importlib.machinery.SourceFileLoader("blip_contacts", SCRIPT)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+contacts = importlib.util.module_from_spec(spec)
+loader.exec_module(contacts)
+
+
+class Stdin:
+    def __init__(self, value: bytes):
+        self.buffer = io.BytesIO(value)
+
+
+class ContactResolverTests(unittest.TestCase):
+    def test_card_deletion_uses_the_current_contacts_framework(self):
+        script_helper = os.path.join(os.path.dirname(__file__), "contact-repair.js")
+        native_helper = os.path.join(os.path.dirname(__file__), "contact-delete.swift")
+        with open(script_helper, "r", encoding="utf-8") as stream:
+            script_source = stream.read()
+        with open(native_helper, "r", encoding="utf-8") as stream:
+            native_source = stream.read()
+        self.assertNotIn("removeRecord(", script_source)
+        # Contacts.delete() covers the person delete-fallback AND field
+        # removal — the remove-from-person Apple event is broken on current
+        # macOS ("Message not understood"), deleting the specifier works.
+        self.assertNotIn("contacts.remove(", script_source)
+        self.assertNotIn("Contacts.remove(", script_source)
+        self.assertGreaterEqual(script_source.count("delete("), 3)
+        self.assertIn('request.operation === "delete-fallback"', script_source)
+        self.assertIn('value.operation === "delete-fallback"', script_source)
+        # the add-to-person Apple event errors with "No error. (0)" on current
+        # macOS; the push pattern is the one that works
+        self.assertIn('person[kind === "email" ? "emails" : "phones"].push(entry)', script_source)
+        # add-only edits keep existing entries (and their damaged rows) untouched
+        self.assertIn("function addedEntries", script_source)
+        self.assertIn("CNSaveRequest()", native_source)
+        self.assertIn("save.delete(mutable)", native_source)
+        self.assertIn("request.unifyResults = false", native_source)
+        self.assertIn("grouped[container, default: []]", native_source)
+        # every save stage retries transient Cocoa 134092 against a FRESH
+        # store session, refetching by pinned identifier each attempt
+        self.assertIn("func withFreshStoreRetry", native_source)
+        self.assertIn("try body(CNContactStore())", native_source)
+        self.assertIn("nsError.code == 134092", native_source)
+        self.assertIn('withFreshStoreRetry("update survivor")', native_source)
+        self.assertIn('withFreshStoreRetry("delete sources")', native_source)
+        self.assertIn('withFreshStoreRetry("save same-account merge")', native_source)
+        self.assertIn("Contacts saved the merged contact but could not delete", native_source)
+        # unchanged label+value rows are REUSED, never rebuilt: replacing a value
+        # forces contactsd to fault the old row out, and one damaged stored row
+        # then fails the whole save with Cocoa 134092. Contacts.app's scripting
+        # layer also reports unlabeled values under default kind names, which
+        # must normalize back to nil instead of becoming literal custom labels.
+        self.assertIn("func reuseLabeled", native_source)
+        self.assertIn("func normalizedLabel", native_source)
+        self.assertIn('kindDefaults: ["Email"]', native_source)
+        self.assertIn('kindDefaults: ["Phone"]', native_source)
+        # residual failures name their stage and code so reports are diagnosable
+        self.assertIn("(stage: \\(stage), code \\(nsError.code))", native_source)
+
+    def test_native_deletion_uses_fixed_argv_and_private_stdin(self):
+        completed = (0, b'{"deletedCount":2,"ok":true}', b"")
+        file_info = os.stat_result((stat.S_IFREG | 0o700, 0, 0, 1, os.getuid(), 0, 1, 0, 0, 0))
+        with mock.patch.object(contacts.os, "lstat", return_value=file_info), mock.patch.object(
+            contacts, "run_bounded_process", return_value=completed,
+        ) as run:
+            result = contacts.run_contact_delete(["person-1", "person-2"])
+        argv, payload = run.call_args.args
+        self.assertEqual(len(argv), 1)
+        self.assertTrue(argv[0].endswith("contact-delete"))
+        self.assertNotIn(b"person-1", " ".join(argv).encode())
+        self.assertIn(b"person-1", payload)
+        self.assertEqual(result["deletedCount"], 2)
+
+    def test_handle_normalization(self):
+        self.assertEqual(contacts.normalize_resolve_handle("+1 (555) 010-0001")[1], "5550100001")
+        self.assertEqual(contacts.normalize_resolve_handle("Person@Example.COM")[1], "person@example.com")
+        with self.assertRaisesRegex(ValueError, "valid phone"):
+            contacts.normalize_resolve_handle("--not-a-phone")
+
+    def test_source_names_come_from_active_mac_accounts_without_exposing_ids(self):
+        with tempfile.TemporaryDirectory() as root:
+            accounts_db = os.path.join(root, "Accounts4.sqlite")
+            with sqlite3.connect(accounts_db) as con:
+                con.executescript("""
+                    CREATE TABLE ZACCOUNTTYPE (
+                        Z_PK INTEGER PRIMARY KEY,
+                        ZACCOUNTTYPEDESCRIPTION TEXT
+                    );
+                    CREATE TABLE ZACCOUNT (
+                        Z_PK INTEGER PRIMARY KEY,
+                        ZACTIVE INTEGER,
+                        ZACCOUNTTYPE INTEGER,
+                        ZPARENTACCOUNT INTEGER,
+                        ZIDENTIFIER TEXT,
+                        ZACCOUNTDESCRIPTION TEXT,
+                        ZUSERNAME TEXT
+                    );
+                    INSERT INTO ZACCOUNTTYPE VALUES (1, 'CardDAV');
+                    INSERT INTO ZACCOUNT VALUES (1, 1, 1, NULL, 'parent', 'Personal iCloud', 'private@example.com');
+                    INSERT INTO ZACCOUNT VALUES (2, 1, 1, 1, 'source-one', 'iCloud', 'private@example.com');
+                    INSERT INTO ZACCOUNT VALUES (3, 0, 1, NULL, 'inactive', 'Old account', 'old@example.com');
+                """)
+            paths = [
+                os.path.join(root, "AddressBook", "Sources", "source-one", "AddressBook-v22.abcddb"),
+                os.path.join(root, "AddressBook", "AddressBook-v22.abcddb"),
+            ]
+            with mock.patch.object(contacts, "ACCOUNTS_DB", accounts_db):
+                labels = contacts.contact_source_names(paths)
+            self.assertEqual(labels["source-one"], "Personal iCloud")
+            self.assertEqual(labels["__on_my_mac__"], "On My Mac")
+            self.assertNotIn("inactive", labels)
+            self.assertNotIn("private@example.com", json.dumps(labels))
+
+    def test_candidates_group_duplicate_cards_by_name(self):
+        records = [
+            {"name": "Alex Rivera", "uid": "one", "source": "a", "sourceName": "iCloud", "modified": 2, "photo": True},
+            {"name": "Alex Rivera", "uid": "two", "source": "b", "sourceName": "Google", "modified": 3, "photo": False},
+            {"name": "Pat Rivera", "uid": "three", "source": "b", "sourceName": "Google", "modified": 1, "photo": False},
+        ]
+        with mock.patch.object(
+            contacts, "matching_records", return_value=("+15550100001", "5550100001", records)
+        ), mock.patch.object(
+            contacts, "active_record_uids", return_value={record["uid"] for record in records}
+        ):
+            handle, candidates, by_name = contacts.contact_candidates("ignored")
+        self.assertEqual(handle, "+15550100001")
+        self.assertEqual([row["name"] for row in candidates], ["Alex Rivera", "Pat Rivera"])
+        self.assertEqual(candidates[0]["recordCount"], 2)
+        self.assertEqual(candidates[0]["sourceCount"], 2)
+        self.assertTrue(candidates[0]["hasPhoto"])
+        self.assertEqual(len(candidates[0]["cards"]), 2)
+        self.assertEqual(
+            [card["accountNumber"] for card in candidates[0]["cards"]], [1, 2]
+        )
+        self.assertEqual(
+            [card["sourceName"] for card in candidates[0]["cards"]], ["iCloud", "Google"]
+        )
+        self.assertRegex(candidates[0]["cards"][0]["token"], r"^sha256:[0-9a-f]{64}$")
+        self.assertNotEqual(candidates[0]["cards"][0]["token"], candidates[0]["token"])
+        self.assertEqual(len(by_name["alex rivera"]), 2)
+        self.assertRegex(candidates[0]["token"], r"^sha256:[0-9a-f]{64}$")
+
+    def test_candidate_counts_multiple_matching_fields_as_one_card(self):
+        records = [{
+            "name": "Alex Rivera", "uid": "one", "source": "a", "modified": 2,
+            "photo": False, "fields": [
+                {"id": "field-1", "value": "+15550100001", "label": "mobile"},
+                {"id": "field-2", "value": "5550100001", "label": "home"},
+            ],
+        }]
+        with mock.patch.object(
+            contacts, "matching_records", return_value=("+15550100001", "5550100001", records)
+        ), mock.patch.object(contacts, "active_record_uids", return_value={"one"}):
+            _, candidates, _ = contacts.contact_candidates("ignored")
+        self.assertEqual(candidates[0]["recordCount"], 1)
+        self.assertEqual(candidates[0]["cards"][0]["matchCount"], 2)
+
+    def test_candidates_exclude_inactive_account_cache_rows(self):
+        records = [
+            {"name": "Alex Rivera", "uid": "active", "source": "a", "modified": 2,
+             "photo": True, "fields": []},
+            {"name": "Mom", "uid": "inactive", "source": "b", "modified": 3,
+             "photo": True, "fields": []},
+        ]
+        with mock.patch.object(
+            contacts, "matching_records", return_value=("+15550100001", "5550100001", records)
+        ), mock.patch.object(contacts, "active_record_uids", return_value={"active"}):
+            _, candidates, by_name = contacts.contact_candidates("ignored")
+        self.assertEqual([candidate["name"] for candidate in candidates], ["Alex Rivera"])
+        self.assertNotIn("mom", by_name)
+
+    def test_contact_audit_classifies_matches_without_returning_unmatched_handles(self):
+        one = {"name": "Alex", "recordCount": 1, "sourceCount": 1, "cards": []}
+        duplicate = {"name": "Pat", "recordCount": 2, "sourceCount": 2, "cards": []}
+        conflict = {"name": "Sam", "recordCount": 1, "sourceCount": 1, "cards": []}
+        responses = {
+            "5550100001": ("+15550100001", [one], {}),
+            "5550100002": ("+15550100002", [duplicate], {}),
+            "5550100003": ("+15550100003", [one, conflict], {}),
+            "5550100004": ("+15550100004", [], {}),
+        }
+        with mock.patch.object(
+            contacts, "contact_candidates",
+            side_effect=lambda handle: responses[contacts.normalize_resolve_handle(handle)[1]],
+        ):
+            result = contacts.audit_contact_handles(list(row[0] for row in responses.values()))
+        self.assertEqual(result["handleCount"], 4)
+        self.assertEqual(result["noMatchCount"], 1)
+        self.assertEqual([row["handle"] for row in result["singleCards"]], ["+15550100001"])
+        self.assertEqual([row["handle"] for row in result["duplicates"]], ["+15550100002"])
+        self.assertEqual([row["handle"] for row in result["conflicts"]], ["+15550100003"])
+        self.assertNotIn("+15550100004", json.dumps(result))
+
+    def test_contact_audit_rejects_duplicate_or_excessive_handles(self):
+        with self.assertRaisesRegex(ValueError, "duplicate handle"):
+            contacts.audit_contact_handles(["+15550100001", "5550100001"])
+        with self.assertRaisesRegex(ValueError, "handle list"):
+            contacts.audit_contact_handles(["+15550100001"] * (contacts.MAX_AUDIT_HANDLES + 1))
+
+    def test_active_card_filter_rejects_ids_the_object_layer_did_not_receive(self):
+        records = [{"uid": "active"}, {"uid": "inactive"}]
+        with mock.patch.object(
+            contacts, "run_contact_repair", return_value={"ok": True, "available": ["other"]}
+        ):
+            with self.assertRaisesRegex(RuntimeError, "active-card id"):
+                contacts.active_record_uids(records)
+
+    def test_resolve_input_is_bounded_before_json_parse(self):
+        original = sys.stdin
+        try:
+            sys.stdin = Stdin(b" " * (contacts.MAX_RESOLVE_INPUT_BYTES + 1))
+            with self.assertRaisesRegex(ValueError, "too large"):
+                contacts.read_resolve_request()
+        finally:
+            sys.stdin = original
+
+    def test_open_uses_a_validated_addressbook_url_and_fixed_argv(self):
+        name = "Alex Rivera"
+        key = "5550100001"
+        token = contacts.resolve_token(key, name)
+        exact_token = contacts.card_token(key, "x", "A/B UUID")
+        candidate = {
+            "token": token, "name": name, "recordCount": 1,
+            "sourceCount": 1, "hasPhoto": True,
+            "cards": [{"token": exact_token, "accountNumber": 1,
+                       "sourceName": "iCloud", "hasPhoto": True}],
+        }
+        by_name = {
+            name.casefold(): [{
+                "name": name, "uid": "A/B UUID", "source": "x", "modified": 3, "photo": True,
+            }]
+        }
+        completed = subprocess.CompletedProcess([], 0, "", "")
+        with mock.patch.object(contacts, "read_resolve_request", return_value={
+            "operation": "open", "handle": "+15550100001", "token": exact_token,
+        }), mock.patch.object(
+            contacts, "contact_candidates", return_value=("+15550100001", [candidate], by_name)
+        ), mock.patch.object(contacts.subprocess, "run", return_value=completed) as run:
+            output = io.StringIO()
+            with redirect_stdout(output):
+                contacts._cmd_resolve(None)
+        argv = run.call_args.args[0]
+        self.assertEqual(argv[0], "/usr/bin/open")
+        self.assertEqual(argv[1], "addressbook://A%2FB%20UUID")
+        result = json.loads(output.getvalue())
+        self.assertEqual(result["opened"], True)
+        self.assertEqual(result["cardNumber"], 1)
+        self.assertEqual(result["cardCount"], 1)
+        self.assertEqual(result["accountNumber"], 1)
+        self.assertEqual(result["sourceName"], "iCloud")
+
+    def test_open_rejects_an_unknown_card_token_without_launching_contacts(self):
+        candidate = {
+            "token": contacts.resolve_token("5550100001", "Alex"),
+            "name": "Alex", "recordCount": 1, "sourceCount": 1, "hasPhoto": False,
+            "cards": [{
+                "token": contacts.card_token("5550100001", "x", "uid"),
+                "accountNumber": 1, "sourceName": "iCloud", "hasPhoto": False,
+            }],
+        }
+        with mock.patch.object(contacts, "read_resolve_request", return_value={
+            "operation": "open", "handle": "+15550100001", "token": "sha256:" + "f" * 64,
+        }), mock.patch.object(
+            contacts, "contact_candidates", return_value=("+15550100001", [candidate], {
+                "alex": [{"name": "Alex", "uid": "uid", "source": "x", "modified": 0, "photo": False}]
+            })
+        ), mock.patch.object(contacts.subprocess, "run") as run:
+            with self.assertRaisesRegex(ValueError, "no longer a candidate"):
+                contacts._cmd_resolve(None)
+        run.assert_not_called()
+
+    def test_discard_unsaved_requires_gate_and_reports_only_confirmation(self):
+        with mock.patch.object(
+            contacts, "read_resolve_request",
+            return_value={"operation": "discard-unsaved"},
+        ), mock.patch.object(contacts, "require_write_gate") as gate, mock.patch.object(
+            contacts, "run_contact_repair",
+            return_value={"ok": True, "discarded": True},
+        ) as repair:
+            output = io.StringIO()
+            with redirect_stdout(output):
+                contacts._cmd_resolve(None)
+        gate.assert_called_once_with()
+        repair.assert_called_once_with({"operation": "discard-unsaved"})
+        self.assertEqual(json.loads(output.getvalue()), {"ok": True, "discarded": True})
+
+    def test_write_gate_requires_an_owner_only_regular_file(self):
+        with tempfile.TemporaryDirectory() as root, mock.patch.object(
+            contacts, "WRITE_GATE", os.path.join(root, "gate")
+        ):
+            self.assertFalse(contacts.write_gate_enabled())
+            with open(contacts.WRITE_GATE, "wb") as stream:
+                stream.write(b"enabled-v1\n")
+            os.chmod(contacts.WRITE_GATE, 0o600)
+            self.assertTrue(contacts.write_gate_enabled())
+            os.chmod(contacts.WRITE_GATE, 0o644)
+            self.assertFalse(contacts.write_gate_enabled())
+            os.unlink(contacts.WRITE_GATE)
+            os.symlink(__file__, contacts.WRITE_GATE)
+            self.assertFalse(contacts.write_gate_enabled())
+
+    def test_undo_receipt_is_private_bounded_and_token_pinned(self):
+        receipt = {
+            "personUid": "person-1", "key": "5550100001", "kind": "phone",
+            "fields": [{"id": "field-1", "value": "+15550100001", "label": "mobile"}],
+            "name": "Alex Rivera", "handle": "+15550100001", "source": "source-1",
+            "cardToken": "sha256:" + "a" * 64,
+        }
+        with tempfile.TemporaryDirectory() as root, mock.patch.object(
+            contacts, "UNDO_DIR", os.path.join(root, "undo")
+        ):
+            token = contacts.write_undo_receipt(receipt)
+            self.assertRegex(token, r"^undo:[0-9a-f]{32}$")
+            self.assertEqual(contacts.read_undo_receipt(token)["personUid"], "person-1")
+            self.assertEqual(os.stat(contacts.UNDO_DIR).st_mode & 0o777, 0o700)
+            self.assertEqual(os.stat(os.path.join(contacts.UNDO_DIR, contacts.UNDO_FILE)).st_mode & 0o777, 0o600)
+            with self.assertRaisesRegex(ValueError, "no longer available"):
+                contacts.read_undo_receipt("undo:" + "f" * 32)
+            contacts.clear_undo_receipt(token)
+            self.assertFalse(os.path.exists(os.path.join(contacts.UNDO_DIR, contacts.UNDO_FILE)))
+
+    def test_automation_output_cap_kills_a_producer_before_timeout(self):
+        started = time.monotonic()
+        producer = (
+            "import os,time;"
+            f"os.write(1,b'x'*{contacts.MAX_REPAIR_PROCESS_BYTES + 1});"
+            "time.sleep(10)"
+        )
+        with self.assertRaisesRegex(RuntimeError, "too much data"):
+            contacts.run_bounded_process([sys.executable, "-c", producer], b"{}")
+        self.assertLess(time.monotonic() - started, 2)
+
+    def test_comparison_validates_details_and_keeps_raw_ids_private(self):
+        key = "5550100001"
+        candidate = {
+            "token": contacts.resolve_token(key, "Alex Rivera"),
+            "name": "Alex Rivera", "recordCount": 2, "sourceCount": 2,
+            "hasPhoto": True,
+            "cards": [
+                {"token": "sha256:" + "b" * 64, "accountNumber": 1,
+                 "sourceName": "iCloud", "hasPhoto": True},
+                {"token": "sha256:" + "c" * 64, "accountNumber": 2,
+                 "sourceName": "Google", "hasPhoto": False},
+            ],
+        }
+        records = [
+            {"uid": "private-person-one", "source": "source-one", "photo": True},
+            {"uid": "private-person-two", "source": "source-two", "photo": False},
+        ]
+        detail = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "Example",
+            "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+            "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+            "emails": [], "urls": [], "addresses": [],
+        }
+        with mock.patch.object(
+            contacts, "selected_candidate",
+            return_value=("+15550100001", key, candidate, records),
+        ), mock.patch.object(
+            contacts, "run_contact_repair", return_value={"ok": True, "cards": [detail, detail]},
+        ), mock.patch.object(
+            contacts, "native_collection_counts",
+            side_effect=lambda uids: {uid: (1, 0, 0, 0) for uid in uids},
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            result = contacts.compare_candidate("+15550100001", candidate["token"])
+        self.assertEqual(result["cardCount"], 2)
+        self.assertEqual(result["sourceCount"], 2)
+        self.assertEqual(result["cards"][0]["accountNumber"], 1)
+        self.assertEqual(result["cards"][0]["sourceName"], "iCloud")
+        self.assertRegex(result["cards"][0]["token"], r"^sha256:[0-9a-f]{64}$")
+        self.assertRegex(result["cards"][0]["revision"], r"^sha256:[0-9a-f]{64}$")
+        serialized = json.dumps(result)
+        self.assertNotIn("private-person-one", serialized)
+        self.assertNotIn("private-person-two", serialized)
+        self.assertNotIn("source-one", serialized)
+
+        hostile = dict(detail)
+        hostile["phones"] = [{"label": "x", "value": "1"}] * 17
+        with self.assertRaisesRegex(RuntimeError, "phone list"):
+            contacts.validated_card_detail(hostile)
+
+    def test_link_helper_uses_fixed_argv_and_refuses_unsafe_card_ids(self):
+        records = [{"uid": "person-1"}, {"uid": "person_2"}]
+        completed = (0, b'{"ok":true,"ready":true,"action":"Link Selected Cards"}', b"")
+        with mock.patch.object(
+            contacts, "run_bounded_process", return_value=completed,
+        ) as run:
+            result = contacts.run_contact_link("prepare", records)
+        argv, payload = run.call_args.args
+        self.assertEqual(argv[0], "/usr/bin/osascript")
+        self.assertTrue(argv[1].endswith("contact-link.applescript"))
+        self.assertEqual(argv[2:], ["prepare", "person-1", "person_2"])
+        self.assertEqual(payload, b"")
+        self.assertTrue(result["ready"])
+
+        with mock.patch.object(contacts, "run_bounded_process") as run:
+            with self.assertRaisesRegex(RuntimeError, "unsafe card identifier"):
+                contacts.run_contact_link("prepare", [{"uid": "safe"}, {"uid": "bad/value"}])
+        run.assert_not_called()
+
+    def test_link_apply_requires_gate_and_preserves_apple_action(self):
+        candidate = {
+            "name": "Alex Rivera", "sourceCount": 2,
+        }
+        selected = (
+            "+15550100001", "5550100001", candidate,
+            [{"uid": "person-1"}, {"uid": "person-2"}],
+        )
+        with mock.patch.object(
+            contacts, "selected_candidate", return_value=selected,
+        ), mock.patch.object(
+            contacts, "run_contact_link",
+            return_value={"ok": True, "ready": False, "action": "Merge Selected Cards"},
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            preview = contacts.link_candidate("+15550100001", "sha256:" + "a" * 64, False)
+        self.assertFalse(preview["ready"])
+        self.assertEqual(preview["action"], "Merge Selected Cards")
+
+        with mock.patch.object(contacts, "require_write_gate", side_effect=PermissionError("disabled")):
+            with self.assertRaisesRegex(PermissionError, "disabled"):
+                contacts.link_candidate(
+                    "+15550100001", "sha256:" + "a" * 64, True,
+                    "Merge Selected Cards",
+                )
+
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "selected_candidate", return_value=selected,
+        ), mock.patch.object(
+            contacts, "run_contact_link",
+            return_value={"ok": True, "linked": True, "action": "Link Selected Cards"},
+        ):
+            with self.assertRaisesRegex(RuntimeError, "action changed"):
+                contacts.link_candidate(
+                    "+15550100001", "sha256:" + "a" * 64, True,
+                    "Merge Selected Cards",
+                )
+
+    def test_remove_revalidates_fields_and_saves_undo_before_automation(self):
+        preview = {
+            "handle": "+15550100001", "name": "Pat Rivera", "kind": "phone",
+            "fieldCount": 1, "labels": ["mobile"], "cardNumber": 1,
+            "cardCount": 1, "accountNumber": 1, "sourceName": "iCloud",
+            "writeEnabled": True,
+        }
+        private = {
+            "personUid": "person-1", "key": "5550100001", "kind": "phone",
+            "fields": [{"id": "field-1", "value": "+15550100001", "label": "mobile"}],
+            "name": "Pat Rivera", "handle": "+15550100001", "source": "source-1",
+            "cardToken": "sha256:" + "a" * 64,
+        }
+        events = []
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "inspect_repair", return_value=(preview, private, private["fields"])
+        ), mock.patch.object(
+            contacts, "write_undo_receipt", side_effect=lambda value: events.append("receipt") or "undo:" + "b" * 32
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=lambda value: events.append("automation") or {"ok": True, "removed": True, "fieldCount": 1},
+        ):
+            result = contacts.remove_from_contact(
+                "+15550100001", private["cardToken"], "sha256:" + "c" * 64
+            )
+        self.assertEqual(events, ["receipt", "automation"])
+        self.assertTrue(result["removed"])
+        self.assertRegex(result["undoToken"], r"^undo:")
+
+    def test_inspect_refuses_the_saved_correct_contact(self):
+        key = "5550100001"
+        correct = {
+            "token": contacts.resolve_token(key, "Alex Rivera"),
+            "name": "Alex Rivera", "recordCount": 1, "sourceCount": 1,
+            "hasPhoto": False, "cards": [],
+        }
+        wrong = {
+            "token": contacts.resolve_token(key, "Pat Rivera"),
+            "name": "Pat Rivera", "recordCount": 1, "sourceCount": 1,
+            "hasPhoto": False, "cards": [],
+        }
+        record = {
+            "name": "Alex Rivera", "uid": "person-1", "source": "source-1",
+            "kind": "phone", "modified": 0, "photo": False,
+        }
+        with mock.patch.object(
+            contacts, "selected_card",
+            return_value=("+15550100001", key, correct, record, 1, 1),
+        ), mock.patch.object(
+            contacts, "contact_candidates",
+            return_value=("+15550100001", [correct, wrong], {}),
+        ), mock.patch.object(contacts, "run_contact_repair") as repair:
+            with self.assertRaisesRegex(ValueError, "selected correct contact"):
+                contacts.inspect_repair(
+                    "+15550100001", "sha256:" + "a" * 64, correct["token"]
+                )
+        repair.assert_not_called()
+
+    def test_card_edit_requires_revision_preview_and_writes_receipt_before_apply(self):
+        detail = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [{"label": "mobile", "value": "+15550100001"}],
+            "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft({**detail, "nickname": "Lex"})
+        token = "sha256:" + "b" * 64
+        owner = "sha256:" + "a" * 64
+        candidate = {
+            "name": "Alex Rivera", "recordCount": 1, "sourceCount": 1,
+            "cards": [{"accountNumber": 1, "sourceName": "iCloud"}],
+        }
+        selected = (
+            "+15550100001", "5550100001", candidate,
+            [{"uid": "person-1", "source": "source-1"}],
+            {"uid": "person-1", "source": "source-1"}, 1, 1,
+        )
+        events = []
+        edited = {**detail, "nickname": "Lex"}
+        with mock.patch.object(contacts, "owned_card", return_value=selected), mock.patch.object(
+            contacts, "describe_records", return_value=[detail]
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            preview, _ = contacts.prepare_card_edit(
+                "+15550100001", owner, token, contacts.card_revision(detail), draft
+            )
+        self.assertEqual(preview["changedFields"], ["nickname"])
+        self.assertRegex(preview["planHash"], r"^sha256:[0-9a-f]{64}$")
+
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_card_edit", return_value=(preview, {
+                "personUid": "person-1", "before": detail, "after": draft,
+                "handle": "+15550100001", "name": "Alex Rivera", "cardToken": token,
+                "planHash": preview["planHash"],
+            })
+        ), mock.patch.object(
+            contacts, "write_undo_receipt",
+            side_effect=lambda value: events.append("receipt") or "undo:" + "c" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=lambda value: events.append("automation") or {
+                "ok": True, "edited": True, "card": edited,
+            },
+        ):
+            result = contacts.apply_card_edit(
+                "+15550100001", owner, token, contacts.card_revision(detail), draft,
+                preview["planHash"],
+            )
+        self.assertEqual(events, ["receipt", "automation"])
+        self.assertTrue(result["applied"])
+
+    def test_card_collection_edit_uses_native_contacts_update(self):
+        before = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [{"label": "mobile", "value": "+15550100001"}],
+            "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft({
+            **before, "phones": [{"label": "mobile", "value": "+15550100002"}],
+        })
+        after = {**before, **draft}
+        plan = "sha256:" + "d" * 64
+        preview = {"planHash": plan, "changedFields": ["phone numbers"]}
+        private = {
+            "personUid": "person-1", "before": before, "after": draft,
+            "handle": "+15550100001", "name": "Alex Rivera",
+            "cardToken": "sha256:" + "b" * 64, "planHash": plan,
+        }
+        events = []
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_card_edit", return_value=(preview, private),
+        ), mock.patch.object(
+            contacts, "write_undo_receipt",
+            side_effect=lambda value: events.append("receipt") or "undo:" + "c" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_update",
+            side_effect=lambda uid, card: events.append("native") or {"updated": True},
+        ), mock.patch.object(contacts, "describe_records", return_value=[after]), mock.patch.object(
+            contacts, "run_contact_repair",
+        ) as automation:
+            result = contacts.apply_card_edit(
+                "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                contacts.card_revision(before), draft, plan,
+            )
+        self.assertEqual(events, ["receipt", "native"])
+        automation.assert_not_called()
+        self.assertTrue(result["applied"])
+
+    def test_consolidation_plan_pins_every_card_and_keeps_raw_ids_private(self):
+        base = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [], "emails": [], "urls": [], "addresses": [],
+        }
+        other = {**base, "emails": [{"label": "home", "value": "alex@example.com"}]}
+        key = "5550100001"
+        records = [
+            {"uid": "private-1", "source": "source-1"},
+            {"uid": "private-2", "source": "source-2"},
+        ]
+        tokens = [contacts.card_token(key, record["source"], record["uid"]) for record in records]
+        candidate = {
+            "name": "Alex Rivera", "recordCount": 2, "sourceCount": 2,
+            "cards": [{"accountNumber": 1, "sourceName": "iCloud"},
+                      {"accountNumber": 2, "sourceName": "Google"}],
+        }
+        revisions = [
+            {"token": tokens[0], "revision": contacts.card_revision(base)},
+            {"token": tokens[1], "revision": contacts.card_revision(other)},
+        ]
+        with mock.patch.object(
+            contacts, "selected_candidate",
+            return_value=("+15550100001", key, candidate, records),
+        ), mock.patch.object(
+            contacts, "describe_records", return_value=[base, other],
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            preview, private = contacts.prepare_consolidation(
+                "+15550100001", "sha256:" + "a" * 64, tokens[0], revisions,
+                contacts.card_draft(other),
+            )
+        self.assertEqual(preview["action"], "consolidate")
+        self.assertEqual(preview["sourceCardCount"], 1)
+        self.assertNotIn("private-1", json.dumps(preview))
+        self.assertEqual(private["targetUid"], "private-1")
+
+        changed = [dict(item) for item in revisions]
+        changed[1]["revision"] = "sha256:" + "f" * 64
+        with mock.patch.object(
+            contacts, "selected_candidate",
+            return_value=("+15550100001", key, candidate, records),
+        ), mock.patch.object(contacts, "describe_records", return_value=[base, other]):
+            with self.assertRaisesRegex(ValueError, "source card changed"):
+                contacts.prepare_consolidation(
+                    "+15550100001", "sha256:" + "a" * 64, tokens[0], changed,
+                    contacts.card_draft(other),
+                )
+
+    def test_consolidation_preflights_then_updates_and_deletes(self):
+        before = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [], "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft({
+            **before, "emails": [{"label": "home", "value": "alex@example.com"}],
+        })
+        after = {**before, **draft}
+        plan = "sha256:" + "d" * 64
+        preview = {
+            "action": "consolidate", "handle": "+15550100001", "name": "Alex Rivera",
+            "cardNumber": 1, "cardCount": 2, "accountNumber": 1, "sourceName": "iCloud",
+            "sourceCardCount": 1, "changedFields": ["email addresses"],
+            "planHash": plan, "writeEnabled": True,
+        }
+        private = {
+            "targetUid": "person-1", "targetBefore": before, "targetAfter": draft,
+            "sources": [{"personUid": "person-2", "card": before}],
+            "handle": "+15550100001", "name": "Alex Rivera", "planHash": plan,
+        }
+        events = []
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_consolidation", return_value=(preview, private),
+        ), mock.patch.object(
+            contacts, "describe_records", return_value=[after],
+        ), mock.patch.object(
+            contacts, "write_undo_receipt",
+            side_effect=lambda value: events.append("receipt") or "undo:" + "e" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=lambda value: events.append(value["operation"]) or {
+                "ok": True, "readyToConsolidate": True, "sourceCount": 1,
+            },
+        ), mock.patch.object(
+            contacts, "run_contact_consolidation",
+            side_effect=lambda target, sources, card: events.append("native") or {
+                "ok": True, "updated": True, "deletedCount": len(sources),
+            },
+        ) as consolidate:
+            result = contacts.apply_consolidation(
+                "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                [], draft, plan,
+            )
+        self.assertEqual(events, ["consolidate", "receipt", "native"])
+        consolidate.assert_called_once_with("person-1", ["person-2"], draft)
+        self.assertTrue(result["applied"])
+
+    def test_consolidation_never_deletes_a_source_when_survivor_save_fails(self):
+        before = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [], "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft(before)
+        plan = "sha256:" + "d" * 64
+        preview = {
+            "action": "consolidate", "handle": "+15550100001", "name": "Alex Rivera",
+            "cardNumber": 1, "cardCount": 2, "accountNumber": 1, "sourceName": "iCloud",
+            "sourceCardCount": 1, "changedFields": ["source-card consolidation"],
+            "planHash": plan, "writeEnabled": True,
+        }
+        private = {
+            "targetUid": "person-1", "targetBefore": before, "targetAfter": draft,
+            "sources": [{"personUid": "person-2", "card": before}],
+            "handle": "+15550100001", "name": "Alex Rivera", "planHash": plan,
+        }
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_consolidation", return_value=(preview, private),
+        ), mock.patch.object(
+            contacts, "write_undo_receipt", return_value="undo:" + "e" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            return_value={"ok": True, "readyToConsolidate": True, "sourceCount": 1},
+        ), mock.patch.object(
+            contacts, "run_contact_consolidation", side_effect=RuntimeError("native save failed"),
+        ), mock.patch.object(contacts, "run_contact_delete") as delete:
+            with self.assertRaisesRegex(RuntimeError, "native save failed"):
+                contacts.apply_consolidation(
+                    "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                    [], draft, plan,
+                )
+        delete.assert_not_called()
+
+
+
+class CrossNameMergeTests(unittest.TestCase):
+    def fake_candidates(self):
+        gray = {"token": "sha256:" + "a" * 64, "name": "Julia Gray", "recordCount": 1,
+                "sourceCount": 1, "hasPhoto": True,
+                "cards": [{"token": "sha256:" + "1" * 64, "accountNumber": 1,
+                           "sourceName": "iCloud", "hasPhoto": True, "matchCount": 1}]}
+        kinney = {"token": "sha256:" + "b" * 64, "name": "Julia Kinney", "recordCount": 1,
+                  "sourceCount": 1, "hasPhoto": True,
+                  "cards": [{"token": "sha256:" + "2" * 64, "accountNumber": 1,
+                             "sourceName": "Gmail", "hasPhoto": True, "matchCount": 1}]}
+        by_name = {
+            "julia gray": [{"uid": "uid-gray", "source": "s-icloud", "photo": True,
+                            "modified": 2, "name": "Julia Gray"}],
+            "julia kinney": [{"uid": "uid-kinney", "source": "s-gmail", "photo": True,
+                              "modified": 1, "name": "Julia Kinney"}],
+        }
+        return ("+15550100001", [gray, kinney], by_name)
+
+    def test_pair_combines_both_people_in_global_account_order(self):
+        # the union follows the same largest-store-first account order as
+        # every other view — NOT selected-person-first
+        stores = ["/AB/Sources/s-gmail/AddressBook-v22.abcddb",
+                  "/AB/Sources/s-icloud/AddressBook-v22.abcddb"]
+        with mock.patch.object(contacts, "contact_candidates", return_value=self.fake_candidates()), \
+             mock.patch.object(contacts, "bounded_source_dbs", return_value=stores), \
+             mock.patch.object(contacts, "normalize_resolve_handle",
+                               return_value=("+15550100001", "5550100001", False)):
+            _, _, combined, records = contacts.selected_candidate_pair(
+                "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64)
+        self.assertEqual(combined["recordCount"], 2)
+        self.assertEqual(combined["sourceCount"], 2)
+        # gmail (the bigger store) leads even though iCloud's person was selected
+        self.assertEqual([r["uid"] for r in records], ["uid-kinney", "uid-gray"])
+        self.assertEqual([c["sourceName"] for c in combined["cards"]], ["Gmail", "iCloud"])
+        self.assertEqual([c["accountNumber"] for c in combined["cards"]], [1, 2])
+
+    def test_pair_requires_two_distinct_candidates(self):
+        with mock.patch.object(contacts, "contact_candidates", return_value=self.fake_candidates()), \
+             mock.patch.object(contacts, "normalize_resolve_handle",
+                               return_value=("+15550100001", "5550100001", False)):
+            with self.assertRaises(ValueError):
+                contacts.selected_candidate_pair(
+                    "+15550100001", "sha256:" + "a" * 64, "sha256:" + "a" * 64)
+
+
+class SourceOrderTests(unittest.TestCase):
+    def test_sources_order_largest_account_first(self):
+        # the biggest store is always card 1, so compare/merge order is stable
+        counts = {
+            "/AB/Sources/aaa/AddressBook-v22.abcddb": 5,
+            "/AB/Sources/bbb/AddressBook-v22.abcddb": 500,
+            "/AB/Sources/ccc/AddressBook-v22.abcddb": 500,
+        }
+        def fake_open(path):
+            connection = mock.MagicMock()
+            connection.__enter__.return_value = connection
+            connection.__exit__.return_value = False
+            connection.execute.return_value.fetchone.return_value = (counts[path],)
+            return connection
+        with mock.patch.object(contacts, "glob", return_value=sorted(counts)), mock.patch.object(
+            contacts.os.path, "exists", return_value=False,
+        ), mock.patch.object(contacts, "open_db", side_effect=fake_open):
+            ordered = contacts.source_dbs()
+        self.assertEqual(ordered, [
+            "/AB/Sources/bbb/AddressBook-v22.abcddb",
+            "/AB/Sources/ccc/AddressBook-v22.abcddb",
+            "/AB/Sources/aaa/AddressBook-v22.abcddb",
+        ])
+
+
+class CardContentComparisonTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "Example",
+        "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [{"label": "Email", "value": "a@example.invalid"},
+                   {"label": "Email", "value": "b@example.invalid"}],
+        "urls": [], "addresses": [],
+    }
+
+    def test_collection_order_never_fails_verification(self):
+        # the writer reuses existing rows and appends additions, so a merged
+        # card can read back with the same values in a different sequence
+        draft = contacts.card_draft(self.DETAIL)
+        reordered = dict(draft, emails=list(reversed(draft["emails"])))
+        self.assertTrue(contacts.same_card_content(reordered, draft))
+
+    def test_changed_values_still_fail_verification(self):
+        draft = contacts.card_draft(self.DETAIL)
+        changed = dict(draft, emails=[{"label": "Email", "value": "c@example.invalid"},
+                                      {"label": "Email", "value": "b@example.invalid"}])
+        self.assertFalse(contacts.same_card_content(changed, draft))
+        renamed = dict(draft, organization="Someone Else")
+        self.assertFalse(contacts.same_card_content(renamed, draft))
+
+
+class ConsolidationRecoveryTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "Example",
+        "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [], "urls": [], "addresses": [],
+    }
+
+    def private(self):
+        after = dict(contacts.card_draft(self.DETAIL), organization="Merged Org")
+        return {
+            "targetUid": "uid-target", "targetAfter": after,
+            "sources": [{"personUid": "uid-source"}],
+        }
+
+    def test_native_failures_carry_their_stage(self):
+        completed = (1, b'{"ok":false,"error":"boom","stage":"update survivor"}', b"")
+        file_info = os.stat_result((stat.S_IFREG | 0o700, 0, 0, 1, os.getuid(), 0, 1, 0, 0, 0))
+        with mock.patch.object(contacts.os, "lstat", return_value=file_info), mock.patch.object(
+            contacts, "run_bounded_process", return_value=completed,
+        ):
+            with self.assertRaises(contacts.NativeMutationError) as caught:
+                contacts.run_native_contact_mutation({"operation": "consolidate"})
+        self.assertEqual(caught.exception.stage, "update survivor")
+
+    def test_survivor_fault_recovers_through_contacts_app_edit(self):
+        private = self.private()
+        error = contacts.NativeMutationError("boom", "update survivor")
+        with mock.patch.object(
+            contacts, "describe_records", return_value=[self.DETAIL],
+        ), mock.patch.object(
+            contacts, "run_contact_repair", return_value={"ok": True, "edited": True},
+        ) as repair, mock.patch.object(contacts, "run_contact_delete") as delete:
+            contacts.recover_consolidation_via_contacts_app(private, error)
+        self.assertEqual(repair.call_args.args[0]["operation"], "edit")
+        self.assertEqual(repair.call_args.args[0]["card"], private["targetAfter"])
+        delete.assert_called_once_with(["uid-source"])
+
+    def test_delete_fault_falls_back_to_contacts_app_deletion(self):
+        private = self.private()
+        error = contacts.NativeMutationError("boom", "delete sources")
+        with mock.patch.object(
+            contacts, "run_contact_delete", side_effect=RuntimeError("still faulting"),
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            return_value={"ok": True, "deletedCount": 1},
+        ) as repair:
+            contacts.recover_consolidation_via_contacts_app(private, error)
+        self.assertEqual(repair.call_args.args[0]["operation"], "delete-fallback")
+        self.assertEqual(repair.call_args.args[0]["personUids"], ["uid-source"])
+
+    def test_unknown_stage_is_never_recovered(self):
+        error = contacts.NativeMutationError("boom", "")
+        with self.assertRaises(contacts.NativeMutationError):
+            contacts.recover_consolidation_via_contacts_app(self.private(), error)
+
+
+class StaleDescribeGuardTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "", "department": "",
+        "jobTitle": "", "birthday": "", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [], "urls": [], "addresses": [],
+    }
+
+    def test_stale_app_view_retries_until_counts_agree(self):
+        # first describe returns a stale empty-collection view; the retry sees
+        # the real card
+        stale = dict(self.DETAIL, phones=[])
+        with mock.patch.object(
+            contacts, "native_collection_counts", return_value={"uid-1": (1, 0, 0, 0)},
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=[{"ok": True, "cards": [stale]}, {"ok": True, "cards": [self.DETAIL]}],
+        ) as described, mock.patch.object(contacts.time, "sleep"):
+            details = contacts.describe_records([{"uid": "uid-1"}])
+        self.assertEqual(len(details[0]["phones"]), 1)
+        self.assertEqual(described.call_count, 2)
+
+    def test_persistently_stale_view_fails_honestly(self):
+        stale = dict(self.DETAIL, phones=[])
+        with mock.patch.object(
+            contacts, "native_collection_counts", return_value={"uid-1": (1, 0, 0, 0)},
+        ), mock.patch.object(
+            contacts, "run_contact_repair", return_value={"ok": True, "cards": [stale]},
+        ), mock.patch.object(contacts.time, "sleep"):
+            with self.assertRaises(RuntimeError) as caught:
+                contacts.describe_records([{"uid": "uid-1"}])
+        self.assertIn("stale card data", str(caught.exception))
+
+
+class SettledReadbackTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "Example",
+        "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [], "urls": [], "addresses": [],
+    }
+
+    def test_readback_polls_past_contacts_stale_view(self):
+        # Saves go through CNContactStore; describe goes through Contacts.app,
+        # whose view refreshes asynchronously. The first read returns the
+        # pre-save card, the second the saved one — no error, no false
+        # "Contacts changed the card" report.
+        stale = dict(self.DETAIL, organization="Old Org")
+        draft = contacts.card_draft(self.DETAIL)
+        with mock.patch.object(
+            contacts, "describe_records", side_effect=[[stale], [self.DETAIL]],
+        ) as described, mock.patch.object(contacts.time, "sleep") as slept:
+            result = contacts.settled_card_detail("uid-one", draft)
+        self.assertEqual(contacts.card_draft(result), draft)
+        self.assertEqual(described.call_count, 2)
+        slept.assert_called_once()
+
+    def test_readback_returns_last_view_when_the_card_really_changed(self):
+        changed = dict(self.DETAIL, organization="Someone Else Edited")
+        draft = contacts.card_draft(self.DETAIL)
+        with mock.patch.object(
+            contacts, "describe_records", return_value=[changed],
+        ) as described, mock.patch.object(contacts.time, "sleep"):
+            result = contacts.settled_card_detail("uid-one", draft)
+        self.assertNotEqual(contacts.card_draft(result), draft)
+        self.assertEqual(described.call_count, 10)
+
+    def test_readback_tolerates_transient_describe_failures(self):
+        draft = contacts.card_draft(self.DETAIL)
+        with mock.patch.object(
+            contacts, "describe_records",
+            side_effect=[RuntimeError("app view lagging"), [self.DETAIL]],
+        ), mock.patch.object(contacts.time, "sleep"):
+            result = contacts.settled_card_detail("uid-one", draft)
+        self.assertEqual(contacts.card_draft(result), draft)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -29,6 +29,7 @@ import plistlib
 import re
 import sqlite3
 import struct
+import subprocess
 import sys
 from glob import glob
 
@@ -41,6 +42,7 @@ PINNING_PLIST_PATHS = (
     ),
 )
 APPLE_EPOCH = 978307200  # 2001-01-01 UTC
+CONTACT_HELPER = os.path.expanduser("~/.blip/bin/contact-delete")
 
 # ---------- Contacts name resolution (built-in, no external deps) ----------
 
@@ -188,6 +190,39 @@ def name_for(handle: str | None) -> str | None:
     if "@" in handle:
         return _NAME_INDEX.get(handle.strip().lower()) or None
     return _NAME_INDEX.get(_normalize_phone(handle)) or None
+
+
+def unified_names(handles: list[str]) -> dict[str, dict[str, str]]:
+    """Resolve a bounded set through the same unified-card view Messages uses."""
+    bounded = []
+    seen = set()
+    for value in handles[:128]:
+        if (isinstance(value, str) and 1 <= len(value) <= 320
+                and not re.search(r"[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]", value)
+                and value not in seen):
+            seen.add(value)
+            bounded.append(value)
+    if not bounded or not os.path.isfile(CONTACT_HELPER):
+        return {}
+    try:
+        result = subprocess.run(
+            [CONTACT_HELPER], input=json.dumps({"operation": "names", "handles": bounded}),
+            text=True, capture_output=True, timeout=10, check=False,
+        )
+        payload = json.loads(result.stdout) if result.returncode == 0 else {}
+        rows = payload.get("names") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            return {}
+        return {
+            row["handle"]: {
+                "name": str(row.get("name") or "")[:160],
+                "short": str(row.get("shortName") or row.get("name") or "")[:160],
+            }
+            for row in rows
+            if isinstance(row, dict) and row.get("handle") in seen and row.get("name")
+        }
+    except (OSError, subprocess.SubprocessError, ValueError, TypeError):
+        return {}
 
 
 def label(handle: str | None, is_from_me: int, with_names: bool) -> str:
@@ -792,7 +827,7 @@ def cmd_chats(con, args):
     rows = con.execute(
         f"""
         SELECT c.ROWID AS cid, c.chat_identifier, c.guid, c.group_id,
-               {orig_col} AS original_group_id, c.display_name, c.room_name,
+               {orig_col} AS original_group_id, c.display_name, c.room_name, c.style,
                c.service_name, MAX(m.date) AS last_date,
                COUNT(m.ROWID) AS n
         FROM chat c
@@ -809,20 +844,34 @@ def cmd_chats(con, args):
         # One entry per CONVERSATION: a group re-keyed by Messages leaves
         # several chat rows and used to list once per row.
         clusters = _group_cluster_map(con)
-        merged_counts: dict = {}
+        merged_counts: dict[str, int] = {}
+        pin_orders: dict[str, int] = {}
         for r in rows:
-            canon = clusters.get(r["chat_identifier"])
-            if canon:
-                merged_counts[canon] = merged_counts.get(canon, 0) + r["n"]
-        out = []
+            chat_id = r["chat_identifier"]
+            canon = clusters.get(chat_id, chat_id)
+            merged_counts[canon] = merged_counts.get(canon, 0) + r["n"]
+            order = pin_order_for(pin_ids, chat_id, r["guid"],
+                                  r["group_id"], r["original_group_id"])
+            if order is not None and (canon not in pin_orders or order < pin_orders[canon]):
+                pin_orders[canon] = order
+
+        selected = []
+        seen_ids = set()
         for r in rows:
-            canon = clusters.get(r["chat_identifier"])
-            if canon and canon != r["chat_identifier"]:
+            chat_id = r["chat_identifier"]
+            if chat_id in seen_ids:
+                continue
+            seen_ids.add(chat_id)
+            canon = clusters.get(chat_id)
+            if canon and canon != chat_id:
                 continue                 # an older row of a conversation listed under `canon`
-            pin_order = pin_order_for(pin_ids, r["chat_identifier"], r["guid"],
-                                      r["group_id"], r["original_group_id"])
+            selected.append(r)
+
+        latest = {}
+        for r in selected:
             last = con.execute(
-                f"""SELECT m.text, m.attributedBody, m.is_from_me, h.id AS handle
+                f"""SELECT m.ROWID AS mid, m.text, m.attributedBody, m.is_from_me,
+                            h.id AS handle
                     FROM chat_message_join cmj
                     JOIN {MESSAGE_SRC} m ON m.ROWID = cmj.message_id
                     LEFT JOIN handle h ON h.ROWID = m.handle_id
@@ -830,26 +879,89 @@ def cmd_chats(con, args):
                     ORDER BY m.date DESC LIMIT 1""",
                 (r["cid"],),
             ).fetchone()
+            if last:
+                latest[r["cid"]] = last
+
+        attachments = {}
+        for attachment in _chunked_in(
+            con,
+            """SELECT maj.message_id AS mid, a.transfer_name AS name, a.mime_type AS mime
+                 FROM message_attachment_join maj
+                 JOIN attachment a ON a.ROWID = maj.attachment_id
+                WHERE maj.message_id IN ({marks})
+                  AND COALESCE(a.transfer_name, '') NOT LIKE '%.pluginPayloadAttachment'
+                ORDER BY a.ROWID""",
+            [last["mid"] for last in latest.values()],
+        ):
+            attachments.setdefault(attachment["mid"], {
+                "name": attachment["name"] or "", "mime": attachment["mime"] or "",
+            })
+
+        participants = {}
+        for member in _chunked_in(
+            con,
+            """SELECT chj.chat_id AS cid, h.id AS handle
+                 FROM chat_handle_join chj JOIN handle h ON h.ROWID = chj.handle_id
+                WHERE chj.chat_id IN ({marks}) ORDER BY chj.chat_id, h.ROWID""",
+            [r["cid"] for r in selected if r["style"] == 43],
+        ):
+            if member["handle"]:
+                participants.setdefault(member["cid"], []).append(member["handle"])
+
+        wanted_names = []
+        for r in selected:
+            if r["chat_identifier"] not in pin_orders:
+                continue
+            if r["style"] == 43:
+                wanted_names.extend(participants.get(r["cid"], []))
+            else:
+                wanted_names.append(r["chat_identifier"])
+        contact_names = unified_names(wanted_names)
+
+        out = []
+        for r in selected:
+            chat_id = r["chat_identifier"]
+            last = latest.get(r["cid"])
+            raw_name = r["display_name"] or r["room_name"] or ""
+            explicit_name = raw_name if raw_name != chat_id else ""
+            pin_order = pin_orders.get(chat_id)
+            pin_name = ""
+            if pin_order is not None:
+                if r["style"] == 43:
+                    member_names = [
+                        contact_names.get(handle, {}).get("short") or name_for(handle) or handle
+                        for handle in participants.get(r["cid"], [])
+                    ]
+                    if len(member_names) == 2:
+                        generated_name = " & ".join(member_names)
+                    elif len(member_names) > 2:
+                        generated_name = ", ".join(member_names[:-1]) + " & " + member_names[-1]
+                    else:
+                        generated_name = member_names[0] if member_names else ""
+                    pin_name = explicit_name or generated_name
+                else:
+                    pin_name = contact_names.get(chat_id, {}).get("short") or ""
+
             out.append({
-                "id": r["chat_identifier"],
-                "name": r["display_name"] or r["room_name"],
+                "id": chat_id,
+                "name": explicit_name or None,
                 "service": r["service_name"],
-                "messages": r["n"],
+                "messages": merged_counts.get(chat_id, r["n"]),
                 "last": fmt_ts(r["last_date"]),
                 "last_text": message_text(last) if last else "",
                 "last_from_me": bool(last["is_from_me"]) if last else False,
                 "last_handle": (last["handle"] if last else None) or "",
                 "last_name": (None if args.no_names
                               else _dm_name(last["handle"] if last else None, r["chat_identifier"])),
+                "last_attachment": attachments.get(last["mid"]) if last else None,
                 "pinned": pin_order is not None,
                 "pin_order": pin_order,
+                "pin_name": pin_name or None,
                 # Other chat rows of this same conversation. A client must fold
                 # any thread carrying one of these onto this id.
                 "aliases": [c for c, k in clusters.items()
-                            if k == r["chat_identifier"] and c != r["chat_identifier"]],
+                            if k == chat_id and c != chat_id][:15],
             })
-            if canon:
-                out[-1]["messages"] = merged_counts.get(canon, r["n"])
         print(json.dumps(out, indent=2, ensure_ascii=False))
         return
     for r in rows:
@@ -902,6 +1014,13 @@ def cmd_groups(con, args):
         live.append(r)
     rows = live[: args.n]
     if args.json:
+        participant_lists = [
+            (r["participants"] or "").split(",") if r["participants"] else []
+            for r in rows
+        ]
+        contact_names = unified_names([
+            handle for members in participant_lists for handle in members
+        ]) if not args.no_names else {}
         print(
             json.dumps(
                 [
@@ -909,10 +1028,18 @@ def cmd_groups(con, args):
                         "chat": r["chat_identifier"],
                         "guid": r["guid"],
                         "name": r["display_name"] or "",
-                        "participants": (r["participants"] or "").split(",") if r["participants"] else [],
+                        "participants": participant_lists[index],
+                        "participant_names": {
+                            handle: (
+                                contact_names.get(handle, {}).get("name")
+                                or name_for(handle)
+                                or handle
+                            )
+                            for handle in participant_lists[index]
+                        } if not args.no_names else {},
                         "last": fmt_ts(r["last_date"]) if r["last_date"] else None,
                     }
-                    for r in rows
+                    for index, r in enumerate(rows)
                 ],
                 indent=2,
             )

--- a/bridge/mac/imsg_test.py
+++ b/bridge/mac/imsg_test.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Projection tests for the Messages conversation list."""
+
+import importlib.machinery
+import importlib.util
+import contextlib
+import io
+import json
+import os
+import sqlite3
+import unittest
+from types import SimpleNamespace
+
+
+def load_imsg():
+    path = os.path.join(os.path.dirname(__file__), "imsg")
+    loader = importlib.machinery.SourceFileLoader("blip_imsg", path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+imsg = load_imsg()
+
+
+class ChatProjectionTests(unittest.TestCase):
+    def test_chat_json_deduplicates_parallel_service_rows(self):
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        con.executescript("""
+            CREATE TABLE chat (
+              ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT, display_name TEXT,
+              room_name TEXT, service_name TEXT, group_id TEXT, original_group_id TEXT,
+              style INTEGER
+            );
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+              ROWID INTEGER PRIMARY KEY, date INTEGER, text TEXT,
+              attributedBody BLOB, is_from_me INTEGER, handle_id INTEGER,
+              item_type INTEGER DEFAULT 0
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+            CREATE TABLE attachment (
+              ROWID INTEGER PRIMARY KEY, transfer_name TEXT, mime_type TEXT
+            );
+            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+            CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+            INSERT INTO chat VALUES (1, '+15551234567', NULL, NULL, NULL, 'SMS', NULL, NULL, 45);
+            INSERT INTO chat VALUES (2, '+15551234567', NULL, NULL, NULL, 'iMessage', NULL, NULL, 45);
+            INSERT INTO handle VALUES (1, '+15551234567');
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (10, 100, 'old', NULL, 0, 1);
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (11, 200, 'new', NULL, 0, 1);
+            INSERT INTO chat_message_join VALUES (1, 10);
+            INSERT INTO chat_message_join VALUES (2, 11);
+        """)
+        original = imsg.pinned_chat_identifiers
+        imsg.pinned_chat_identifiers = lambda: [{"+15551234567"}]
+        try:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                imsg.cmd_chats(con, SimpleNamespace(n=300, json=True, no_names=True))
+            rows = json.loads(output.getvalue())
+        finally:
+            imsg.pinned_chat_identifiers = original
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["last_text"], "new")
+        self.assertEqual(rows[0]["pin_order"], 0)
+
+    def test_chat_json_labels_an_attachment_without_leaking_placeholder_text(self):
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        con.executescript("""
+            CREATE TABLE chat (
+              ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT, display_name TEXT,
+              room_name TEXT, service_name TEXT, group_id TEXT, original_group_id TEXT,
+              style INTEGER
+            );
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+              ROWID INTEGER PRIMARY KEY, date INTEGER, text TEXT,
+              attributedBody BLOB, is_from_me INTEGER, handle_id INTEGER,
+              item_type INTEGER DEFAULT 0
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+            CREATE TABLE attachment (
+              ROWID INTEGER PRIMARY KEY, transfer_name TEXT, mime_type TEXT
+            );
+            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+            CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+            INSERT INTO chat VALUES (1, 'chat999', NULL, NULL, 'chat999', 'iMessage', NULL, NULL, 43);
+            INSERT INTO handle VALUES (1, '+15551234567');
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (10, 100, '￼', NULL, 0, 1);
+            INSERT INTO chat_message_join VALUES (1, 10);
+            INSERT INTO attachment VALUES (20, 'photo.HEIC', 'image/heic');
+            INSERT INTO message_attachment_join VALUES (10, 20);
+        """)
+        original_pins = imsg.pinned_chat_identifiers
+        original_names = imsg.unified_names
+        imsg.pinned_chat_identifiers = lambda: []
+        imsg.unified_names = lambda _handles: {}
+        try:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                imsg.cmd_chats(con, SimpleNamespace(n=300, json=True, no_names=True))
+            rows = json.loads(output.getvalue())
+        finally:
+            imsg.pinned_chat_identifiers = original_pins
+            imsg.unified_names = original_names
+        self.assertIsNone(rows[0]["name"])
+        self.assertEqual(rows[0]["last_attachment"]["mime"], "image/heic")
+
+    def test_named_group_migrations_coalesce_only_with_the_same_participants(self):
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        con.executescript("""
+            CREATE TABLE chat (
+              ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT, display_name TEXT,
+              room_name TEXT, service_name TEXT, group_id TEXT, original_group_id TEXT,
+              style INTEGER
+            );
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+              ROWID INTEGER PRIMARY KEY, date INTEGER, text TEXT,
+              attributedBody BLOB, is_from_me INTEGER, handle_id INTEGER,
+              item_type INTEGER DEFAULT 0
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+            CREATE TABLE attachment (
+              ROWID INTEGER PRIMARY KEY, transfer_name TEXT, mime_type TEXT
+            );
+            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+            CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+            INSERT INTO chat VALUES (1, 'old-group', NULL, 'Project Team', NULL, 'iMessage', 'old', NULL, 43);
+            INSERT INTO chat VALUES (2, 'new-group', NULL, 'Project Team', NULL, 'iMessage', 'new', 'old', 43);
+            INSERT INTO chat VALUES (3, 'other-group', NULL, 'Project Team', NULL, 'iMessage', 'other', NULL, 43);
+            INSERT INTO handle VALUES (1, '+15550000001');
+            INSERT INTO handle VALUES (2, '+15550000002');
+            INSERT INTO handle VALUES (3, '+15550000003');
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (10, 100, 'old', NULL, 0, 1);
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (11, 200, 'new', NULL, 0, 1);
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (12, 150, 'different people', NULL, 0, 3);
+            INSERT INTO chat_message_join VALUES (1, 10);
+            INSERT INTO chat_message_join VALUES (2, 11);
+            INSERT INTO chat_message_join VALUES (3, 12);
+            INSERT INTO chat_handle_join VALUES (1, 1);
+            INSERT INTO chat_handle_join VALUES (1, 2);
+            INSERT INTO chat_handle_join VALUES (2, 1);
+            INSERT INTO chat_handle_join VALUES (2, 2);
+            INSERT INTO chat_handle_join VALUES (3, 1);
+            INSERT INTO chat_handle_join VALUES (3, 3);
+        """)
+        original_pins = imsg.pinned_chat_identifiers
+        original_names = imsg.unified_names
+        imsg.pinned_chat_identifiers = lambda: [{"old-group"}]
+        imsg.unified_names = lambda _handles: {}
+        try:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                imsg.cmd_chats(con, SimpleNamespace(n=300, json=True, no_names=True))
+            rows = json.loads(output.getvalue())
+        finally:
+            imsg.pinned_chat_identifiers = original_pins
+            imsg.unified_names = original_names
+        self.assertEqual(len(rows), 2)
+        merged = next(row for row in rows if row["id"] == "new-group")
+        self.assertEqual(merged["aliases"], ["old-group"])
+        self.assertEqual(merged["messages"], 2)
+        self.assertEqual(merged["pin_order"], 0)
+        self.assertIn("other-group", [row["id"] for row in rows])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bridge/mac/install.sh
+++ b/bridge/mac/install.sh
@@ -5,7 +5,9 @@
 # What it does:
 #   1. copies the bridge tools into ~/.blip/bin (imsg, imsg-send, imsg-read, contacts,
 #      tcc-check, blip-check) — read-only sqlite over chat.db, AppleScript
-#      send, Contacts — plus blip-dispatch, the forced-command gate that
+#      send, Contacts — plus the static contact-repair.js Automation helper,
+#      the compiled contact-mutation helper that uses Apple's current Contacts framework,
+#      the scoped contact-link.applescript UI handoff, and blip-dispatch, the forced-command gate that
 #      confines Blip's dedicated ssh key to exactly those tools;
 #   2. makes sure Remote Login (sshd) is on, since Blip talks over ssh;
 #   3. explains the two TCC grants that cannot be scripted:
@@ -17,13 +19,22 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 dest="$HOME/.blip/bin"
 mkdir -p "$dest"
-for t in imsg imsg-send imsg-read contacts tcc-check blip-check blip-dispatch; do
+for t in imsg imsg-send imsg-read contacts contact-repair.js contact-link.applescript tcc-check blip-check blip-dispatch; do
   if [[ -f "$here/$t" ]]; then
     install -m 0755 "$here/$t" "$dest/$t"
   else
     echo "install.sh: missing $here/$t" >&2; exit 1
   fi
 done
+
+if ! xcrun --find swiftc >/dev/null 2>&1; then
+  echo "install.sh: swiftc not found — install Xcode Command Line Tools" >&2
+  exit 1
+fi
+delete_tmp="$dest/.contact-delete.new"
+xcrun swiftc -O -framework Contacts "$here/contact-delete.swift" -o "$delete_tmp"
+chmod 0755 "$delete_tmp"
+mv -f "$delete_tmp" "$dest/contact-delete"
 echo "✓ bridge tools installed to $dest"
 
 # /usr/bin/python3 ALWAYS exists on macOS — as a Command Line Tools stub that
@@ -50,6 +61,20 @@ Two permissions must be granted by hand (macOS will not let a script do it):
   2. Automation → Messages: the first send from an ssh session pops a prompt on
      THIS Mac's screen: "sshd-keygen-wrapper wants to control Messages" — click
      Allow once. (blip-setup triggers this with a dry-run-free self-send.)
+
+Optional contact comparison, editing, deletion, consolidation, repair, and linking need Automation →
+Contacts for sshd-keygen-wrapper. Blip requests it only when you explicitly
+open those tools; contact writes additionally require both contact_writes=on
+on Linux and the owner-only ~/.blip/contact-writes-enabled gate on this Mac.
+
+Blip previews and revision-pins each card mutation. It writes an owner-only
+undo receipt before saving through Contacts.app and Apple's Contacts framework;
+it never writes Contacts' private SQLite databases directly.
+
+Linking or merging exact cards from Blip additionally uses System Events and
+requires sshd-keygen-wrapper under Privacy & Security → Accessibility. Blip
+first selects the revalidated cards and shows a separate confirmation; it
+invokes only Contacts' enabled Link/Merge Selected Cards menu item.
 
 Then check:
 EOF

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -14,6 +14,7 @@ import {
   dedupeSelfEcho,
   isGroupChat,
   displayName,
+  messagePreview,
   fetchMessages,
   loadAllowlist,
   loadState,
@@ -55,6 +56,16 @@ describe("buildThreads", () => {
     expect(threads[0]!.chat).toBe("A");          // newest thread first
     expect(threads[0]!.last_text).toBe("newer");
     expect(threads[0]!.count).toBe(2);
+  });
+
+  test("attachment previews never expose the object-replacement glyph", () => {
+    expect(messagePreview("\uFFFC", { name: "IMG_0042.HEIC", mime: "image/heic" })).toBe("Photo");
+    expect(messagePreview("\uFFFC", { name: "clip.mov", mime: "video/quicktime" })).toBe("Video");
+    expect(messagePreview("caption \uFFFC", { name: "clip.mov", mime: "video/quicktime" })).toBe("caption");
+    const threads = buildThreads([
+      msg({ text: "\uFFFC", attachments: [{ name: "IMG_1.png", mime: "image/png", bytes: 5 }] }),
+    ], "");
+    expect(threads[0]!.last_text).toBe("Photo");
   });
 
   test("orders threads newest-first regardless of input order", () => {
@@ -158,8 +169,12 @@ describe("isGroupChat", () => {
     expect(r.online).toBe(false);
   });
   test("groups JSON with an array of participants (claude-on-mac 1.4)", () => {
-    const g = fetchGroups((() => ({ status: 0, stdout: JSON.stringify([{ chat: "chat1", guid: "any;+;chat1", name: "", participants: ["+1", "+2"], last: null }]), stderr: "" })) as never);
+    const g = fetchGroups((() => ({ status: 0, stdout: JSON.stringify([{
+      chat: "chat1", guid: "any;+;chat1", name: "", participants: ["+1", "+2"],
+      participant_names: { "+1": "Alex", "+2": "Pat" }, last: null,
+    }]), stderr: "" })) as never);
     expect(g!.chat1.participants).toEqual(["+1", "+2"]);
+    expect(g!.chat1.participantNames).toEqual({ "+1": "Alex", "+2": "Pat" });
   });
 });
 
@@ -234,6 +249,20 @@ describe("self-echo in the thread list", () => {
       { [guid]: { name: "", guid: "any;+;" + guid, participants: ["+15550100004", "+15550100005"] } },
     );
     expect(threads[0]!.name).toBe("Jordan Blake, +15550100005");
+  });
+
+  test("group threads expose named participants for explicit contact actions", () => {
+    const guid = "053856bb0d9a40e392db59eace1c56d1";
+    const groups = {
+      [guid]: { name: "Friends", guid: "any;+;" + guid,
+        participants: ["+15550100004", "+15550100005"],
+        participantNames: { "+15550100004": "Jordan", "+15550100005": "Casey" } },
+    };
+    const thread = buildThreads([msg({ chat: guid, handle: "+15550100004" })], "", {}, groups)[0]!;
+    expect(thread.participants).toEqual([
+      { handle: "+15550100004", name: "Jordan" },
+      { handle: "+15550100005", name: "Casey" },
+    ]);
   });
 
   test("a group with no metadata at all falls back to its id, never one member", () => {
@@ -824,11 +853,14 @@ describe("complete conversation list (mergeChats)", () => {
   };
   const chats = [
     { id: "+15551234567", name: null, service: "iMessage", last: "2026-08-31 20:00:00",
-      last_text: "hi", last_from_me: false, last_handle: "+15551234567", last_name: "Pat", pinned: false, pin_order: null },
+      last_text: "hi", last_from_me: false, last_handle: "+15551234567", last_name: "Pat",
+      pinned: false, pin_order: null, aliases: ["+15551234567"], pin_name: null },
     { id: "ce5a593a78af408282d61461ade89135", name: "Lunch Crew", service: "iMessage", last: "2026-08-31 19:00:00",
-      last_text: "Nice", last_from_me: false, last_handle: "+15550001111", last_name: "Sam", pinned: false, pin_order: null },
+      last_text: "Nice", last_from_me: false, last_handle: "+15550001111", last_name: "Sam",
+      pinned: false, pin_order: null, aliases: ["ce5a593a78af408282d61461ade89135"], pin_name: null },
     { id: "+15559990000", name: null, service: "SMS", last: "2026-08-20 09:00:00",
-      last_text: "old news", last_from_me: true, last_handle: "+15559990000", last_name: "Quiet Q", pinned: false, pin_order: null },
+      last_text: "old news", last_from_me: true, last_handle: "+15559990000", last_name: "Quiet Q",
+      pinned: false, pin_order: null, aliases: ["+15559990000"], pin_name: null },
   ];
 
   test("quiet conversations outside the window appear, newest first", () => {
@@ -843,7 +875,18 @@ describe("complete conversation list (mergeChats)", () => {
 
   test("a chat already covered by the window keeps the window's richer row", () => {
     const out = mergeChats([windowThread], chats, {}, {});
-    expect(out[0]).toBe(windowThread);
+    expect(out[0]!.count).toBe(windowThread.count);
+    expect(out[0]!.unread).toBe(windowThread.unread);
+  });
+
+  test("pinned rows receive Messages-style names and cleaned latest previews", () => {
+    const namedChats = chats.map((chat, index) => index === 0
+      ? { ...chat, pin_name: "Pat", last_text: "Photo" }
+      : chat);
+    const matchingWindow = { ...windowThread, last_text: "\uFFFC" };
+    const out = mergeChats([matchingWindow], namedChats, {}, {});
+    expect(out[0]!.pin_name).toBe("Pat");
+    expect(out[0]!.last_text).toBe("Photo");
   });
 
   test("DM rows are named from the contact, groups from the group cache", () => {
@@ -897,6 +940,40 @@ describe("pinned conversation metadata", () => {
     expect(out[0]!.pin_order).toBe(0);
     expect(out[1]!.pinned).toBe(false);
     expect(out[1]!.pin_order).toBe(null);
+  });
+
+  test("migrated named groups combine alias history, unread counts, and pin state", () => {
+    const oldId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const newId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const baseThread = {
+      chat: newId, guid: "", name: "Project Team", handle: "+15550000001",
+      service: "iMessage", last_ts: "2026-09-02 19:29:00", last_text: "",
+      last_from_me: false, count: 0, unread: 0, pinned: false, pin_order: null,
+    };
+    const source = [{
+      id: newId, aliases: [newId, oldId], name: "Project Team", service: "iMessage",
+      last: "2026-09-02 19:29:00", last_text: "new side", last_from_me: false,
+      last_handle: "+15550000001", last_name: "Eric", pinned: true, pin_order: 1,
+      pin_name: "Project Team",
+    }];
+    const rich = [
+      { ...baseThread, chat: oldId, name: "Project Team", count: 5, unread: 2,
+        last_ts: "2026-09-01 09:00:00", last_text: "old side" },
+      { ...baseThread, chat: newId, name: "Project Team", count: 3, unread: 1,
+        last_ts: "2026-09-02 19:29:00", last_text: "new side" },
+    ];
+    const { foldThreadAliases, mergeChats } = require("./collector") as typeof import("./collector");
+    const folded = foldThreadAliases(rich as never, { [oldId]: newId });
+    const out = mergeChats(folded, source, {
+      [newId]: { name: "Project Team", guid: `any;+;${newId}`, participants: ["+1", "+2"] },
+    }, {});
+    expect(out).toHaveLength(1);
+    expect(out[0]!.chat).toBe(newId);
+    expect(out[0]!.aliases).toEqual([newId, oldId]);
+    expect(out[0]!.count).toBe(8);
+    expect(out[0]!.unread).toBe(3);
+    expect(out[0]!.pinned).toBe(true);
+    expect(out[0]!.guid).toBe(`any;+;${newId}`);
   });
 });
 

--- a/collector.ts
+++ b/collector.ts
@@ -23,6 +23,11 @@ import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import {
+  identityNameFor,
+  safeReadIdentityConfig,
+  type IdentityConfig,
+} from "./identities";
 
 const HOME = process.env.HOME ?? homedir();
 
@@ -89,6 +94,8 @@ export interface LinkCard { url: string; title: string; summary: string; image_i
 
 export interface Thread {
   chat: string;
+  /** Historical chat identifiers coalesced into this logical conversation. */
+  aliases?: string[];
   /** Full AppleScript chat GUID for groups (""), empty for DMs. Sending to a
    *  group means `imsg-send --chat-id <guid>`; never the bare id. */
   guid: string;
@@ -104,7 +111,13 @@ export interface Thread {
   pinned: boolean;
   /** Position in Messages' pinned section, when pinned. */
   pin_order: number | null;
+  /** Messages-style short label from Contacts' unified-card view. */
+  pin_name?: string;
+  /** Other people in a group, for explicit per-person contact actions. */
+  participants?: GroupParticipant[];
 }
+
+export interface GroupParticipant { handle: string; name: string }
 
 export interface Toast {
   chat: string;
@@ -125,7 +138,12 @@ export interface Toast {
  *               Only moves on --mark-read (panel open, or middle-click).
  */
 /** guid is what AppleScript's `chat id` wants ("any;+;<id>"); chat is the bare id. */
-export interface GroupInfo { name: string; guid: string; participants: string[] }
+export interface GroupInfo {
+  name: string;
+  guid: string;
+  participants: string[];
+  participantNames?: Record<string, string>;
+}
 
 export interface BlipState {
   watermark: string;
@@ -256,6 +274,47 @@ export function displayName(msgs: ImsgMessage[]): string {
   return chatKey(msgs[0]);
 }
 
+/** Never expose Messages' U+FFFC attachment marker as a dotted OBJ glyph. */
+export function messagePreview(
+  text: unknown,
+  attachment?: { name?: unknown; mime?: unknown } | null,
+): string {
+  const cleaned = String(text ?? "").replace(/\uFFFC/g, "").trim();
+  if (cleaned) return cleaned;
+  if (!attachment) return "";
+  const mime = String(attachment.mime ?? "").toLowerCase();
+  const name = String(attachment.name ?? "").toLowerCase();
+  if (mime.startsWith("image/") || /\.(?:avif|gif|heic|heif|jpe?g|png|webp)$/.test(name)) return "Photo";
+  if (mime.startsWith("video/") || /\.(?:m4v|mov|mp4|webm)$/.test(name)) return "Video";
+  if (mime.startsWith("audio/") || /\.(?:aac|m4a|mp3|wav)$/.test(name)) return "Audio message";
+  if (mime === "text/vcard" || /\.vcf$/.test(name)) return "Contact card";
+  return "Attachment";
+}
+
+/** Apply a user's explicit resolution before any list, toast, or group label is built. */
+export function applyIdentityOverrides(
+  msgs: ImsgMessage[],
+  config: IdentityConfig,
+): ImsgMessage[] {
+  return msgs.map((message) => {
+    const name = identityNameFor(message.handle, config)
+      || identityNameFor(chatKey(message), config);
+    return name && name !== message.name ? { ...message, name } : message;
+  });
+}
+
+/** Complete chat rows may have no message in the preview window, so name DMs again here. */
+export function applyThreadIdentityOverrides(
+  threads: Thread[],
+  config: IdentityConfig,
+): Thread[] {
+  return threads.map((thread) => {
+    if (isGroupChat(thread.chat)) return thread;
+    const name = identityNameFor(thread.chat, config) || identityNameFor(thread.handle, config);
+    return name && name !== thread.name ? { ...thread, name } : thread;
+  });
+}
+
 /**
  * Group chat ids (chat.style=43) are either 32 hex chars or "chat<digits>";
  * DMs are a phone or email. Anything that is not a phone/email is treated as
@@ -369,8 +428,25 @@ export function chatKey(m: ImsgMessage | undefined): string {
  */
 export function groupName(chat: string, info: GroupInfo | undefined, byHandle: Map<string, string>): string {
   if (info?.name) return info.name;
-  const members = (info?.participants ?? []).map((h) => byHandle.get(h) || h);
+  const members = groupParticipants(info, byHandle).map((member) => member.name);
   return members.length ? members.join(", ") : chat;
+}
+
+/** Bounded, de-duplicated people for a group contact menu. */
+export function groupParticipants(
+  info: GroupInfo | undefined,
+  byHandle: Map<string, string> = new Map(),
+): GroupParticipant[] {
+  const result: GroupParticipant[] = [];
+  const seen = new Set<string>();
+  for (const raw of info?.participants ?? []) {
+    const handle = String(raw || "").trim().slice(0, 320);
+    if (!handle || seen.has(handle) || result.length >= 64) continue;
+    seen.add(handle);
+    const resolved = info?.participantNames?.[handle] || byHandle.get(handle) || handle;
+    result.push({ handle, name: String(resolved).trim().slice(0, 160) || handle });
+  }
+  return result;
 }
 
 export function buildThreads(
@@ -407,12 +483,13 @@ export function buildThreads(
       handle: String(last.handle || chat),
       service: last.service,
       last_ts: last.ts,
-      last_text: last.text,
+      last_text: messagePreview(last.text, last.attachments?.[0]),
       last_from_me: last.from_me,
       count: sorted.length,
       unread,
       pinned: false,
       pin_order: null,
+      ...(isGroupChat(chat) ? { participants: groupParticipants(groups[chat], byHandle) } : {}),
     });
   }
 
@@ -793,6 +870,8 @@ export function unreadOldest(
 /** One row of `imsg --json chats`: a conversation with preview + pin metadata. */
 export interface ChatInfo {
   id: string;
+  /** Canonical id followed by historical ids for this conversation. */
+  aliases: string[];
   name: string | null;
   service: string;
   last: string;
@@ -803,8 +882,8 @@ export interface ChatInfo {
   /** Mirrored from Messages' pinning preferences; absent on old bridges. */
   pinned: boolean;
   pin_order: number | null;
-  /** Other chat rows of this same conversation (imsg ≥ 2.3.0). */
-  aliases: string[];
+  last_attachment?: { name: string; mime: string } | null;
+  pin_name: string | null;
 }
 
 /** How many conversations the sidebar lists (chat.db has hundreds). */
@@ -828,20 +907,45 @@ export function fetchChats(runner = spawnSync): ChatInfo[] | null {
     const rows = JSON.parse(res.stdout as string);
     if (!Array.isArray(rows)) return null;
     return rows
-      .filter((r) => r && typeof r.id === "string" && r.id !== "")
-      .map((r) => ({
-        id: String(r.id),
-        name: typeof r.name === "string" ? r.name : null,
-        service: String(r.service ?? ""),
-        last: String(r.last ?? ""),
-        last_text: String(r.last_text ?? ""),
-        last_from_me: r.last_from_me === true,
-        last_handle: String(r.last_handle ?? ""),
-        last_name: typeof r.last_name === "string" ? r.last_name : null,
-        pinned: r.pinned === true,
-        pin_order: Number.isInteger(r.pin_order) ? Number(r.pin_order) : null,
-        aliases: Array.isArray(r.aliases) ? r.aliases.filter((a: unknown) => typeof a === "string" && a !== "") : [],
-      }));
+      .filter((r) => r && typeof r.id === "string" && r.id.length > 0 && r.id.length <= 512 &&
+        !/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/.test(r.id))
+      .map((r) => {
+        const id = String(r.id);
+        const aliases = [...new Set([
+          id,
+          ...(Array.isArray(r.aliases) ? r.aliases : []),
+        ].filter((value): value is string =>
+          typeof value === "string" && value.length > 0 && value.length <= 512 &&
+          !/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/.test(value),
+        ))].slice(0, 16);
+        const legacyPinOrder = Number.isInteger(r.pinned_order) ? Number(r.pinned_order) : null;
+        const pinOrder = Number.isInteger(r.pin_order) ? Number(r.pin_order) : legacyPinOrder;
+        const boundedPinOrder = pinOrder !== null && pinOrder >= 0 && pinOrder < 16 ? pinOrder : null;
+        const rawPinName = typeof r.pin_name === "string" ? r.pin_name : r.pinned_name;
+        return {
+          id,
+          aliases,
+          name: typeof r.name === "string" ? r.name : null,
+          service: String(r.service ?? ""),
+          last: String(r.last ?? ""),
+          last_text: messagePreview(
+            r.last_text,
+            r.last_attachment && typeof r.last_attachment === "object"
+              ? { name: r.last_attachment.name, mime: r.last_attachment.mime }
+              : null,
+          ),
+          last_from_me: r.last_from_me === true,
+          last_handle: String(r.last_handle ?? ""),
+          last_name: typeof r.last_name === "string" ? r.last_name : null,
+          last_attachment: r.last_attachment && typeof r.last_attachment === "object"
+            ? { name: String(r.last_attachment.name ?? ""), mime: String(r.last_attachment.mime ?? "") }
+            : null,
+          pinned: r.pinned === true || boundedPinOrder !== null,
+          pin_order: boundedPinOrder,
+          pin_name: typeof rawPinName === "string" && rawPinName.trim() !== ""
+            ? rawPinName.trim().slice(0, 160) : null,
+        };
+      });
   } catch {
     return null;
   }
@@ -919,11 +1023,33 @@ export function mergeChats(
   const applyPin = (thread: Thread): Thread => {
     const info = infoByChat.get(thread.chat);
     if (!info) return thread;
+    const aliases = info.aliases ?? [info.id];
     const pinned = info.pinned === true;
     const pin_order = Number.isInteger(info.pin_order) ? Number(info.pin_order) : null;
-    return thread.pinned === pinned && thread.pin_order === pin_order
-      ? thread
-      : { ...thread, pinned, pin_order };
+    const group = isGroupChat(thread.chat);
+    const groupInfo = groups[thread.chat]
+      ?? aliases.map((alias) => groups[alias]).find((value) => value !== undefined);
+    const knownParticipantNames = new Map<string, string>(
+      (thread.participants ?? []).map((person) => [person.handle, person.name]),
+    );
+    return {
+      ...thread,
+      aliases,
+      guid: group ? groupInfo?.guid ?? thread.guid : "",
+      name: group
+        ? (groupInfo?.name || info.name || thread.name || thread.chat)
+        : (info.last_name || info.name || thread.name || thread.chat),
+      service: info.service || thread.service,
+      last_text: info.last === thread.last_ts ? info.last_text : messagePreview(thread.last_text),
+      pinned,
+      pin_order,
+      ...(info.pin_name ? { pin_name: info.pin_name } : {}),
+      ...(group ? {
+        participants: groupInfo
+          ? groupParticipants(groupInfo, knownParticipantNames)
+          : thread.participants ?? [],
+      } : {}),
+    };
   };
   const have = new Set(threads.map((t) => t.chat));
   const out = threads.map(applyPin);
@@ -931,12 +1057,16 @@ export function mergeChats(
     if (have.has(c.id)) continue;
     have.add(c.id);
     const group = isGroupChat(c.id);
+    const aliases = c.aliases ?? [c.id];
+    const groupInfo = groups[c.id]
+      ?? aliases.map((alias) => groups[alias]).find((value) => value !== undefined);
     const name = group
-      ? (groups[c.id]?.name || c.name || c.id)
+      ? (groupInfo?.name || c.name || c.id)
       : (c.last_name || c.name || c.id);
     out.push({
       chat: c.id,
-      guid: group ? groups[c.id]?.guid ?? "" : "",
+      aliases,
+      guid: group ? groupInfo?.guid ?? "" : "",
       name,
       handle: group ? c.last_handle || c.id : c.id,
       service: c.service,
@@ -944,9 +1074,11 @@ export function mergeChats(
       last_text: c.last_text,
       last_from_me: c.last_from_me,
       count: 0,
-      unread: unreadCounts[c.id] ?? 0,
+      unread: aliases.reduce((sum, alias) => sum + (unreadCounts[alias] ?? 0), 0),
       pinned: c.pinned === true,
       pin_order: Number.isInteger(c.pin_order) ? Number(c.pin_order) : null,
+      ...(c.pin_name ? { pin_name: c.pin_name } : {}),
+      ...(group ? { participants: groupParticipants(groupInfo) } : {}),
     });
   }
   return out.sort(compareThreads);
@@ -961,12 +1093,20 @@ export function fetchGroups(runner = spawnSync): Record<string, GroupInfo> | nul
     const out: Record<string, GroupInfo> = {};
     for (const r of rows) {
       if (!r || typeof r.chat !== "string") continue;
+      const participantNames = r.participant_names && typeof r.participant_names === "object"
+        && !Array.isArray(r.participant_names)
+        ? Object.fromEntries(Object.entries(r.participant_names)
+          .filter(([handle, name]) => typeof handle === "string" && handle.length <= 320
+            && typeof name === "string" && name.length <= 160)
+          .slice(0, 64)) as Record<string, string>
+        : {};
       out[r.chat] = {
         name: typeof r.name === "string" ? r.name : "",
         guid: typeof r.guid === "string" ? r.guid : "",
         participants: Array.isArray(r.participants)
           ? r.participants.filter((h: unknown) => typeof h === "string")
           : typeof r.participants === "string" ? r.participants.split(",").filter(Boolean) : [],
+        ...(Object.keys(participantNames).length ? { participantNames } : {}),
       };
     }
     return out;
@@ -977,7 +1117,13 @@ export function fetchGroups(runner = spawnSync): Record<string, GroupInfo> | nul
 
 // ---------------------------------------------------------------- main
 
-export function collect(deep: boolean, markRead = false, readChat = "", seenTs = ""): BlipOutput {
+export function collect(
+  deep: boolean,
+  markRead = false,
+  readChat = "",
+  seenTs = "",
+  readAliases: string[] = [],
+): BlipOutput {
   const now = new Date().toISOString();
   const state = loadState();
   // On migration, seed the ledger all the way back to what the user last read.
@@ -1007,7 +1153,9 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
     };
   }
 
-  const highest = maxTs(fetched.msgs, state.watermark);
+  const identityConfig = safeReadIdentityConfig();
+  const resolvedMessages = applyIdentityOverrides(fetched.msgs, identityConfig);
+  const highest = maxTs(resolvedMessages, state.watermark);
   // A message can carry a FUTURE timestamp (timezone skew — a "Sep 1
   // 08:53" birthday text arrived Aug 31 morning). A read mark taken from
   // the GLOBAL max therefore poisoned unrelated threads: anything arriving
@@ -1017,7 +1165,7 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
   // nothing beyond now leaks onto other threads.
   const nowTs = localNowTs();
   const chatMax: Record<string, string> = {};
-  for (const m of fetched.msgs) {
+  for (const m of resolvedMessages) {
     const c = chatKey(m);
     if (!chatMax[c] || m.ts > chatMax[c]!) chatMax[c] = m.ts;
   }
@@ -1032,29 +1180,37 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
       if (ts > readMark) readMarks[c] = ts;
     }
   }
+  const readTargets = [...new Set([readChat, ...readAliases])]
+    .filter((chat) => chat !== "" && chat.length <= 512 &&
+      !/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/.test(chat))
+    .slice(0, 16);
   if (readChat) {
     // Mark through what the user actually SAW (the panel passes the newest
     // bubble ts as --seen; it includes a future-dated row when the chat has
     // one on screen). A message arriving between the click and this run has
     // ts > seen and stays unread. Fallback without --seen: through now, or
     // the chat's own future row.
-    const own = chatMax[readChat] ?? "";
-    readMarks[readChat] = seenTs !== "" ? seenTs : (own > nowTs ? own : nowTs);
+    for (const target of readTargets) {
+      const own = chatMax[target] ?? "";
+      readMarks[target] = seenTs !== "" ? seenTs : (own > nowTs ? own : nowTs);
+    }
   }
   // Group metadata is ~1000 rows; refresh it only on a deep (panel) fetch and
   // keep the last good copy if the lookup fails.
   const groups = (deep ? fetchGroups() : null) ?? state.groups;
   // persist only on two independent twins; one may be a coincidence (#6)
-  const selfChats = [...new Set([...state.selfChats, ...detectSelfChats(fetched.msgs, 2)])];
-  const msgs = dedupeSelfEcho(fetched.msgs, selfChats);
+  const selfChats = [...new Set([...state.selfChats, ...detectSelfChats(resolvedMessages, 2)])];
+  const msgs = dedupeSelfEcho(resolvedMessages, selfChats);
   let exactCounts = unreadCounts(msgs, state.readMark, state.readMarks, selfChats);
   let exactOldest = unreadOldest(msgs, state.readMark, state.readMarks, selfChats);
   if (markRead) {
     exactCounts = {};
     exactOldest = {};
   } else if (readChat) {
-    delete exactCounts[readChat];
-    delete exactOldest[readChat];
+    for (const target of readTargets) {
+      delete exactCounts[target];
+      delete exactOldest[target];
+    }
   }
   // Prune per-thread marks the global mark has overtaken (Codex finding #13):
   // they no longer affect any count and would otherwise accumulate forever.
@@ -1074,9 +1230,12 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
   exactCounts = foldChatRecord(exactCounts, chatAliases, (a, b) => a + b);
   exactOldest = foldChatRecord(exactOldest, chatAliases, (a, b) => (a < b ? a : b));
   const foldedWindow = foldThreadAliases(windowThreads, chatAliases);
-  const threads = chats ? mergeChats(foldedWindow, chats, groups, exactCounts) : foldedWindow;
+  const threads = applyThreadIdentityOverrides(
+    chats ? mergeChats(foldedWindow, chats, groups, exactCounts) : foldedWindow,
+    identityConfig,
+  );
   const toast = selectToasts(msgs, state.watermark, loadAllowlist(), state.toasted);
-  const failures = selectFailures(fetched.msgs, state.toasted, nowTs);
+  const failures = selectFailures(resolvedMessages, state.toasted, nowTs);
   const links = selectIncomingLinks(msgs, state.watermark, state.toasted, selfChats);
   const unread = Object.values(exactCounts).reduce((n, count) => n + count, 0);
 
@@ -1125,10 +1284,14 @@ if (import.meta.main) {
   const markRead = process.argv.includes("--mark-read");
   const ri = process.argv.indexOf("--read");
   const readChat = ri >= 0 ? String(process.argv[ri + 1] ?? "") : "";
+  const readAliases: string[] = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === "--read-alias") readAliases.push(String(process.argv[i + 1] ?? ""));
+  }
   const si = process.argv.indexOf("--seen");
   const seenTs = si >= 0 ? String(process.argv[si + 1] ?? "") : "";
   try {
-    console.log(JSON.stringify(collect(deep, markRead, readChat, seenTs)));
+    console.log(JSON.stringify(collect(deep, markRead, readChat, seenTs, readAliases)));
   } catch (e) {
     console.log(
       JSON.stringify({

--- a/contact-repair.test.ts
+++ b/contact-repair.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./bridge/mac/contact-repair.js", import.meta.url), "utf8")
+  .replace(/^#![^\n]*\n/, "");
+let contactsApplication: any = null;
+const repair = new Function(
+  "ObjC",
+  "Application",
+  source + "\nreturn { normalizeRequest: normalizeRequest, perform: perform, setCard: setCard };",
+)({ import() {} }, () => contactsApplication) as {
+  normalizeRequest: (request: any) => any;
+  perform: (request: any) => any;
+  setCard: (contacts: any, person: any, card: any) => void;
+};
+
+function scalar(initial = "") {
+  let value = initial;
+  const property = (() => value) as (() => string) & { set: (next: string) => void };
+  property.set = (next: string) => { value = next; };
+  return property;
+}
+
+function labeled(label: string, value: string) {
+  return { label: () => label, value: () => value };
+}
+
+function fixture() {
+  const originalPhone = labeled("_$!<Mobile>!$_", "+1 (404) 555-0101");
+  const phones = [originalPhone];
+  const removed: any[] = [];
+  const added: any[] = [];
+  // JXA collection specifiers are callable AND support .push (the add
+  // pattern that works on current macOS); mirror that shape here.
+  function collection(entries: any[]) {
+    const property = (() => entries) as any;
+    property.push = (entry: any) => { added.push(entry); entries.push(entry); };
+    return property;
+  }
+  const person: any = {
+    firstName: scalar("Alex"), middleName: scalar(""), lastName: scalar("Rivera"),
+    nickname: scalar(), organization: scalar(), department: scalar(), jobTitle: scalar(),
+    note: scalar(), birthDate: scalar(), phones: collection(phones),
+    emails: collection([]), urls: collection([]), addresses: collection([]),
+  };
+  const contacts: any = {
+    // field removal deletes the entry specifier (the remove-from-person
+    // Apple event is broken on current macOS)
+    delete(entry: any) {
+      removed.push(entry);
+      phones.splice(phones.indexOf(entry), 1);
+    },
+    Phone(properties: any) {
+      return labeled(properties.label || "", properties.value);
+    },
+    Email(properties: any) { return labeled(properties.label || "", properties.value); },
+    Url(properties: any) { return labeled(properties.label || "", properties.value); },
+    Address(properties: any) { return properties; },
+    // the add-to-person Apple event is broken on current macOS; entries
+    // arrive through the collection specifiers' push instead
+  };
+  const card = {
+    firstName: "Alex", middleName: "Morgan", lastName: "Rivera",
+    nickname: "", organization: "", department: "", jobTitle: "",
+    birthday: "", note: "",
+    phones: [{ label: "_$!<Mobile>!$_", value: "+1 (404) 555-0101" }],
+    emails: [], urls: [], addresses: [],
+  };
+  return { contacts, person, card, originalPhone, removed, added };
+}
+
+describe("Contacts.app edit reconciliation", () => {
+  test("discarding a pending edit explicitly quits Contacts without saving", () => {
+    let quitArgument: any = null;
+    contactsApplication = {
+      running: () => true,
+      unsaved: () => true,
+      quit: (argument: any) => { quitArgument = argument; },
+    };
+    expect(repair.perform(repair.normalizeRequest({ operation: "discard-unsaved" })))
+      .toEqual({ ok: true, discarded: true });
+    expect(quitArgument).toEqual({ saving: "no" });
+  });
+
+  test("a scalar-only edit preserves the existing phone field", () => {
+    const f = fixture();
+    repair.setCard(f.contacts, f.person, f.card);
+    expect(f.removed).toEqual([]);
+    expect(f.added).toEqual([]);
+    expect(f.person.middleName()).toBe("Morgan");
+  });
+
+  test("a changed collection removes the concrete field object before replacing it", () => {
+    const f = fixture();
+    f.card.phones[0].value = "+1 (404) 555-0199";
+    repair.setCard(f.contacts, f.person, f.card);
+    expect(f.removed).toEqual([f.originalPhone]);
+    expect(f.added).toHaveLength(1);
+    expect(f.added[0].value()).toBe("+1 (404) 555-0199");
+  });
+
+  test("an add-only collection change keeps existing fields and pushes the additions", () => {
+    // removing a damaged stored row fails where additions still work, so an
+    // edit that only ADDS values must never take the remove-all path
+    const f = fixture();
+    f.card.phones.push({ label: "_$!<Home>!$_", value: "+1 (404) 555-0102" });
+    repair.setCard(f.contacts, f.person, f.card);
+    expect(f.removed).toEqual([]);
+    expect(f.added).toHaveLength(1);
+    expect(f.added[0].value()).toBe("+1 (404) 555-0102");
+    expect(f.person.phones()).toHaveLength(2);
+  });
+});

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -11,6 +11,8 @@ inventory of what lands on disk.
 | `~/.config/blip/bridge.conf` (0600) | Mac ssh target, remote tool dir, path of Blip's key, `automation=` switch | credentials |
 | `~/.ssh/blip_ed25519` | Blip's dedicated ssh key — confined on the Mac to the bridge tools | — |
 | `~/.config/blip/allowlist.json` | handles allowed to raise desktop toasts | message text |
+| `~/.config/blip/preferences.json` (0600, atomic) | appearance values: bubble colors, opacity, scale, density, widths and sizes | names, handles, message text |
+| `~/.config/blip/identities.json` (0600, atomic) | explicit handle → display-name choices and an opaque Contacts candidate token | message text, contact photos, other contact fields |
 | `~/.local/state/blip/state.json` (0600, atomic) | poll watermark, read marks, per-chat unread counts and oldest-unread timestamps, self-chat ids, group names/members, opaque SHA-256 toast keys | **message bodies — ever** |
 | `~/.local/state/blip/window.json` | whether the app window was open, its size | anything else |
 | `~/.cache/blip/att/` (0700, files 0600, 500 MB LRU, no expiry) | attachments you viewed, plus images ≤ 5 MB and link-preview thumbnails in any conversation you *open* (they render inline, so they are fetched when the thread is). HEIC arrives converted to JPEG. File names carry the Mac's attachment row id and a sanitized name whose extension follows the MIME type | attachments in conversations you never opened |
@@ -42,8 +44,8 @@ toasts show a sender name and a preview through your notification daemon,
 gated by the allowlist — and your notification daemon may keep its own
 history. Blip itself logs nothing; the shell's stderr (journald) sees
 recipients and exit codes, never bodies (`imsg-send` prints a byte count).
-Message bodies do pass through process arguments on both machines, visible
-to other processes running as you.
+Message bodies and identity-resolution handles travel on bounded stdin, not
+process arguments.
 
 Threat model and the audit findings behind these notes: [SECURITY.md](SECURITY.md).
 
@@ -58,23 +60,48 @@ Threat model and the audit findings behind these notes: [SECURITY.md](SECURITY.m
 
 The tools read `~/Library/Messages/chat.db`, the AddressBook database, and
 Messages' pinning preferences read-only, and drive Messages.app through
-AppleScript. They write nothing else. Messages.app itself keeps your
-conversation history exactly as it always has.
+AppleScript. The pinning data contributes only the
+ordered identifiers needed to reproduce Messages.app's pinned-conversation
+grid. The identity guide returns opaque tokens for individual matching source
+cards. Before presenting them, the Mac bridge verifies that each raw database
+row still exists in the Contacts object layer and drops inactive account-cache
+rows. An explicit comparison can return the selected cards' bounded name,
+organization, phone, email, address, URL, birthday, and notes to Blip for the
+life of the settings view; this detail is not added to Blip's config or cache.
+Only opaque card tokens leave the Mac—raw source and record ids do not.
+
+**Open card on Mac** opens one validated persistent card and makes no edit. If
+the separately gated write feature is enabled, Blip can ask Contacts.app to
+remove one revalidated phone/email field after a second confirmation, or ask
+Apple's UI to link/merge the exact compared cards after a separate confirmation
+that names the action. Field removal has a private seven-day Mac-local undo
+receipt. Apple's link/merge action may sync upstream and has no Blip undo.
+Consolidation and whole-card deletion use Apple's public Contacts framework
+after the same preview and revalidation. Blip never writes the private
+AddressBook SQLite files. Messages.app keeps your conversation history exactly
+as it always has.
 
 ## Permissions the Mac asks for
 
 - **Full Disk Access** for `/usr/libexec/sshd-keygen-wrapper` — so an ssh
   session can read `chat.db`.
 - **Automation → Messages** for the same — so an ssh session can send.
+- Optional **Automation → Contacts** for the same — only if automatic contact
+  repair is explicitly enabled and used.
+- Optional **Accessibility** for the same — only to select exact Contacts cards
+  and invoke an allowlisted, enabled Link/Merge Selected Cards menu action after
+  confirmation.
 
-Both are one-time grants in System Settings; `blip-check` reports which are
-missing. Blip never asks for Contacts, Camera, Microphone, or Location.
+Automation and Full Disk Access are one-time grants in System Settings;
+`blip-check` reports the core grants. Blip never asks for Camera, Microphone,
+or Location.
 
 ## What crosses the network
 
-Only ssh between the two machines: message queries and previews, ordered
-conversation-pin metadata, attachment bytes you request, and files you send.
-Push notifications use a
+Only ssh between the two machines: message queries and previews, pinned chat
+identifiers/order, bounded candidate names/counts and explicitly requested card
+details from the contact resolver, attachment bytes you request, and files you
+send. Push notifications use a
 content-free "something changed" ping — a watcher on the Mac emits a
 timestamp when `chat.db` changes; the client then fetches privately.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -51,3 +51,53 @@ a test fixture. Deferred items are listed in ROADMAP.md.
 Still open and honest about it: drafts in `$XDG_RUNTIME_DIR/blip` are swept
 lazily rather than deleted on cancel; cache file names include the Mac
 attachment ROWID.
+
+## Identity resolver boundary (2026-09-02)
+
+Ambiguous Contacts matches remain fail-closed: the bridge returns no guessed
+name. The settings resolver is a separate, explicit path with these limits:
+
+- Linux request stdin: 4 KiB; local `identities.json`: 48 KiB, 64 choices,
+  320 characters per handle, 160 per name; helper output: 48 KiB.
+- Mac scan: 64 Contacts account stores, 64 matching records, eight distinct
+  candidate names; a selected comparison is limited to eight active cards and
+  16 values per field kind; response: 48 KiB; Linux bridge deadline is 15
+  seconds for lookup/open and 35 seconds for Contacts automation.
+- Controls and bidirectional overrides are removed before display; QML checks
+  the bounded helper schema again before retaining it.
+- The handle crosses the process/ssh boundary on stdin, never argv. A choice
+  is revalidated against a fresh Mac candidate set before the owner-only,
+  descriptor-relative atomic config write.
+- **Open card on Mac** accepts only a revalidated opaque per-card token and
+  invokes `/usr/bin/open` with a percent-encoded `addressbook://` persistent id
+  via a fixed argument array. Source UUIDs and record ids stay on the Mac. It
+  never writes Apple’s private SQLite stores.
+- Candidate cards are intersected with the current Contacts object layer, so
+  inactive per-account cache rows are not presented as editable contacts.
+- Card comparison is read-only and returns only bounded, sanitized fields with
+  opaque card tokens; raw source and record identifiers stay on the Mac. The
+  QML layer revalidates the full schema before rendering it as plain text.
+- Optional automatic repair is fail-closed behind two independent opt-ins:
+  `contact_writes=on` in the owner-controlled Linux config and a 0600 regular
+  `~/.blip/contact-writes-enabled` gate on the Mac that the forced-command key
+  cannot create. The bridge revalidates the opaque card token, Contacts.app
+  verifies the exact matching field set, refuses unrelated unsaved changes,
+  and only then removes through its supported scripting API. One private,
+  seven-day Mac-local receipt supports an immediate exact-field undo.
+- Consolidation and whole-card deletion receive only the revalidated private
+  card identifiers and bounded draft over stdin, then use Apple's public
+  `CNSaveRequest` API. Same-account changes share one request; cross-account
+  consolidation saves the complete survivor first and deletes sources in
+  container-scoped requests because Contacts rejects cross-store transactions.
+  The compiled helper fetches non-unified source records, rejects oversized or
+  malformed input, returns no identifiers, and is not exposed by the dedicated
+  SSH forced-command allowlist.
+- Native link/merge uses Contacts' exact current selection and one allowlisted,
+  enabled menu action through Accessibility. Preview and execution are separate;
+  execution pins the action text the user confirmed and aborts if it changes.
+  Contacts refuses unrelated unsaved changes. Linking may sync upstream and has
+  no Blip undo receipt, so Blip never runs it during discovery or preview.
+
+The Bun and Python suites exercise malformed types, oversize sentinels,
+symlinks, FIFOs, equivalent-handle collisions, hostile display fields,
+stdin-not-argv transport, candidate caps, and the fixed open argument shape.

--- a/fetch.ts
+++ b/fetch.ts
@@ -38,6 +38,7 @@ const HOME = process.env.HOME ?? homedir();
 export const CACHE_DIR = join(process.env.XDG_CACHE_HOME ?? join(HOME, ".cache"), "blip", "att");
 export const CACHE_CAP_BYTES = 500 * 1024 * 1024;
 export const FETCH_MAX_BYTES = 100 * 1024 * 1024;
+
 /** Long edge for an auto-fetched inline preview. The bubble decodes at 800;
  *  1600 keeps it crisp on a HiDPI panel and still lands well under any cap. */
 export const PREVIEW_MAX_DIM = 1600;

--- a/identities.test.ts
+++ b/identities.test.ts
@@ -1,0 +1,703 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyIdentityOverrides, applyThreadIdentityOverrides, type Thread } from "./collector";
+import {
+  auditContactsOnMac,
+  contactWritesEnabled,
+  contactMutationOnMac,
+  exportContactVCard,
+  identityKey,
+  identityNameFor,
+  MAX_BRIDGE_CONFIG_BYTES,
+  MAX_IDENTITIES_BYTES,
+  MAX_IDENTITY_REQUEST_BYTES,
+  normalizeBridgeCandidates,
+  normalizeContactComparison,
+  normalizeContactAudit,
+  normalizeContactDraft,
+  normalizeIdentityConfig,
+  normalizeRepairPreview,
+  parseIdentities,
+  readBoundedIdentityFile,
+  readBoundedBridgeConfig,
+  readIdentities,
+  resolveOnMac,
+  safeReadIdentityConfig,
+  writeIdentities,
+  type IdentityConfig,
+} from "./identities";
+
+const roots: string[] = [];
+function fixture(): { root: string; path: string } {
+  const root = mkdtempSync(join(tmpdir(), "blip-identities-"));
+  roots.push(root);
+  return { root, path: join(root, "blip", "identities.json") };
+}
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+const token = "sha256:" + "a".repeat(64);
+const cardToken = (character: string) => "sha256:" + character.repeat(64);
+const config: IdentityConfig = {
+  schemaVersion: 1,
+  identities: {
+    "+15550100001": { name: "Alex Rivera", source: "contacts", contactToken: token },
+    "quiet@example.com": { name: "Quiet Person", source: "custom" },
+  },
+};
+
+describe("identity schema", () => {
+  test("normalizes valid contact and custom choices", () => {
+    expect(normalizeIdentityConfig(config)).toEqual(config);
+  });
+
+  test("phone variants and email case share one identity key", () => {
+    expect(identityKey("+1 (555) 010-0001")).toBe(identityKey("5550100001"));
+    expect(identityKey("QUIET@EXAMPLE.COM")).toBe(identityKey("quiet@example.com"));
+    expect(identityNameFor("5550100001", config)).toBe("Alex Rivera");
+  });
+
+  test("rejects wrong top-level types, versions, sources, and tokens", () => {
+    for (const value of [null, [], "x", 1, true])
+      expect(() => normalizeIdentityConfig(value)).toThrow("JSON object");
+    expect(() => normalizeIdentityConfig({ ...config, schemaVersion: 2 })).toThrow("schemaVersion");
+    expect(() => normalizeIdentityConfig({ schemaVersion: 1, identities: {
+      "+15550100001": { name: "Alex", source: "guessed" },
+    } })).toThrow("source");
+    expect(() => normalizeIdentityConfig({ schemaVersion: 1, identities: {
+      "+15550100001": { name: "Alex", source: "contacts", contactToken: "bad" },
+    } })).toThrow("token");
+  });
+
+  test("rejects equivalent duplicate handles", () => {
+    expect(() => normalizeIdentityConfig({ schemaVersion: 1, identities: {
+      "+1 (555) 010-0001": { name: "Alex", source: "custom" },
+      "5550100001": { name: "Someone else", source: "custom" },
+    } })).toThrow("equivalent duplicate");
+  });
+
+  test("caps before sanitizing and strips dangerous display controls", () => {
+    const normalized = normalizeIdentityConfig({ schemaVersion: 1, identities: {
+      "+15550100001": { name: "Alex\u202e HTML <b>x</b>", source: "custom" },
+    } });
+    expect(normalized.identities["+15550100001"]!.name).toBe("Alex HTML <b>x</b>");
+    expect(() => normalizeIdentityConfig({ schemaVersion: 1, identities: {
+      "+15550100001": { name: "x".repeat(161), source: "custom" },
+    } })).toThrow("too long");
+  });
+
+  test("malformed JSON is reported without echoing content", () => {
+    expect(() => parseIdentities('{"private":"do not echo"')).toThrow("not valid JSON");
+  });
+});
+
+describe("bounded identity file", () => {
+  test("a missing file is an empty config", () => {
+    const { path } = fixture();
+    expect(readIdentities(path)).toEqual({ exists: false, config: { schemaVersion: 1, identities: {} } });
+  });
+
+  test("round-trips atomically with private modes", () => {
+    const { root, path } = fixture();
+    writeIdentities(path, config);
+    expect(readIdentities(path)).toEqual({ exists: true, config });
+    expect(lstatSync(join(root, "blip")).mode & 0o777).toBe(0o700);
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    expect(readFileSync(path, "utf8")).toContain('"Alex Rivera"');
+  });
+
+  test("accepts the exact byte cap and rejects one byte over", () => {
+    const { path } = fixture();
+    writeIdentities(path, config);
+    writeFileSync(path, Buffer.alloc(MAX_IDENTITIES_BYTES, 0x20));
+    expect(readBoundedIdentityFile(path)?.length).toBe(MAX_IDENTITIES_BYTES);
+    writeFileSync(path, Buffer.alloc(MAX_IDENTITIES_BYTES + 1, 0x20));
+    expect(() => readBoundedIdentityFile(path)).toThrow("too large");
+  });
+
+  test("rejects symlinks and nonblocking FIFOs", () => {
+    const first = fixture();
+    const target = join(first.root, "target.json");
+    writeIdentities(target, config);
+    writeIdentities(join(first.root, "blip", "seed.json"), config);
+    symlinkSync(target, first.path);
+    expect(() => readBoundedIdentityFile(first.path)).toThrow();
+    expect(() => writeIdentities(first.path, config)).toThrow("regular file");
+
+    const second = fixture();
+    writeIdentities(join(second.root, "blip", "seed.json"), config);
+    expect(Bun.spawnSync(["mkfifo", second.path]).exitCode).toBe(0);
+    expect(() => readBoundedIdentityFile(second.path)).toThrow("regular file");
+  });
+
+  test("tightens a permissive identity directory and fails closed on invalid config", () => {
+    const { root, path } = fixture();
+    writeIdentities(path, config);
+    chmodSync(join(root, "blip"), 0o755);
+    writeIdentities(path, config);
+    expect(lstatSync(join(root, "blip")).mode & 0o777).toBe(0o700);
+    writeFileSync(path, "not json");
+    expect(safeReadIdentityConfig(path)).toEqual({ schemaVersion: 1, identities: {} });
+  });
+});
+
+describe("contact-write opt-in", () => {
+  test("is disabled by default and accepts only an explicit on value", () => {
+    const { root } = fixture();
+    const path = join(root, "blip", "bridge.conf");
+    writeIdentities(join(root, "blip", "seed.json"), config);
+    writeFileSync(path, "host=mac\ncontact_writes=off\n");
+    expect(contactWritesEnabled(path)).toBe(false);
+    writeFileSync(path, "contact_writes='on'\n");
+    expect(contactWritesEnabled(path)).toBe(true);
+    writeFileSync(path, "contact_writes=on\ncontact_writes=off\n");
+    expect(contactWritesEnabled(path)).toBe(false);
+  });
+
+  test("fails closed for oversized, symlinked, and group-writable config", () => {
+    const first = fixture();
+    const path = join(first.root, "blip", "bridge.conf");
+    writeIdentities(join(first.root, "blip", "seed.json"), config);
+    writeFileSync(path, Buffer.alloc(MAX_BRIDGE_CONFIG_BYTES + 1, 0x20));
+    expect(contactWritesEnabled(path)).toBe(false);
+    expect(() => readBoundedBridgeConfig(path)).toThrow("too large");
+    writeFileSync(path, "contact_writes=on\n");
+    chmodSync(path, 0o622);
+    expect(contactWritesEnabled(path)).toBe(false);
+
+    const second = fixture();
+    const target = join(second.root, "target.conf");
+    const link = join(second.root, "blip", "bridge.conf");
+    writeIdentities(join(second.root, "blip", "seed.json"), config);
+    writeFileSync(target, "contact_writes=on\n");
+    symlinkSync(target, link);
+    expect(contactWritesEnabled(link)).toBe(false);
+  });
+});
+
+describe("Mac candidate boundary", () => {
+  test("validates a bounded candidate response", () => {
+    const cards = [
+      { token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: true, matchCount: 1 },
+      { token: cardToken("c"), accountNumber: 2, sourceName: "Google", hasPhoto: false, matchCount: 1 },
+      { token: cardToken("d"), accountNumber: 2, sourceName: "Google", hasPhoto: false, matchCount: 1 },
+    ];
+    expect(normalizeBridgeCandidates({
+      ok: true,
+      handle: "+15550100001",
+      candidates: [{
+        token, name: "Alex Rivera", recordCount: 3, sourceCount: 2, hasPhoto: true, cards,
+      }],
+    }, "+15550100001")).toEqual([
+      { token, name: "Alex Rivera", recordCount: 3, sourceCount: 2, hasPhoto: true, cards },
+    ]);
+  });
+
+  test("rejects wrong handles, oversized lists, and hostile fields", () => {
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100002", candidates: [] }, "+15550100001"))
+      .toThrow("different handle");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: Array(9).fill({
+      token, name: "Alex", recordCount: 1, sourceCount: 1, hasPhoto: false,
+    }) }, "+15550100001")).toThrow("too many");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: [{
+      token: "bad", name: "<b>unsafe</b>", recordCount: 1, sourceCount: 1, hasPhoto: false,
+    }] }, "+15550100001")).toThrow("token");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: [{
+      token, name: "Alex", recordCount: 2, sourceCount: 1, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    }] }, "+15550100001")).toThrow("source-card list");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: [{
+      token, name: "Alex", recordCount: 1, sourceCount: 2, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    }] }, "+15550100001")).toThrow("account metadata");
+  });
+
+  test("the handle travels through stdin, never argv", () => {
+    let capturedArgs: string[] = [];
+    let capturedInput = "";
+    const runner = ((_command: string, args: string[], options: any) => {
+      capturedArgs = args;
+      capturedInput = options.input;
+      return {
+        status: 0,
+        signal: null,
+        output: [],
+        pid: 1,
+        stdout: JSON.stringify({
+          ok: true,
+          handle: "+15550100001",
+          candidates: [{
+            token, name: "Alex Rivera", recordCount: 1, sourceCount: 1, hasPhoto: false,
+            cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+          }],
+        }),
+        stderr: "",
+        error: undefined,
+      };
+    }) as any;
+    const result = resolveOnMac("candidates", "+15550100001", undefined, runner);
+    expect(capturedArgs).toEqual(["--json", "resolve"]);
+    expect(capturedArgs.join(" ")).not.toContain("15550100001");
+    expect(JSON.parse(capturedInput).handle).toBe("+15550100001");
+    expect(result.candidates?.[0]?.name).toBe("Alex Rivera");
+  });
+
+  test("contact audit classifies a bounded handle batch through one bridge call", () => {
+    let capturedInput = "";
+    const single = {
+      token, name: "Alex Rivera", recordCount: 1, sourceCount: 1, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    };
+    const duplicate = {
+      token: cardToken("c"), name: "Pat Rivera", recordCount: 2, sourceCount: 2, hasPhoto: false,
+      cards: [
+        { token: cardToken("d"), accountNumber: 1, sourceName: "Gmail", hasPhoto: false },
+        { token: cardToken("e"), accountNumber: 2, sourceName: "iCloud", hasPhoto: false },
+      ],
+    };
+    const runner = ((_command: string, args: string[], options: any) => {
+      capturedInput = options.input;
+      return {
+        status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({
+          ok: true, handleCount: 3, noMatchCount: 1,
+          singleCards: [{ handle: "+15550100001", candidates: [single] }],
+          duplicates: [{ handle: "+15550100002", candidates: [duplicate] }],
+          conflicts: [],
+        }),
+      };
+    }) as any;
+    const savedHome = process.env.HOME;
+    process.env.HOME = mkdtempSync(join(tmpdir(), "blip-audit-test-"));
+    try {
+      const result = auditContactsOnMac(
+        ["+15550100001", "+15550100002", "+15550100003"], runner,
+      );
+      expect(result.cached).toBe(false);
+      expect(result.audit.noMatchCount).toBe(1);
+      expect(result.audit.singleCards[0]?.candidates[0]?.name).toBe("Alex Rivera");
+      expect(result.audit.duplicates[0]?.candidates[0]?.recordCount).toBe(2);
+      expect(JSON.parse(capturedInput)).toEqual({
+        operation: "audit", handles: ["+15550100001", "+15550100002", "+15550100003"],
+      });
+    } finally {
+      process.env.HOME = savedHome;
+    }
+  });
+
+  test("an unchanged store fingerprint reuses the cached scan without re-scanning", () => {
+    const savedHome = process.env.HOME;
+    process.env.HOME = mkdtempSync(join(tmpdir(), "blip-audit-cache-"));
+    const fingerprint = "sha256:" + "9".repeat(64);
+    const operations: string[] = [];
+    const runner = ((_command: string, _args: string[], options: any) => {
+      const request = JSON.parse(options.input);
+      operations.push(request.operation);
+      if (request.operation === "fingerprint")
+        return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+          stdout: JSON.stringify({ ok: true, fingerprint }) };
+      return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({
+          ok: true, fingerprint, handleCount: 1, noMatchCount: 1,
+          singleCards: [], duplicates: [], conflicts: [],
+        }) };
+    }) as any;
+    try {
+      const first = auditContactsOnMac(["+15550100001"], runner);
+      expect(first.cached).toBe(false);
+      const second = auditContactsOnMac(["+15550100001"], runner);
+      expect(second.cached).toBe(true);
+      expect(second.audit.noMatchCount).toBe(1);
+      // the second call only paid one cheap fingerprint round-trip
+      expect(operations).toEqual(["audit", "fingerprint"]);
+      // a different conversation set never reuses the cache
+      const third = auditContactsOnMac(["+15550100002"], runner);
+      expect(third.cached).toBe(false);
+      expect(operations).toEqual(["audit", "fingerprint", "audit"]);
+    } finally {
+      process.env.HOME = savedHome;
+    }
+  });
+
+  test("contact audit rejects inconsistent totals and category shapes", () => {
+    const single = {
+      token, name: "Alex Rivera", recordCount: 1, sourceCount: 1, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    };
+    const base = {
+      handleCount: 1, noMatchCount: 0,
+      singleCards: [{ handle: "+15550100001", candidates: [single] }],
+      duplicates: [], conflicts: [],
+    };
+    expect(() => normalizeContactAudit({ ...base, noMatchCount: 1 }, 1)).toThrow("totals");
+    expect(() => normalizeContactAudit({
+      ...base, singleCards: [], duplicates: [{ handle: "+15550100001", candidates: [single] }],
+    }, 1)).toThrow("duplicate-card");
+    expect(() => auditContactsOnMac(["+15550100001", "5550100001"])).toThrow("duplicate handle");
+    const wrongHandleRunner = (() => ({
+      status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+      stdout: JSON.stringify({
+        ok: true, handleCount: 1, noMatchCount: 0,
+        singleCards: [{ handle: "+15550199999", candidates: [single] }],
+        duplicates: [], conflicts: [],
+      }),
+    })) as any;
+    expect(() => auditContactsOnMac(["+15550100001"], wrongHandleRunner)).toThrow("unrequested");
+  });
+
+  test("exact-card open keeps its token on stdin and validates card metadata", () => {
+    let capturedInput = "";
+    const exactToken = cardToken("e");
+    const runner = ((_command: string, args: string[], options: any) => {
+      capturedInput = options.input;
+      return {
+        status: 0,
+        signal: null,
+        output: [],
+        pid: 1,
+        stdout: JSON.stringify({
+          ok: true, opened: true, name: "Alex Rivera",
+          cardNumber: 2, cardCount: 3, accountNumber: 1, sourceName: "iCloud",
+        }),
+        stderr: "",
+        error: undefined,
+      };
+    }) as any;
+    expect(resolveOnMac("open", "+15550100001", exactToken, runner)).toEqual({
+      handle: "+15550100001", opened: true, name: "Alex Rivera",
+      cardNumber: 2, cardCount: 3, accountNumber: 1, sourceName: "iCloud",
+    });
+    expect(JSON.parse(capturedInput)).toEqual({
+      operation: "open", handle: "+15550100001", token: exactToken,
+    });
+  });
+
+  test("vCard export stays on stdin and creates a real owner-only .vcf file", () => {
+    let bridgeInput = "";
+    const runtime = fixture().root;
+    const card = Buffer.from(
+      "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alex Rivera\r\nEND:VCARD\r\n",
+      "utf8",
+    );
+    const runner = ((_command: string, args: string[], options: any) => {
+      expect(args).toEqual(["--json", "resolve"]);
+      bridgeInput = options.input;
+      return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({ ok: true, name: "Alex Rivera", vcard: card.toString("base64") }) };
+    }) as any;
+    const result = exportContactVCard("+15550100001", runner, runtime);
+    expect(result).toEqual({
+      handle: "+15550100001", name: "Alex Rivera", bytes: card.length,
+      fileName: "Alex Rivera.vcf",
+      fileUri: expect.stringContaining("/Alex%20Rivera.vcf"),
+    });
+    expect(JSON.parse(bridgeInput)).toEqual({
+      operation: "vcard", handle: "+15550100001",
+    });
+    const copiedPath = decodeURIComponent(new URL(result.fileUri).pathname);
+    expect(readFileSync(copiedPath)).toEqual(card);
+    expect(lstatSync(copiedPath).mode & 0o077).toBe(0);
+  });
+
+  test("discard-unsaved sends no contact identifier and validates the result", () => {
+    let bridgeInput = "";
+    const runner = ((_command: string, args: string[], options: any) => {
+      expect(args).toEqual(["--json", "resolve"]);
+      bridgeInput = options.input;
+      return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({ ok: true, discarded: true }) };
+    }) as any;
+    expect(resolveOnMac("discard-unsaved", undefined, undefined, runner))
+      .toEqual({ discarded: true });
+    expect(JSON.parse(bridgeInput)).toEqual({ operation: "discard-unsaved" });
+  });
+
+  test("validates repair previews and rejects inconsistent metadata", () => {
+    const preview = {
+      handle: "+15550100001", name: "Pat Rivera", kind: "phone",
+      fieldCount: 1, labels: ["mobile"], cardNumber: 1, cardCount: 2,
+      accountNumber: 1, sourceName: "iCloud", writeEnabled: true,
+    };
+    expect(normalizeRepairPreview(preview, "5550100001")).toEqual(preview);
+    expect(() => normalizeRepairPreview({ ...preview, labels: [] }, preview.handle))
+      .toThrow("field-label");
+    expect(() => normalizeRepairPreview({ ...preview, cardNumber: 3 }, preview.handle))
+      .toThrow("inconsistent card");
+    expect(() => normalizeRepairPreview({ ...preview, name: "x".repeat(161) }, preview.handle))
+      .toThrow("too long");
+  });
+
+  test("validates bounded contact-card comparisons", () => {
+    const comparison = {
+      handle: "+15550100001", name: "Alex Rivera", cardCount: 2,
+      sourceCount: 2, writeEnabled: true,
+      cards: [1, 2].map((number) => ({
+        token: cardToken(number === 1 ? "b" : "c"), revision: cardToken(number === 1 ? "d" : "e"), cardNumber: number,
+        accountNumber: number, sourceName: number === 1 ? "iCloud" : "Google",
+        hasPhoto: number === 1,
+        displayName: "Alex Rivera", firstName: "Alex", middleName: "", lastName: "Rivera",
+        nickname: "", organization: "Example", department: "", jobTitle: "",
+        birthday: "--09-02", note: "",
+        phones: [{ label: "mobile", value: "+1 555 010 0001" }],
+        emails: number === 1 ? [{ label: "home", value: "alex@example.com" }] : [],
+        urls: [], addresses: number === 2 ? [{ label: "home", street: "1 Main St",
+          city: "Madison", state: "WI", postalCode: "53703", country: "US",
+          countryCode: "US" }] : [],
+      })),
+    };
+    expect(normalizeContactComparison(comparison, "5550100001")).toEqual(comparison);
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      comparison.cards[0], { ...comparison.cards[1], token: comparison.cards[0]!.token },
+    ] }, comparison.handle)).toThrow("duplicate comparison card");
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      comparison.cards[0], { ...comparison.cards[1], cardNumber: 3 },
+    ] }, comparison.handle)).toThrow("card numbers");
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      { ...comparison.cards[0], phones: Array(17).fill({ label: "x", value: "1" }) },
+      comparison.cards[1],
+    ] }, comparison.handle)).toThrow("phone list");
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      { ...comparison.cards[0], note: "x".repeat(1001) }, comparison.cards[1],
+    ] }, comparison.handle)).toThrow("note");
+  });
+
+  test("comparison and link operations stay on stdin and validate Apple actions", () => {
+    const comparison = {
+      handle: "+15550100001", name: "Alex Rivera", cardCount: 2,
+      sourceCount: 2, writeEnabled: true,
+      cards: [1, 2].map((number) => ({
+        token: cardToken(number === 1 ? "b" : "c"), revision: cardToken(number === 1 ? "d" : "e"), cardNumber: number,
+        accountNumber: number, sourceName: number === 1 ? "iCloud" : "Google",
+        hasPhoto: false, displayName: "Alex Rivera",
+        firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "",
+        organization: "", department: "", jobTitle: "", birthday: "", note: "",
+        phones: [], emails: [], urls: [], addresses: [],
+      })),
+    };
+    const captured: Array<{ args: string[]; input: string }> = [];
+    const responses = [
+      { ok: true, ...comparison },
+      { ok: true, handle: comparison.handle, name: comparison.name, cardCount: 2,
+        sourceCount: 2, writeEnabled: true, ready: true, action: "Link Selected Cards" },
+      { ok: true, handle: comparison.handle, name: comparison.name, cardCount: 2,
+        sourceCount: 2, writeEnabled: true, linked: true, action: "Link Selected Cards" },
+    ];
+    const runner = ((_command: string, args: string[], options: any) => {
+      captured.push({ args, input: options.input });
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify(responses.shift()), stderr: "", error: undefined };
+    }) as any;
+    expect(resolveOnMac("compare", comparison.handle, token, runner).comparison?.cardCount).toBe(2);
+    expect(resolveOnMac("link-prepare", comparison.handle, token, runner).linkPreview?.ready).toBe(true);
+    expect(resolveOnMac(
+      "link", comparison.handle, token, runner, undefined, "Link Selected Cards",
+    ).linkResult?.linked).toBe(true);
+    expect(captured.every(({ args }) => args.join(" ").includes("15550100001") === false)).toBe(true);
+    expect(captured.map(({ input }) => JSON.parse(input))).toEqual([
+      { operation: "compare", handle: comparison.handle, ownerToken: token },
+      { operation: "link-prepare", handle: comparison.handle, ownerToken: token },
+      { operation: "link", handle: comparison.handle, ownerToken: token,
+        expectedAction: "Link Selected Cards" },
+    ]);
+    const badRunner = (() => ({ status: 0, signal: null, output: [], pid: 1,
+      stdout: JSON.stringify({ ...responses[0], ok: true, handle: comparison.handle,
+        name: comparison.name, cardCount: 2, sourceCount: 2, writeEnabled: true,
+        ready: true, action: "Delete Cards" }), stderr: "", error: undefined })) as any;
+    expect(() => resolveOnMac("link-prepare", comparison.handle, token, badRunner))
+      .toThrow("invalid link action");
+    expect(() => resolveOnMac(
+      "link", comparison.handle, token, runner, undefined, "Delete Cards",
+    )).toThrow("confirmed Contacts action");
+  });
+
+  test("contact edits are bounded, revision-pinned, previewed, and confirmed", () => {
+    const exactToken = cardToken("b");
+    const revision = cardToken("c");
+    const planHash = cardToken("d");
+    const draft = normalizeContactDraft({
+      firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "Lex",
+      organization: "Example", department: "", jobTitle: "", birthday: "--09-02",
+      note: "", phones: [{ label: "mobile", value: "+1 555 010 0001" }],
+      emails: [], urls: [], addresses: [],
+    });
+    const metadata = {
+      action: "edit", handle: "+15550100001", name: "Alex Rivera", cardNumber: 1,
+      cardCount: 2, accountNumber: 1, sourceName: "iCloud", sourceCardCount: 0,
+      changedFields: ["nickname"], planHash, writeEnabled: true,
+    };
+    const captured: string[] = [];
+    const responses = [
+      { ok: true, preview: metadata },
+      { ok: true, ...metadata, applied: true, undoToken: "undo:" + "f".repeat(32),
+        revision: cardToken("e"), displayName: "Alex Rivera" },
+    ];
+    const runner = ((_command: string, args: string[], options: any) => {
+      expect(args).toEqual(["--json", "resolve"]);
+      captured.push(options.input);
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify(responses.shift()), stderr: "", error: undefined };
+    }) as any;
+    const input = { handle: metadata.handle, ownerToken: token, token: exactToken, revision, card: draft };
+    expect(contactMutationOnMac("edit-prepare", input, runner).preview?.action).toBe("edit");
+    expect(contactMutationOnMac("edit", { ...input, planHash }, runner).result?.applied).toBe(true);
+    expect(JSON.parse(captured[0]!)).toEqual({ operation: "edit-prepare", ...input });
+    expect(JSON.parse(captured[1]!)).toEqual({ operation: "edit", ...input, planHash });
+    expect(() => contactMutationOnMac("edit", { ...input, planHash: "sha256:bad" }, runner))
+      .toThrow("revision");
+  });
+
+  test("cross-name merge threads the second owner token and rejects a duplicate", () => {
+    const token = "sha256:" + "1".repeat(64);
+    const otherToken = "sha256:" + "2".repeat(64);
+    const captured: string[] = [];
+    const comparison = {
+      handle: "+15550100001", name: "Alex Rivera", cardCount: 2,
+      sourceCount: 2, writeEnabled: true,
+      cards: [1, 2].map((number) => ({
+        token: "sha256:" + String(number).repeat(63) + "a",
+        revision: "sha256:" + String(number).repeat(63) + "b", cardNumber: number,
+        accountNumber: number, sourceName: number === 1 ? "iCloud" : "Google",
+        hasPhoto: false, displayName: "Alex Rivera",
+        firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "",
+        organization: "", department: "", jobTitle: "", birthday: "", note: "",
+        phones: [], emails: [], urls: [], addresses: [],
+      })),
+    };
+    const runner = ((_command: string, _args: string[], options: any) => {
+      captured.push(options.input);
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify({ ok: true, ...comparison }), stderr: "", error: undefined };
+    }) as any;
+    resolveOnMac("compare", comparison.handle, token, runner, undefined, undefined, otherToken);
+    expect(JSON.parse(captured[0]!)).toEqual({
+      operation: "compare", handle: comparison.handle, ownerToken: token, otherOwnerToken: otherToken,
+    });
+    expect(() => resolveOnMac(
+      "compare", comparison.handle, token, runner, undefined, undefined, token,
+    )).toThrow("different candidate");
+    const draft = {
+      firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "",
+      organization: "", department: "", jobTitle: "", birthday: "", note: "",
+      phones: [], emails: [], urls: [], addresses: [],
+    };
+    const revisions = comparison.cards.map((card) => ({ token: card.token, revision: card.revision }));
+    expect(() => contactMutationOnMac("merge-prepare", {
+      handle: comparison.handle, ownerToken: token, otherOwnerToken: token,
+      targetToken: comparison.cards[0]!.token, revisions, card: draft,
+    }, runner)).toThrow("different candidate");
+  });
+
+  test("inspect, removal, and undo keep contact data on stdin and validate receipts", () => {
+    const exactToken = cardToken("e");
+    const undoToken = "undo:" + "f".repeat(32);
+    const preview = {
+      handle: "+15550100001", name: "Pat Rivera", kind: "phone",
+      fieldCount: 1, labels: ["mobile"], cardNumber: 1, cardCount: 2,
+      accountNumber: 1, sourceName: "iCloud", writeEnabled: true,
+    };
+    const captured: Array<{ args: string[]; input: string }> = [];
+    const responses = [
+      { ok: true, preview },
+      { ok: true, ...preview, removed: true, undoToken },
+      { ok: true, restored: true, alreadyPresent: false, handle: preview.handle,
+        name: preview.name, action: "field-removal", cardCount: 1, fieldCount: 1 },
+    ];
+    const runner = ((_command: string, args: string[], options: any) => {
+      captured.push({ args, input: options.input });
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify(responses.shift()), stderr: "", error: undefined };
+    }) as any;
+    expect(resolveOnMac("inspect", preview.handle, exactToken, runner, token).preview).toEqual(preview);
+    expect(resolveOnMac("remove", preview.handle, exactToken, runner, token).removal?.undoToken).toBe(undoToken);
+    expect(resolveOnMac("undo", undefined, undoToken, runner).undo?.restored).toBe(true);
+    expect(captured.every(({ args }) => args.join(" ").includes("15550100001") === false)).toBe(true);
+    expect(JSON.parse(captured[0]!.input)).toEqual({
+      operation: "inspect", handle: preview.handle, token: exactToken, ownerToken: token,
+    });
+    expect(JSON.parse(captured[2]!.input)).toEqual({ operation: "undo", undoToken });
+    expect(() => resolveOnMac("undo", undefined, "undo:bad", runner)).toThrow("undo token");
+  });
+});
+
+describe("collector identity application", () => {
+  test("names messages and quiet DM rows without changing group titles", () => {
+    const messages = applyIdentityOverrides([{
+      ts: "2026-09-02 10:00:00", from_me: false, handle: "5550100001", name: null,
+      service: "iMessage", chat: "+15550100001", text: "hello",
+    }], config);
+    expect(messages[0]!.name).toBe("Alex Rivera");
+
+    const base: Thread = {
+      chat: "+15550100001", guid: "", name: "+15550100001", handle: "+15550100001",
+      service: "iMessage", last_ts: "", last_text: "", last_from_me: false, count: 0, unread: 0,
+    };
+    expect(applyThreadIdentityOverrides([base], config)[0]!.name).toBe("Alex Rivera");
+    const group = { ...base, chat: "chat123", name: "Family", guid: "any;+;chat123" };
+    expect(applyThreadIdentityOverrides([group], config)[0]!.name).toBe("Family");
+  });
+});
+
+describe("identity CLI streaming boundary", () => {
+  test("contact comparison does not require or create a display-name preference", () => {
+    const { root } = fixture();
+    const bin = join(root, "bin");
+    const contacts = join(bin, "contacts");
+    const identities = join(root, "missing", "identities.json");
+    const response = JSON.stringify({
+      ok: true, handle: "+15550100001", name: "Alex Rivera",
+      cardCount: 1, sourceCount: 1, writeEnabled: true,
+      cards: [{
+        token: cardToken("b"), revision: cardToken("c"), cardNumber: 1,
+        accountNumber: 1, sourceName: "iCloud", hasPhoto: false,
+        displayName: "Alex Rivera", firstName: "Alex", middleName: "",
+        lastName: "Rivera", nickname: "", organization: "", department: "",
+        jobTitle: "", birthday: "", note: "", phones: [], emails: [], urls: [], addresses: [],
+      }],
+    }) + "\n";
+    mkdirSync(bin);
+    writeFileSync(contacts, `#!/usr/bin/env bun\nprocess.stdout.write(${JSON.stringify(response)})\n`);
+    chmodSync(contacts, 0o700);
+
+    const result = spawnSync("bun", [join(import.meta.dir, "identities.ts"), "compare"], {
+      env: { ...process.env, HOME: root, BLIP_IDENTITIES_PATH: identities },
+      input: JSON.stringify({ handle: "+15550100001", ownerToken: token }),
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).comparison.name).toBe("Alex Rivera");
+    expect(existsSync(identities)).toBe(false);
+  });
+
+  test("exits before an oversized producer closes stdin", async () => {
+    const { path } = fixture();
+    const child = Bun.spawn(["bun", join(import.meta.dir, "identities.ts"), "custom"], {
+      env: { ...process.env, BLIP_IDENTITIES_PATH: path },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    child.stdin.write(Buffer.alloc(MAX_IDENTITY_REQUEST_BYTES + 1, 0x20));
+    child.stdin.flush();
+    const result = await Promise.race([
+      child.exited.then((code) => ({ code })),
+      Bun.sleep(1500).then(() => ({ code: -999 })),
+    ]);
+    expect(result.code).not.toBe(-999);
+    expect(result.code).not.toBe(0);
+    try { child.stdin.end(); } catch { /* child already closed the pipe */ }
+  });
+});

--- a/identities.ts
+++ b/identities.ts
@@ -1,0 +1,1597 @@
+#!/usr/bin/env bun
+/**
+ * Portable, user-chosen identity resolutions for ambiguous Messages handles.
+ *
+ * QML talks only to this short-lived helper. The helper bounds and validates
+ * both ~/.config/blip/identities.json and the candidate response from the Mac,
+ * then writes choices atomically with mode 0600. Handles travel to the bridge
+ * over bounded stdin rather than argv.
+ *
+ *   bun identities.ts read
+ *   printf '%s' '{"handle":"+1555…"}' | bun identities.ts candidates
+ *   printf '%s' '{"handles":["+1555…","person@example.com"]}' | bun identities.ts audit
+ *   printf '%s' '{"handle":"…","name":"…","token":"sha256:…"}' | bun identities.ts choose
+ *   printf '%s' '{"handle":"…","name":"Family line"}' | bun identities.ts custom
+ *   printf '%s' '{"handle":"…"}' | bun identities.ts clear
+ *   printf '%s' '{"handle":"…","token":"sha256:…"}' | bun identities.ts open
+ *   printf '%s' '{"handle":"…"}' | bun identities.ts vcard
+ *   printf '%s' '{"handle":"…","ownerToken":"sha256:…"}' | bun identities.ts compare
+ *   printf '%s' '{"handle":"…","ownerToken":"sha256:…","token":"sha256:…","revision":"sha256:…","card":{…}}' | bun identities.ts edit-prepare
+ *   printf '%s' '{"handle":"…","ownerToken":"sha256:…"}' | bun identities.ts link-prepare
+ *   printf '%s' '{"handle":"…","ownerToken":"sha256:…"}' | bun identities.ts link
+ *   printf '%s' '{"handle":"…","token":"sha256:…"}' | bun identities.ts inspect
+ *   printf '%s' '{"handle":"…","token":"sha256:…"}' | bun identities.ts remove
+ *   printf '%s' '{"undoToken":"undo:…"}' | bun identities.ts undo
+ */
+
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const MAX_IDENTITIES_BYTES = 48 * 1024;
+export const MAX_IDENTITY_REQUEST_BYTES = 48 * 1024;
+export const MAX_IDENTITY_OUTPUT_BYTES = 48 * 1024;
+export const MAX_BRIDGE_OUTPUT_BYTES = 48 * 1024;
+export const MAX_VCARD_BYTES = 2 * 1024 * 1024;
+export const MAX_VCARD_RESPONSE_BYTES = 3 * 1024 * 1024;
+export const MAX_IDENTITY_ENTRIES = 64;
+export const MAX_IDENTITY_CANDIDATES = 8;
+export const MAX_IDENTITY_CARDS = 64;
+export const MAX_REPAIR_FIELDS = 8;
+export const MAX_COMPARE_CARDS = 8;
+export const MAX_CARD_VALUES = 16;
+export const MAX_CONTACT_AUDIT_HANDLES = 200;
+export const MAX_BRIDGE_CONFIG_BYTES = 16 * 1024;
+export const MAX_HANDLE_CHARS = 320;
+export const MAX_NAME_CHARS = 160;
+
+export type IdentitySource = "contacts" | "custom";
+
+export interface IdentityChoice {
+  name: string;
+  source: IdentitySource;
+  contactToken?: string;
+}
+
+export interface IdentityConfig {
+  schemaVersion: 1;
+  identities: Record<string, IdentityChoice>;
+}
+
+export interface IdentityCandidate {
+  token: string;
+  name: string;
+  recordCount: number;
+  sourceCount: number;
+  hasPhoto: boolean;
+  cards: IdentitySourceCard[];
+}
+
+export interface IdentitySourceCard {
+  token: string;
+  accountNumber: number;
+  sourceName: string;
+  hasPhoto: boolean;
+  matchCount: number;
+}
+
+export interface ContactAuditEntry {
+  handle: string;
+  candidates: IdentityCandidate[];
+}
+
+export interface ContactAudit {
+  handleCount: number;
+  noMatchCount: number;
+  singleCards: ContactAuditEntry[];
+  duplicates: ContactAuditEntry[];
+  conflicts: ContactAuditEntry[];
+}
+
+export interface ContactRepairPreview {
+  handle: string;
+  name: string;
+  kind: "phone" | "email";
+  fieldCount: number;
+  labels: string[];
+  cardNumber: number;
+  cardCount: number;
+  accountNumber: number;
+  sourceName: string;
+  writeEnabled: boolean;
+}
+
+export interface ContactRemoval extends ContactRepairPreview {
+  removed: true;
+  undoToken: string;
+}
+
+export interface ContactUndo {
+  restored: true;
+  alreadyPresent: boolean;
+  action: "field-removal" | "edit" | "delete" | "consolidate";
+  handle: string;
+  name: string;
+  cardCount: number;
+  fieldCount: number;
+}
+
+export interface ContactLabeledValue {
+  label: string;
+  value: string;
+}
+
+export interface ContactAddress {
+  label: string;
+  street: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+  countryCode: string;
+}
+
+export interface ContactCardDetail {
+  token: string;
+  revision: string;
+  cardNumber: number;
+  accountNumber: number;
+  sourceName: string;
+  hasPhoto: boolean;
+  displayName: string;
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  nickname: string;
+  organization: string;
+  department: string;
+  jobTitle: string;
+  birthday: string;
+  note: string;
+  phones: ContactLabeledValue[];
+  emails: ContactLabeledValue[];
+  urls: ContactLabeledValue[];
+  addresses: ContactAddress[];
+}
+
+export type ContactCardDraft = Omit<
+  ContactCardDetail,
+  "token" | "revision" | "cardNumber" | "accountNumber" | "sourceName" | "hasPhoto" | "displayName"
+>;
+
+export interface ContactMutationPreview {
+  action: "edit" | "delete" | "consolidate";
+  handle: string;
+  name: string;
+  cardNumber: number;
+  cardCount: number;
+  accountNumber: number;
+  sourceName: string;
+  sourceCardCount: number;
+  changedFields: string[];
+  planHash: string;
+  writeEnabled: boolean;
+}
+
+export interface ContactMutationResult extends ContactMutationPreview {
+  applied: true;
+  undoToken: string;
+  revision?: string;
+  displayName?: string;
+}
+
+export interface ContactComparison {
+  handle: string;
+  name: string;
+  cardCount: number;
+  sourceCount: number;
+  writeEnabled: boolean;
+  cards: ContactCardDetail[];
+}
+
+export interface ContactLinkPreview {
+  handle: string;
+  name: string;
+  cardCount: number;
+  sourceCount: number;
+  writeEnabled: boolean;
+  action: "Link Selected Cards" | "Merge Selected Cards" | "Merge and Link Selected Cards";
+  ready: boolean;
+}
+
+export interface ContactLinkResult extends Omit<ContactLinkPreview, "ready"> {
+  linked: true;
+}
+
+export const EMPTY_IDENTITIES: Readonly<IdentityConfig> = Object.freeze({
+  schemaVersion: 1,
+  identities: Object.freeze({}),
+});
+
+const UNSAFE_TEXT = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g;
+const CONTACT_TOKEN = /^sha256:[0-9a-f]{64}$/;
+const CONTACT_REVISION = /^sha256:[0-9a-f]{64}$/;
+const UNDO_TOKEN = /^undo:[0-9a-f]{32}$/;
+
+function own(value: Record<string, unknown>, key: string): unknown {
+  return Object.prototype.hasOwnProperty.call(value, key) ? value[key] : undefined;
+}
+
+function boundedString(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  if (value.length > maximum) throw new Error(`${label} is too long`);
+  const text = value.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim();
+  if (!text) throw new Error(`${label} must not be empty`);
+  return text;
+}
+
+export function normalizeHandle(value: unknown): string {
+  const handle = boundedString(value, "handle", MAX_HANDLE_CHARS);
+  if (handle.includes("@")) {
+    const email = handle.toLowerCase();
+    if (email.length > 254 || !/^[^@\s]+@[^@\s]+$/.test(email))
+      throw new Error("handle is not a valid email address");
+    return handle;
+  }
+  if (!/^\+?[0-9][0-9 ()./-]{2,39}$/.test(handle))
+    throw new Error("handle is not a valid phone number");
+  const digits = handle.replace(/\D/g, "");
+  if (digits.length < 5) throw new Error("phone handle is too short");
+  return handle;
+}
+
+export function identityKey(value: unknown): string {
+  const handle = normalizeHandle(value);
+  if (handle.includes("@")) return `email:${handle.toLowerCase()}`;
+  const digits = handle.replace(/\D/g, "");
+  return `phone:${digits.length >= 10 ? digits.slice(-10) : digits}`;
+}
+
+export function normalizeIdentityName(value: unknown): string {
+  return boundedString(value, "name", MAX_NAME_CHARS);
+}
+
+function normalizeContactToken(value: unknown): string {
+  if (typeof value !== "string" || !CONTACT_TOKEN.test(value))
+    throw new Error("contact token is invalid");
+  return value;
+}
+
+function normalizeContactRevision(value: unknown): string {
+  if (typeof value !== "string" || !CONTACT_REVISION.test(value))
+    throw new Error("contact revision is invalid");
+  return value;
+}
+
+export function normalizeIdentityConfig(value: unknown): IdentityConfig {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("identities must be a JSON object");
+  const input = value as Record<string, unknown>;
+  if (own(input, "schemaVersion") !== 1) throw new Error("schemaVersion must be 1");
+  const rawEntries = own(input, "identities");
+  if (rawEntries === null || typeof rawEntries !== "object" || Array.isArray(rawEntries))
+    throw new Error("identities must be an object keyed by handle");
+  const pairs = Object.entries(rawEntries as Record<string, unknown>);
+  if (pairs.length > MAX_IDENTITY_ENTRIES)
+    throw new Error(`identities may contain at most ${MAX_IDENTITY_ENTRIES} choices`);
+
+  const normalized: Record<string, IdentityChoice> = {};
+  const seen = new Set<string>();
+  for (const [rawHandle, rawChoice] of pairs) {
+    const handle = normalizeHandle(rawHandle);
+    const key = identityKey(handle);
+    if (seen.has(key)) throw new Error("identities contains equivalent duplicate handles");
+    seen.add(key);
+    if (rawChoice === null || typeof rawChoice !== "object" || Array.isArray(rawChoice))
+      throw new Error(`identity for ${handle} must be an object`);
+    const choice = rawChoice as Record<string, unknown>;
+    const name = normalizeIdentityName(own(choice, "name"));
+    const source = own(choice, "source");
+    if (source !== "contacts" && source !== "custom")
+      throw new Error(`identity for ${handle} has an invalid source`);
+    const result: IdentityChoice = { name, source };
+    if (source === "contacts") result.contactToken = normalizeContactToken(own(choice, "contactToken"));
+    normalized[handle] = result;
+  }
+  return { schemaVersion: 1, identities: normalized };
+}
+
+export function parseIdentities(text: string): IdentityConfig {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw new Error("identities.json is not valid JSON");
+  }
+  return normalizeIdentityConfig(value);
+}
+
+function currentUid(): number {
+  const uid = typeof process.getuid === "function" ? process.getuid() : -1;
+  if (uid < 0) throw new Error("cannot determine the current user");
+  return uid;
+}
+
+function openPinnedDirectory(path: string, create: boolean): number {
+  if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+  );
+  const info = fstatSync(fd);
+  if (!info.isDirectory()) {
+    closeSync(fd);
+    throw new Error("identity directory is not a directory");
+  }
+  if (info.uid !== currentUid()) {
+    closeSync(fd);
+    throw new Error("identity directory is not owned by the current user");
+  }
+  if ((info.mode & 0o077) !== 0) fchmodSync(fd, 0o700);
+  return fd;
+}
+
+function pinnedPath(directoryFd: number, name: string): string {
+  return `/proc/self/fd/${directoryFd}/${name}`;
+}
+
+export function readBoundedIdentityFile(path: string): string | null {
+  const directoryFd = openPinnedDirectory(dirname(path), false);
+  let fileFd = -1;
+  try {
+    try {
+      fileFd = openSync(
+        pinnedPath(directoryFd, basename(path)),
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+    } catch (error: any) {
+      if (error?.code === "ENOENT") return null;
+      throw error;
+    }
+    const info = fstatSync(fileFd);
+    if (!info.isFile()) throw new Error("identities.json must be a regular file");
+    if (info.uid !== currentUid()) throw new Error("identities.json is not owned by the current user");
+    if (info.size > MAX_IDENTITIES_BYTES) throw new Error("identities.json is too large");
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const room = MAX_IDENTITIES_BYTES + 1 - total;
+      const chunk = Buffer.alloc(Math.min(4096, room));
+      const count = readSync(fileFd, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > MAX_IDENTITIES_BYTES) throw new Error("identities.json is too large");
+      chunks.push(chunk.subarray(0, count));
+    }
+    return Buffer.concat(chunks, total).toString("utf8");
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    closeSync(directoryFd);
+  }
+}
+
+/** Read the small bridge config through one no-follow descriptor. */
+export function readBoundedBridgeConfig(path: string): string | null {
+  let directoryFd = -1;
+  let fileFd = -1;
+  try {
+    try { directoryFd = openPinnedDirectory(dirname(path), false); }
+    catch (error: any) {
+      if (error?.code === "ENOENT") return null;
+      throw error;
+    }
+    try {
+      fileFd = openSync(
+        pinnedPath(directoryFd, basename(path)),
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+    } catch (error: any) {
+      if (error?.code === "ENOENT") return null;
+      throw error;
+    }
+    const info = fstatSync(fileFd);
+    if (!info.isFile()) throw new Error("bridge.conf must be a regular file");
+    if (info.uid !== currentUid()) throw new Error("bridge.conf is not owned by the current user");
+    if ((info.mode & 0o022) !== 0) throw new Error("bridge.conf is writable by another user");
+    if (info.size > MAX_BRIDGE_CONFIG_BYTES) throw new Error("bridge.conf is too large");
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.alloc(Math.min(4096, MAX_BRIDGE_CONFIG_BYTES + 1 - total));
+      const count = readSync(fileFd, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > MAX_BRIDGE_CONFIG_BYTES) throw new Error("bridge.conf is too large");
+      chunks.push(chunk.subarray(0, count));
+    }
+    return Buffer.concat(chunks, total).toString("utf8");
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    if (directoryFd >= 0) closeSync(directoryFd);
+  }
+}
+
+export function bridgeConfigPath(): string {
+  const overridden = process.env.BLIP_BRIDGE_CONF;
+  if (overridden) {
+    if (!isAbsolute(overridden)) throw new Error("BLIP_BRIDGE_CONF must be absolute");
+    return overridden;
+  }
+  const home = process.env.HOME;
+  if (!home || !isAbsolute(home)) throw new Error("HOME must be an absolute path");
+  return join(home, ".config", "blip", "bridge.conf");
+}
+
+/** Fail closed: only an explicit, owner-controlled `contact_writes=on` enables UI writes. */
+export function contactWritesEnabled(path = bridgeConfigPath()): boolean {
+  let text: string | null;
+  try { text = readBoundedBridgeConfig(path); }
+  catch { return false; }
+  if (text === null) return false;
+  let enabled = false;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.replace(/#.*/, "").trim();
+    if (!line || !line.includes("=")) continue;
+    const split = line.indexOf("=");
+    if (line.slice(0, split).trim() !== "contact_writes") continue;
+    let value = line.slice(split + 1).trim().toLowerCase();
+    if ((value.startsWith('"') && value.endsWith('"'))
+        || (value.startsWith("'") && value.endsWith("'"))) value = value.slice(1, -1);
+    enabled = ["on", "true", "1", "yes"].includes(value);
+  }
+  return enabled;
+}
+
+export function readIdentities(path = identitiesPath()): { exists: boolean; config: IdentityConfig } {
+  let text: string | null;
+  try {
+    text = readBoundedIdentityFile(path);
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return { exists: false, config: { schemaVersion: 1, identities: {} } };
+    throw error;
+  }
+  if (text === null) return { exists: false, config: { schemaVersion: 1, identities: {} } };
+  return { exists: true, config: parseIdentities(text) };
+}
+
+function verifyReplaceableTarget(directoryFd: number, name: string): void {
+  try {
+    const info = lstatSync(pinnedPath(directoryFd, name));
+    if (!info.isFile()) throw new Error("identities.json must be a regular file");
+    if (info.uid !== currentUid()) throw new Error("identities.json is not owned by the current user");
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+export function writeIdentities(path: string, value: unknown): IdentityConfig {
+  if (!isAbsolute(path)) throw new Error("identity path must be absolute");
+  const config = normalizeIdentityConfig(value);
+  const sorted = Object.fromEntries(
+    Object.entries(config.identities).sort(([a], [b]) => a.localeCompare(b)),
+  );
+  const normalized: IdentityConfig = { schemaVersion: 1, identities: sorted };
+  const serialized = `${JSON.stringify(normalized, null, 2)}\n`;
+  if (Buffer.byteLength(serialized) > MAX_IDENTITIES_BYTES)
+    throw new Error("normalized identities exceed the size limit");
+
+  const directoryFd = openPinnedDirectory(dirname(path), true);
+  const name = basename(path);
+  const tempName = `.${name}.tmp.${process.pid}.${randomBytes(6).toString("hex")}`;
+  const tempPath = pinnedPath(directoryFd, tempName);
+  let tempFd = -1;
+  let renamed = false;
+  try {
+    verifyReplaceableTarget(directoryFd, name);
+    tempFd = openSync(
+      tempPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    const bytes = Buffer.from(serialized, "utf8");
+    let offset = 0;
+    while (offset < bytes.length) offset += writeSync(tempFd, bytes, offset, bytes.length - offset);
+    fchmodSync(tempFd, 0o600);
+    fsyncSync(tempFd);
+    closeSync(tempFd);
+    tempFd = -1;
+    renameSync(tempPath, pinnedPath(directoryFd, name));
+    renamed = true;
+    chmodSync(pinnedPath(directoryFd, name), 0o600);
+    fsyncSync(directoryFd);
+    return normalized;
+  } finally {
+    if (tempFd >= 0) closeSync(tempFd);
+    if (!renamed) {
+      try { unlinkSync(tempPath); } catch { /* no temporary file */ }
+    }
+    closeSync(directoryFd);
+  }
+}
+
+export function identityNameFor(handle: unknown, config: IdentityConfig): string | null {
+  let key: string;
+  try { key = identityKey(handle); } catch { return null; }
+  for (const [candidateHandle, choice] of Object.entries(config.identities)) {
+    if (identityKey(candidateHandle) === key) return choice.name;
+  }
+  return null;
+}
+
+export function safeReadIdentityConfig(path = identitiesPath()): IdentityConfig {
+  try { return readIdentities(path).config; }
+  catch { return { schemaVersion: 1, identities: {} }; }
+}
+
+function finiteInteger(value: unknown, label: string, low: number, high: number): number {
+  if (!Number.isInteger(value) || Number(value) < low || Number(value) > high)
+    throw new Error(`${label} is invalid`);
+  return Number(value);
+}
+
+function optionalLabel(value: unknown): string {
+  if (typeof value !== "string" || value.length > 80) throw new Error("contact label is invalid");
+  return value.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim();
+}
+
+function contactSourceName(value: unknown): string {
+  return boundedString(value, "contact source name", 120);
+}
+
+function normalizeUndoToken(value: unknown): string {
+  if (typeof value !== "string" || !UNDO_TOKEN.test(value)) throw new Error("undo token is invalid");
+  return value;
+}
+
+export function normalizeBridgeCandidates(value: unknown, requestedHandle: string): IdentityCandidate[] {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid response");
+  const response = value as Record<string, unknown>;
+  if (response.ok !== true) {
+    throw new Error(safeError(response.error || "Contacts could not resolve this handle"));
+  }
+  if (identityKey(response.handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  if (!Array.isArray(response.candidates) || response.candidates.length > MAX_IDENTITY_CANDIDATES)
+    throw new Error("Contacts returned too many candidates");
+  const seen = new Set<string>();
+  let cardCount = 0;
+  return response.candidates.map((raw: unknown) => {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+      throw new Error("Contacts returned an invalid candidate");
+    const candidate = raw as Record<string, unknown>;
+    const token = normalizeContactToken(candidate.token);
+    if (seen.has(token)) throw new Error("Contacts returned a duplicate candidate");
+    seen.add(token);
+    const recordCount = finiteInteger(candidate.recordCount, "record count", 1, MAX_IDENTITY_CARDS);
+    const sourceCount = finiteInteger(candidate.sourceCount, "source count", 1, MAX_IDENTITY_CARDS);
+    if (!Array.isArray(candidate.cards) || candidate.cards.length !== recordCount)
+      throw new Error("Contacts returned an invalid source-card list");
+    cardCount += candidate.cards.length;
+    if (cardCount > MAX_IDENTITY_CARDS) throw new Error("Contacts returned too many source cards");
+    const accounts = new Set<number>();
+    const cards = candidate.cards.map((rawCard: unknown): IdentitySourceCard => {
+      if (rawCard === null || typeof rawCard !== "object" || Array.isArray(rawCard))
+        throw new Error("Contacts returned an invalid source card");
+      const card = rawCard as Record<string, unknown>;
+      const cardToken = normalizeContactToken(card.token);
+      if (seen.has(cardToken)) throw new Error("Contacts returned a duplicate card token");
+      seen.add(cardToken);
+      const accountNumber = finiteInteger(
+        card.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+      );
+      const matchCount = finiteInteger(card.matchCount ?? 1, "matching field count", 1, MAX_REPAIR_FIELDS);
+      accounts.add(accountNumber);
+      return {
+        token: cardToken,
+        accountNumber,
+        sourceName: contactSourceName(card.sourceName),
+        hasPhoto: card.hasPhoto === true,
+        matchCount,
+      };
+    });
+    if (accounts.size !== sourceCount)
+      throw new Error("Contacts returned inconsistent account metadata");
+    return {
+      token,
+      name: normalizeIdentityName(candidate.name),
+      recordCount,
+      sourceCount,
+      hasPhoto: candidate.hasPhoto === true,
+      cards,
+    };
+  });
+}
+
+export function normalizeContactAudit(value: unknown, expectedHandleCount: number): ContactAudit {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid audit");
+  if (!Number.isInteger(expectedHandleCount) || expectedHandleCount < 1
+      || expectedHandleCount > MAX_CONTACT_AUDIT_HANDLES)
+    throw new Error("contact audit handle count is invalid");
+  const audit = value as Record<string, unknown>;
+  const handleCount = finiteInteger(
+    audit.handleCount, "audit handle count", 1, MAX_CONTACT_AUDIT_HANDLES,
+  );
+  if (handleCount !== expectedHandleCount)
+    throw new Error("Contacts returned an incomplete audit");
+  const noMatchCount = finiteInteger(
+    audit.noMatchCount, "audit no-match count", 0, MAX_CONTACT_AUDIT_HANDLES,
+  );
+  const seen = new Set<string>();
+  function entries(raw: unknown, kind: "single" | "duplicate" | "conflict"): ContactAuditEntry[] {
+    if (!Array.isArray(raw) || raw.length > MAX_CONTACT_AUDIT_HANDLES)
+      throw new Error("Contacts returned an invalid audit category");
+    return raw.map((item) => {
+      if (item === null || typeof item !== "object" || Array.isArray(item))
+        throw new Error("Contacts returned an invalid audit entry");
+      const entry = item as Record<string, unknown>;
+      const handle = normalizeHandle(entry.handle);
+      const key = identityKey(handle);
+      if (seen.has(key)) throw new Error("Contacts returned a duplicate audited handle");
+      seen.add(key);
+      const candidates = normalizeBridgeCandidates({
+        ok: true, handle, candidates: entry.candidates,
+      }, handle);
+      if (kind === "single" && (candidates.length !== 1 || candidates[0]!.recordCount !== 1))
+        throw new Error("Contacts returned an invalid single-card audit entry");
+      if (kind === "duplicate" && (candidates.length !== 1 || candidates[0]!.recordCount < 2))
+        throw new Error("Contacts returned an invalid duplicate-card audit entry");
+      if (kind === "conflict" && candidates.length < 2)
+        throw new Error("Contacts returned an invalid conflict audit entry");
+      return { handle, candidates };
+    });
+  }
+  const singleCards = entries(audit.singleCards, "single");
+  const duplicates = entries(audit.duplicates, "duplicate");
+  const conflicts = entries(audit.conflicts, "conflict");
+  if (noMatchCount + singleCards.length + duplicates.length + conflicts.length !== handleCount)
+    throw new Error("Contacts returned inconsistent audit totals");
+  return { handleCount, noMatchCount, singleCards, duplicates, conflicts };
+}
+
+export const MAX_AUDIT_CACHE_BYTES = 512 * 1024;
+const FINGERPRINT_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+export function auditCachePath(): string {
+  const home = process.env.HOME ?? homedir();
+  return join(home, ".local", "state", "blip", "audit-cache.json");
+}
+
+export function storeFingerprintOnMac(runner: Runner = spawnSync): string {
+  const home = process.env.HOME ?? homedir();
+  const result: SpawnSyncReturns<string> = runner(
+    join(home, "bin", "contacts"),
+    ["--json", "resolve"],
+    { encoding: "utf8", input: JSON.stringify({ operation: "fingerprint" }),
+      timeout: 15000, maxBuffer: MAX_BRIDGE_OUTPUT_BYTES },
+  );
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  let response: unknown;
+  try { response = JSON.parse(String(result.stdout || "")); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  const body = (response ?? {}) as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts fingerprint failed"));
+  if (typeof body.fingerprint !== "string" || !FINGERPRINT_PATTERN.test(body.fingerprint))
+    throw new Error("Contacts returned an invalid store fingerprint");
+  return body.fingerprint;
+}
+
+function handleSetFingerprint(handles: string[]): string {
+  const keys = handles.map(identityKey).sort();
+  return "sha256:" + createHash("sha256")
+    .update(`blip-audit-handles-v1 ${JSON.stringify(keys)}`).digest("hex");
+}
+
+type AuditCacheEntry = { storeFingerprint: string; handleFingerprint: string; audit: ContactAudit };
+
+export function readAuditCache(path = auditCachePath()): AuditCacheEntry | null {
+  let directoryFd = -1;
+  let fileFd = -1;
+  try {
+    try { directoryFd = openPinnedDirectory(dirname(path), false); }
+    catch (error: any) { if (error?.code === "ENOENT") return null; throw error; }
+    try {
+      fileFd = openSync(
+        pinnedPath(directoryFd, basename(path)),
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+    } catch (error: any) { if (error?.code === "ENOENT") return null; throw error; }
+    const info = fstatSync(fileFd);
+    if (!info.isFile() || info.uid !== currentUid() || info.size > MAX_AUDIT_CACHE_BYTES)
+      return null;
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.alloc(Math.min(4096, MAX_AUDIT_CACHE_BYTES + 1 - total));
+      const count = readSync(fileFd, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > MAX_AUDIT_CACHE_BYTES) return null;
+      chunks.push(chunk.subarray(0, count));
+    }
+    let parsed: unknown;
+    try { parsed = JSON.parse(Buffer.concat(chunks, total).toString("utf8")); }
+    catch { return null; }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const entry = parsed as Record<string, unknown>;
+    if (typeof entry.storeFingerprint !== "string" || !FINGERPRINT_PATTERN.test(entry.storeFingerprint)
+        || typeof entry.handleFingerprint !== "string"
+        || !FINGERPRINT_PATTERN.test(entry.handleFingerprint)) return null;
+    const rawAudit = entry.audit as Record<string, unknown> | undefined;
+    const handleCount = Number(rawAudit?.handleCount);
+    if (!Number.isInteger(handleCount)) return null;
+    let audit: ContactAudit;
+    try { audit = normalizeContactAudit(entry.audit, handleCount); }
+    catch { return null; }
+    return { storeFingerprint: entry.storeFingerprint, handleFingerprint: entry.handleFingerprint, audit };
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    if (directoryFd >= 0) closeSync(directoryFd);
+  }
+}
+
+export function writeAuditCache(entry: AuditCacheEntry, path = auditCachePath()): void {
+  const serialized = `${JSON.stringify(entry)}
+`;
+  if (Buffer.byteLength(serialized) > MAX_AUDIT_CACHE_BYTES)
+    throw new Error("audit cache entry is too large");
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const directoryFd = openPinnedDirectory(dirname(path), true);
+  const name = basename(path);
+  const tempName = `.${name}.tmp.${process.pid}.${randomBytes(6).toString("hex")}`;
+  const tempPath = pinnedPath(directoryFd, tempName);
+  let tempFd = -1;
+  let renamed = false;
+  try {
+    tempFd = openSync(
+      tempPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    const bytes = Buffer.from(serialized, "utf8");
+    let offset = 0;
+    while (offset < bytes.length) offset += writeSync(tempFd, bytes, offset, bytes.length - offset);
+    fchmodSync(tempFd, 0o600);
+    fsyncSync(tempFd);
+    closeSync(tempFd);
+    tempFd = -1;
+    renameSync(tempPath, pinnedPath(directoryFd, name));
+    renamed = true;
+  } finally {
+    if (tempFd >= 0) closeSync(tempFd);
+    if (!renamed) { try { unlinkSync(tempPath); } catch { /* no temporary file */ } }
+    closeSync(directoryFd);
+  }
+}
+
+export function auditContactsOnMac(
+  value: unknown, runner: Runner = spawnSync,
+): { audit: ContactAudit; cached: boolean } {
+  if (!Array.isArray(value) || value.length < 1 || value.length > MAX_CONTACT_AUDIT_HANDLES)
+    throw new Error("contact audit handle list is invalid");
+  const seen = new Set<string>();
+  const handles = value.map((raw) => {
+    const handle = normalizeHandle(raw);
+    const key = identityKey(handle);
+    if (seen.has(key)) throw new Error("contact audit contains a duplicate handle");
+    seen.add(key);
+    return handle;
+  });
+  // Freshness short-circuit: when the conversation set matches the cached
+  // scan, one cheap fingerprint round-trip decides whether the Mac's
+  // Contacts stores changed at all â unchanged means the cached cleanup
+  // results are still exact, so skip the full scan.
+  const handleFingerprint = handleSetFingerprint(handles);
+  let cache: AuditCacheEntry | null = null;
+  try { cache = readAuditCache(); } catch { cache = null; }
+  if (cache && cache.handleFingerprint === handleFingerprint) {
+    try {
+      if (storeFingerprintOnMac(runner) === cache.storeFingerprint) {
+        const requested = new Set(handles.map(identityKey));
+        const entries = [...cache.audit.singleCards, ...cache.audit.duplicates, ...cache.audit.conflicts];
+        if (entries.every((entry) => requested.has(identityKey(entry.handle))))
+          return { audit: cache.audit, cached: true };
+      }
+    } catch { /* fingerprint unavailable â fall through to a full scan */ }
+  }
+  const home = process.env.HOME ?? homedir();
+  const result: SpawnSyncReturns<string> = runner(
+    join(home, "bin", "contacts"),
+    ["--json", "resolve"],
+    {
+      encoding: "utf8",
+      input: JSON.stringify({ operation: "audit", handles }),
+      timeout: 35000,
+      maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
+    },
+  );
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES)
+    throw new Error("Contacts returned too much data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid audit response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts audit failed"));
+  const audit = normalizeContactAudit(body, handles.length);
+  const requestedKeys = new Set(handles.map(identityKey));
+  for (const entry of [...audit.singleCards, ...audit.duplicates, ...audit.conflicts]) {
+    if (!requestedKeys.has(identityKey(entry.handle)))
+      throw new Error("Contacts returned an unrequested audited handle");
+  }
+  if (typeof body.fingerprint === "string" && FINGERPRINT_PATTERN.test(body.fingerprint)) {
+    try { writeAuditCache({ storeFingerprint: body.fingerprint, handleFingerprint, audit }); }
+    catch { /* caching is best-effort */ }
+  }
+  return { audit, cached: false };
+}
+
+type Runner = typeof spawnSync;
+
+export function normalizeRepairPreview(value: unknown, requestedHandle: string): ContactRepairPreview {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid repair preview");
+  const preview = value as Record<string, unknown>;
+  const handle = normalizeHandle(preview.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  const kind = preview.kind === "phone" || preview.kind === "email" ? preview.kind : null;
+  if (!kind) throw new Error("Contacts returned an invalid field kind");
+  const fieldCount = finiteInteger(preview.fieldCount, "matching field count", 1, MAX_REPAIR_FIELDS);
+  if (!Array.isArray(preview.labels) || preview.labels.length !== fieldCount)
+    throw new Error("Contacts returned an invalid field-label list");
+  const cardNumber = finiteInteger(preview.cardNumber, "card number", 1, MAX_IDENTITY_CARDS);
+  const cardCount = finiteInteger(preview.cardCount, "card count", 1, MAX_IDENTITY_CARDS);
+  if (cardNumber > cardCount) throw new Error("Contacts returned inconsistent card metadata");
+  return {
+    handle,
+    name: normalizeIdentityName(preview.name),
+    kind,
+    fieldCount,
+    labels: preview.labels.map(optionalLabel),
+    cardNumber,
+    cardCount,
+    accountNumber: finiteInteger(
+      preview.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+    ),
+    sourceName: contactSourceName(preview.sourceName),
+    writeEnabled: preview.writeEnabled === true,
+  };
+}
+
+function contactText(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== "string" || value.length > maximum)
+    throw new Error(`Contacts returned an invalid ${label}`);
+  return value.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim();
+}
+
+function normalizeLabeledValues(value: unknown, label: string): ContactLabeledValue[] {
+  if (!Array.isArray(value) || value.length > MAX_CARD_VALUES)
+    throw new Error(`Contacts returned an invalid ${label} list`);
+  return value.map((raw) => {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+      throw new Error(`Contacts returned an invalid ${label}`);
+    const item = raw as Record<string, unknown>;
+    const itemValue = contactText(item.value, `${label} value`, 320);
+    if (!itemValue) throw new Error(`Contacts returned an empty ${label}`);
+    return { label: contactText(item.label, `${label} label`, 80), value: itemValue };
+  });
+}
+
+function normalizeAddresses(value: unknown): ContactAddress[] {
+  if (!Array.isArray(value) || value.length > MAX_CARD_VALUES)
+    throw new Error("Contacts returned an invalid address list");
+  return value.map((raw) => {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+      throw new Error("Contacts returned an invalid address");
+    const item = raw as Record<string, unknown>;
+    const address = {
+      label: contactText(item.label, "address label", 80),
+      street: contactText(item.street, "street", 320),
+      city: contactText(item.city, "city", 320),
+      state: contactText(item.state, "state", 320),
+      postalCode: contactText(item.postalCode, "postal code", 80),
+      country: contactText(item.country, "country", 160),
+      countryCode: contactText(item.countryCode, "country code", 8),
+    };
+    if (![address.street, address.city, address.state, address.postalCode, address.country].some(Boolean))
+      throw new Error("Contacts returned an empty address");
+    return address;
+  });
+}
+
+function normalizeCardDetail(value: unknown, seen: Set<string>): ContactCardDetail {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid card detail");
+  const card = value as Record<string, unknown>;
+  const token = normalizeContactToken(card.token);
+  if (seen.has(token)) throw new Error("Contacts returned a duplicate comparison card");
+  seen.add(token);
+  const birthday = contactText(card.birthday, "birthday", 10);
+  if (birthday && !/^(?:\d{4}\-|--)\d{2}\-\d{2}$/.test(birthday))
+    throw new Error("Contacts returned an invalid birthday");
+  return {
+    token,
+    revision: normalizeContactRevision(card.revision),
+    cardNumber: finiteInteger(card.cardNumber, "card number", 1, MAX_COMPARE_CARDS),
+    accountNumber: finiteInteger(card.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS),
+    sourceName: contactSourceName(card.sourceName),
+    hasPhoto: card.hasPhoto === true,
+    displayName: contactText(card.displayName, "display name", 160),
+    firstName: contactText(card.firstName, "first name", 160),
+    middleName: contactText(card.middleName, "middle name", 160),
+    lastName: contactText(card.lastName, "last name", 160),
+    nickname: contactText(card.nickname, "nickname", 160),
+    organization: contactText(card.organization, "organization", 320),
+    department: contactText(card.department, "department", 320),
+    jobTitle: contactText(card.jobTitle, "job title", 320),
+    birthday,
+    note: contactText(card.note, "note", 1000),
+    phones: normalizeLabeledValues(card.phones, "phone"),
+    emails: normalizeLabeledValues(card.emails, "email"),
+    urls: normalizeLabeledValues(card.urls, "URL"),
+    addresses: normalizeAddresses(card.addresses),
+  };
+}
+
+export function normalizeContactDraft(value: unknown): ContactCardDraft {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("contact card draft is invalid");
+  const card = value as Record<string, unknown>;
+  const birthday = contactText(card.birthday, "birthday", 10);
+  if (birthday && !/^(?:\d{4}\-|--)\d{2}\-\d{2}$/.test(birthday))
+    throw new Error("birthday must be YYYY-MM-DD or --MM-DD");
+  const draft = {
+    firstName: contactText(card.firstName, "first name", 160),
+    middleName: contactText(card.middleName, "middle name", 160),
+    lastName: contactText(card.lastName, "last name", 160),
+    nickname: contactText(card.nickname, "nickname", 160),
+    organization: contactText(card.organization, "organization", 320),
+    department: contactText(card.department, "department", 320),
+    jobTitle: contactText(card.jobTitle, "job title", 320),
+    birthday,
+    note: contactText(card.note, "note", 1000),
+    phones: normalizeLabeledValues(card.phones, "phone"),
+    emails: normalizeLabeledValues(card.emails, "email"),
+    urls: normalizeLabeledValues(card.urls, "URL"),
+    addresses: normalizeAddresses(card.addresses),
+  };
+  if (![draft.firstName, draft.lastName, draft.nickname, draft.organization].some(Boolean))
+    throw new Error("contact card needs a name, nickname, or organization");
+  return draft;
+}
+
+export function normalizeContactComparison(
+  value: unknown, requestedHandle: string,
+): ContactComparison {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid card comparison");
+  const body = value as Record<string, unknown>;
+  const handle = normalizeHandle(body.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  const cardCount = finiteInteger(body.cardCount, "card count", 1, MAX_COMPARE_CARDS);
+  const sourceCount = finiteInteger(body.sourceCount, "source count", 1, MAX_COMPARE_CARDS);
+  if (!Array.isArray(body.cards) || body.cards.length !== cardCount)
+    throw new Error("Contacts returned an invalid comparison-card list");
+  const seen = new Set<string>();
+  const cards = body.cards.map((card) => normalizeCardDetail(card, seen));
+  if (cards.some((card, index) => card.cardNumber !== index + 1))
+    throw new Error("Contacts returned inconsistent comparison-card numbers");
+  if (new Set(cards.map((card) => card.accountNumber)).size !== sourceCount)
+    throw new Error("Contacts returned inconsistent comparison accounts");
+  return {
+    handle,
+    name: normalizeIdentityName(body.name),
+    cardCount,
+    sourceCount,
+    writeEnabled: body.writeEnabled === true,
+    cards,
+  };
+}
+
+function normalizeLinkMetadata(
+  value: Record<string, unknown>, requestedHandle: string,
+): Omit<ContactLinkPreview, "ready"> {
+  const handle = normalizeHandle(value.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  const action = value.action;
+  if (action !== "Link Selected Cards" && action !== "Merge Selected Cards"
+      && action !== "Merge and Link Selected Cards")
+    throw new Error("Contacts returned an invalid link action");
+  return {
+    handle,
+    name: normalizeIdentityName(value.name),
+    cardCount: finiteInteger(value.cardCount, "card count", 2, MAX_COMPARE_CARDS),
+    sourceCount: finiteInteger(value.sourceCount, "source count", 1, MAX_COMPARE_CARDS),
+    writeEnabled: value.writeEnabled === true,
+    action,
+  };
+}
+
+function normalizeExpectedLinkAction(value: unknown): ContactLinkPreview["action"] {
+  if (value !== "Link Selected Cards" && value !== "Merge Selected Cards"
+      && value !== "Merge and Link Selected Cards")
+    throw new Error("the confirmed Contacts action is invalid");
+  return value;
+}
+
+function normalizeMutationPreview(
+  value: unknown, requestedHandle: string, expectedAction?: ContactMutationPreview["action"],
+): ContactMutationPreview {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid mutation preview");
+  const preview = value as Record<string, unknown>;
+  const action = preview.action;
+  if (action !== "edit" && action !== "delete" && action !== "consolidate")
+    throw new Error("Contacts returned an invalid contact action");
+  if (expectedAction && action !== expectedAction)
+    throw new Error("the contact action changed; preview it again");
+  const handle = normalizeHandle(preview.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  if (!Array.isArray(preview.changedFields) || preview.changedFields.length < 1
+      || preview.changedFields.length > 13)
+    throw new Error("Contacts returned an invalid change summary");
+  return {
+    action,
+    handle,
+    name: normalizeIdentityName(preview.name),
+    cardNumber: finiteInteger(preview.cardNumber, "card number", 1, MAX_COMPARE_CARDS),
+    cardCount: finiteInteger(preview.cardCount, "card count", 1, MAX_COMPARE_CARDS),
+    accountNumber: finiteInteger(
+      preview.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+    ),
+    sourceName: contactSourceName(preview.sourceName),
+    sourceCardCount: finiteInteger(
+      preview.sourceCardCount, "source card count", 0, MAX_COMPARE_CARDS - 1,
+    ),
+    changedFields: preview.changedFields.map((field) => contactText(field, "changed field", 40)),
+    planHash: normalizeContactRevision(preview.planHash),
+    writeEnabled: preview.writeEnabled === true,
+  };
+}
+
+type ContactMutationOperation =
+  "edit-prepare" | "edit" | "delete-prepare" | "delete" | "merge-prepare" | "merge";
+
+export function contactMutationOnMac(
+  operation: ContactMutationOperation,
+  input: Record<string, unknown>,
+  runner: Runner = spawnSync,
+): { preview?: ContactMutationPreview; result?: ContactMutationResult } {
+  const handle = normalizeHandle(input.handle);
+  const ownerToken = normalizeContactToken(input.ownerToken);
+  const request: Record<string, unknown> = { operation, handle, ownerToken };
+  let action: ContactMutationPreview["action"];
+  if (operation === "edit-prepare" || operation === "edit") {
+    action = "edit";
+    request.token = normalizeContactToken(input.token);
+    request.revision = normalizeContactRevision(input.revision);
+    request.card = normalizeContactDraft(input.card);
+  } else if (operation === "delete-prepare" || operation === "delete") {
+    action = "delete";
+    request.token = normalizeContactToken(input.token);
+    request.revision = normalizeContactRevision(input.revision);
+  } else {
+    action = "consolidate";
+    request.targetToken = normalizeContactToken(input.targetToken);
+    request.card = normalizeContactDraft(input.card);
+    // Explicit cross-name merge: the second owner token widens the scope to
+    // both people's cards; it must be a distinct, valid token.
+    if (input.otherOwnerToken !== undefined && input.otherOwnerToken !== null
+        && input.otherOwnerToken !== "") {
+      const otherOwnerToken = normalizeContactToken(input.otherOwnerToken);
+      if (otherOwnerToken === ownerToken)
+        throw new Error("the other person must be a different candidate");
+      request.otherOwnerToken = otherOwnerToken;
+    }
+    if (!Array.isArray(input.revisions) || input.revisions.length < 2
+        || input.revisions.length > MAX_COMPARE_CARDS)
+      throw new Error("contact revision list is invalid");
+    const seen = new Set<string>();
+    request.revisions = input.revisions.map((raw) => {
+      if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+        throw new Error("contact revision is invalid");
+      const item = raw as Record<string, unknown>;
+      const token = normalizeContactToken(item.token);
+      if (seen.has(token)) throw new Error("contact revision list contains a duplicate card");
+      seen.add(token);
+      return { token, revision: normalizeContactRevision(item.revision) };
+    });
+  }
+  const applying = operation === "edit" || operation === "delete" || operation === "merge";
+  if (applying) request.planHash = normalizeContactRevision(input.planHash);
+  const home = process.env.HOME ?? homedir();
+  const result = runner(join(home, "bin", "contacts"), ["--json", "resolve"], {
+    encoding: "utf8",
+    input: JSON.stringify(request),
+    timeout: 35000,
+    maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
+  });
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES)
+    throw new Error("Contacts returned too much data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts operation failed"));
+  const preview = normalizeMutationPreview(applying ? body : body.preview, handle, action);
+  if (!applying) return { preview };
+  if (body.applied !== true) throw new Error("Contacts did not confirm the contact change");
+  const mutation: ContactMutationResult = {
+    ...preview,
+    applied: true,
+    undoToken: normalizeUndoToken(body.undoToken),
+  };
+  if (action !== "delete") {
+    mutation.revision = normalizeContactRevision(body.revision);
+    mutation.displayName = contactText(body.displayName, "display name", 160);
+  }
+  return { result: mutation };
+}
+
+function vCardFileName(name: string): string {
+  const safe = name.normalize("NFKC")
+    .replace(/[\\/\0-\x1f\x7f]/g, "_")
+    .replace(/^\.+/, "")
+    .trim()
+    .slice(0, 120);
+  return `${safe || "Contact"}.vcf`;
+}
+
+function writeClipboardVCard(card: Buffer, name: string, runtimeRoot: string): {
+  path: string;
+  fileName: string;
+} {
+  const copyDirectory = join(
+    runtimeRoot,
+    "blip",
+    "vcards",
+    `${Date.now()}-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+  const directoryFd = openPinnedDirectory(copyDirectory, true);
+  const fileName = vCardFileName(name);
+  let fileFd = -1;
+  try {
+    fileFd = openSync(
+      pinnedPath(directoryFd, fileName),
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    let offset = 0;
+    while (offset < card.length)
+      offset += writeSync(fileFd, card, offset, card.length - offset);
+    fchmodSync(fileFd, 0o600);
+    fsyncSync(fileFd);
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    closeSync(directoryFd);
+  }
+  return { path: join(copyDirectory, fileName), fileName };
+}
+
+/** Export one unambiguous Mac contact to an owner-only runtime .vcf file. */
+export function exportContactVCard(
+  handle: unknown,
+  runner: Runner = spawnSync,
+  runtimeRoot: string = process.env.XDG_RUNTIME_DIR
+    ?? `/run/user/${typeof process.getuid === "function" ? process.getuid() : 1000}`,
+): { handle: string; name: string; bytes: number; fileName: string; fileUri: string } {
+  const normalizedHandle = normalizeHandle(handle);
+  const home = process.env.HOME ?? homedir();
+  const result = runner(join(home, "bin", "contacts"), ["--json", "resolve"], {
+    encoding: "utf8",
+    input: JSON.stringify({ operation: "vcard", handle: normalizedHandle }),
+    timeout: 35000,
+    maxBuffer: MAX_VCARD_RESPONSE_BYTES,
+  });
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_VCARD_RESPONSE_BYTES)
+    throw new Error("Contacts returned too much vCard data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned an invalid vCard response"); }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid vCard response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts vCard export failed"));
+  if (typeof body.vcard !== "string" || body.vcard.length > MAX_VCARD_RESPONSE_BYTES
+      || !/^[A-Za-z0-9+/=\r\n]+$/.test(body.vcard))
+    throw new Error("Contacts returned an invalid vCard");
+  const card = Buffer.from(body.vcard.replace(/[\r\n]/g, ""), "base64");
+  if (!card.length || card.length > MAX_VCARD_BYTES
+      || !card.subarray(0, 32).toString("utf8").startsWith("BEGIN:VCARD"))
+    throw new Error("Contacts returned an invalid vCard");
+  const name = normalizeIdentityName(body.name);
+  const file = writeClipboardVCard(card, name, runtimeRoot);
+  return {
+    handle: normalizedHandle,
+    name,
+    bytes: card.length,
+    fileName: file.fileName,
+    fileUri: pathToFileURL(file.path).href,
+  };
+}
+
+export function resolveOnMac(
+  operation: "candidates" | "open" | "compare" | "link-prepare" | "link"
+    | "inspect" | "remove" | "undo" | "discard-unsaved",
+  handle: unknown = undefined,
+  token: unknown = undefined,
+  runner: Runner = spawnSync,
+  ownerToken: unknown = undefined,
+  expectedAction: unknown = undefined,
+  otherOwnerToken: unknown = undefined,
+): {
+  handle?: string;
+  candidates?: IdentityCandidate[];
+  opened?: boolean;
+  name?: string;
+  cardNumber?: number;
+  cardCount?: number;
+  accountNumber?: number;
+  sourceName?: string;
+  preview?: ContactRepairPreview;
+  removal?: ContactRemoval;
+  undo?: ContactUndo;
+  comparison?: ContactComparison;
+  linkPreview?: ContactLinkPreview;
+  linkResult?: ContactLinkResult;
+  discarded?: boolean;
+} {
+  const normalizedHandle = operation === "undo" || operation === "discard-unsaved"
+    ? "" : normalizeHandle(handle);
+  const request: Record<string, unknown> = { operation };
+  if (operation === "undo") request.undoToken = normalizeUndoToken(token);
+  else if (operation === "discard-unsaved") { /* no contact data crosses this boundary */ }
+  else request.handle = normalizedHandle;
+  if (operation === "open" || operation === "inspect" || operation === "remove")
+    request.token = normalizeContactToken(token);
+  if (operation === "compare" || operation === "link-prepare" || operation === "link")
+    request.ownerToken = normalizeContactToken(token);
+  if (operation === "compare" && otherOwnerToken !== undefined && otherOwnerToken !== null
+      && otherOwnerToken !== "") {
+    const normalizedOther = normalizeContactToken(otherOwnerToken);
+    if (normalizedOther === request.ownerToken)
+      throw new Error("the other person must be a different candidate");
+    request.otherOwnerToken = normalizedOther;
+  }
+  const confirmedAction = operation === "link" ? normalizeExpectedLinkAction(expectedAction) : "";
+  if (operation === "link") request.expectedAction = confirmedAction;
+  if (operation === "inspect" || operation === "remove") {
+    const normalizedOwner = normalizeContactToken(ownerToken);
+    if (normalizedOwner === request.token) throw new Error("the correct and repair contact cannot be the same");
+    request.ownerToken = normalizedOwner;
+  }
+  const home = process.env.HOME ?? homedir();
+  const result: SpawnSyncReturns<string> = runner(
+    join(home, "bin", "contacts"),
+    ["--json", "resolve"],
+    {
+      encoding: "utf8",
+      input: JSON.stringify(request),
+      timeout: operation === "candidates" || operation === "open" ? 15000 : 35000,
+      maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
+    },
+  );
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES)
+    throw new Error("Contacts returned too much data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  if (operation === "candidates") {
+    const candidates = normalizeBridgeCandidates(response, normalizedHandle);
+    return { handle: normalizedHandle, candidates };
+  }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts operation failed"));
+  if (operation === "discard-unsaved") {
+    if (typeof body.discarded !== "boolean")
+      throw new Error("Contacts returned an invalid unsaved-change result");
+    return { discarded: body.discarded };
+  }
+  if (operation === "open") {
+    if (body.opened !== true) throw new Error("Contacts could not open this card");
+    return {
+      handle: normalizedHandle,
+      opened: true,
+      name: normalizeIdentityName(body.name),
+      cardNumber: finiteInteger(body.cardNumber, "card number", 1, MAX_IDENTITY_CARDS),
+      cardCount: finiteInteger(body.cardCount, "card count", 1, MAX_IDENTITY_CARDS),
+      accountNumber: finiteInteger(
+        body.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+      ),
+      sourceName: contactSourceName(body.sourceName),
+    };
+  }
+  if (operation === "compare") {
+    return { comparison: normalizeContactComparison(body, normalizedHandle) };
+  }
+  if (operation === "link-prepare") {
+    const metadata = normalizeLinkMetadata(body, normalizedHandle);
+    if (typeof body.ready !== "boolean") throw new Error("Contacts returned an invalid link preview");
+    return { linkPreview: { ...metadata, ready: body.ready } };
+  }
+  if (operation === "link") {
+    const metadata = normalizeLinkMetadata(body, normalizedHandle);
+    if (metadata.action !== confirmedAction)
+      throw new Error("Contacts link action changed; review the cards again");
+    if (body.linked !== true) throw new Error("Contacts did not confirm the link action");
+    return { linkResult: { ...metadata, linked: true } };
+  }
+  if (operation === "inspect") {
+    return { handle: normalizedHandle, preview: normalizeRepairPreview(body.preview, normalizedHandle) };
+  }
+  if (operation === "remove") {
+    const preview = normalizeRepairPreview(body, normalizedHandle);
+    if (body.removed !== true) throw new Error("Contacts did not confirm the removal");
+    return {
+      handle: normalizedHandle,
+      removal: { ...preview, removed: true, undoToken: normalizeUndoToken(body.undoToken) },
+    };
+  }
+  if (body.restored !== true) throw new Error("Contacts did not confirm the restore");
+  const undoAction = body.action;
+  if (undoAction !== "field-removal" && undoAction !== "edit" && undoAction !== "delete"
+      && undoAction !== "consolidate")
+    throw new Error("Contacts returned an invalid undo action");
+  return {
+    undo: {
+      restored: true,
+      alreadyPresent: body.alreadyPresent === true,
+      action: undoAction,
+      handle: normalizeHandle(body.handle),
+      name: normalizeIdentityName(body.name),
+      cardCount: finiteInteger(body.cardCount, "restored card count", 1, MAX_COMPARE_CARDS),
+      fieldCount: finiteInteger(body.fieldCount, "restored field count", 1, 13),
+    },
+  };
+}
+
+export async function readStdinBounded(
+  input: AsyncIterable<Uint8Array | string> = process.stdin as any,
+  maximum = MAX_IDENTITY_REQUEST_BYTES,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const raw of input) {
+    const chunk = typeof raw === "string" ? Buffer.from(raw) : Buffer.from(raw);
+    total += chunk.length;
+    if (total > maximum) throw new Error("identity request is too large");
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function parseRequest(text: string): Record<string, unknown> {
+  let value: unknown;
+  try { value = JSON.parse(text); }
+  catch { throw new Error("identity request must be valid JSON"); }
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("identity request must be a JSON object");
+  return value as Record<string, unknown>;
+}
+
+export function identitiesPath(): string {
+  const overridden = process.env.BLIP_IDENTITIES_PATH;
+  if (overridden) {
+    if (!isAbsolute(overridden)) throw new Error("BLIP_IDENTITIES_PATH must be absolute");
+    return overridden;
+  }
+  const home = process.env.HOME;
+  if (!home || !isAbsolute(home)) throw new Error("HOME must be an absolute path");
+  return join(home, ".config", "blip", "identities.json");
+}
+
+function entries(config: IdentityConfig): Array<IdentityChoice & { handle: string }> {
+  return Object.entries(config.identities).map(([handle, choice]) => ({ handle, ...choice }));
+}
+
+function safeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error || "identity operation failed");
+  return message.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim().slice(0, 180)
+    || "identity operation failed";
+}
+
+function emit(value: unknown): void {
+  const output = JSON.stringify(value);
+  if (Buffer.byteLength(output) > MAX_IDENTITY_OUTPUT_BYTES)
+    throw new Error("identity helper output exceeded its contract");
+  process.stdout.write(`${output}\n`);
+}
+
+function withChoice(config: IdentityConfig, handle: string, choice: IdentityChoice): IdentityConfig {
+  const targetKey = identityKey(handle);
+  const next: Record<string, IdentityChoice> = {};
+  for (const [savedHandle, savedChoice] of Object.entries(config.identities)) {
+    if (identityKey(savedHandle) !== targetKey) next[savedHandle] = savedChoice;
+  }
+  next[handle] = choice;
+  return normalizeIdentityConfig({ schemaVersion: 1, identities: next });
+}
+
+function withoutChoice(config: IdentityConfig, handle: string): IdentityConfig {
+  const targetKey = identityKey(handle);
+  return normalizeIdentityConfig({
+    schemaVersion: 1,
+    identities: Object.fromEntries(
+      Object.entries(config.identities).filter(([savedHandle]) => identityKey(savedHandle) !== targetKey),
+    ),
+  });
+}
+
+async function main(): Promise<void> {
+  const operation = process.argv[2] || "read";
+  const path = identitiesPath();
+  try {
+    if (operation === "read") {
+      const result = readIdentities(path);
+      emit({
+        ok: true,
+        exists: result.exists,
+        path,
+        identities: entries(result.config),
+        contactWrites: contactWritesEnabled(),
+      });
+      return;
+    }
+    const request = parseRequest(await readStdinBounded());
+    if (operation === "candidates") {
+      const result = resolveOnMac("candidates", request.handle);
+      emit({
+        ok: true,
+        handle: result.handle,
+        ambiguous: (result.candidates?.length ?? 0) > 1,
+        candidates: result.candidates ?? [],
+      });
+      return;
+    }
+    if (operation === "vcard") {
+      const result = exportContactVCard(request.handle);
+      emit({
+        ok: true, handle: result.handle, name: result.name,
+        bytes: result.bytes, fileName: result.fileName, fileUri: result.fileUri,
+      });
+      return;
+    }
+    if (operation === "audit") {
+      const result = auditContactsOnMac(request.handles);
+      emit({ ok: true, audit: result.audit, cached: result.cached });
+      return;
+    }
+    if (operation === "choose") {
+      const handle = normalizeHandle(request.handle);
+      const name = normalizeIdentityName(request.name);
+      const token = normalizeContactToken(request.token);
+      const candidateResult = resolveOnMac("candidates", handle);
+      const selected = candidateResult.candidates?.find((c) => c.token === token && c.name === name);
+      if (!selected) throw new Error("the selected contact is no longer a candidate");
+      const current = readIdentities(path).config;
+      const config = writeIdentities(path, withChoice(current, handle, {
+        name: selected.name, source: "contacts", contactToken: selected.token,
+      }));
+      emit({ ok: true, path, identity: { handle, ...config.identities[handle]! } });
+      return;
+    }
+    if (operation === "custom") {
+      const handle = normalizeHandle(request.handle);
+      const name = normalizeIdentityName(request.name);
+      const current = readIdentities(path).config;
+      const config = writeIdentities(path, withChoice(current, handle, { name, source: "custom" }));
+      emit({ ok: true, path, identity: { handle, ...config.identities[handle]! } });
+      return;
+    }
+    if (operation === "clear") {
+      const handle = normalizeHandle(request.handle);
+      const current = readIdentities(path).config;
+      const config = writeIdentities(path, withoutChoice(current, handle));
+      emit({ ok: true, path, cleared: handle, identities: entries(config) });
+      return;
+    }
+    if (operation === "open") {
+      const result = resolveOnMac("open", request.handle, request.token);
+      emit({
+        ok: true,
+        opened: result.opened === true,
+        name: result.name,
+        cardNumber: result.cardNumber,
+        cardCount: result.cardCount,
+        accountNumber: result.accountNumber,
+        sourceName: result.sourceName,
+      });
+      return;
+    }
+    if (operation === "compare" || operation === "link-prepare" || operation === "link") {
+      if (operation !== "compare" && !contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac(
+        operation, request.handle, request.ownerToken, spawnSync, undefined,
+        request.expectedAction, request.otherOwnerToken,
+      );
+      if (operation === "compare") emit({ ok: true, comparison: result.comparison });
+      else if (operation === "link-prepare") emit({ ok: true, preview: result.linkPreview });
+      else emit({ ok: true, ...result.linkResult });
+      return;
+    }
+    if (["edit-prepare", "edit", "delete-prepare", "delete", "merge-prepare", "merge"]
+      .includes(operation)) {
+      const mutationOperation = operation as ContactMutationOperation;
+      const applying = operation === "edit" || operation === "delete" || operation === "merge";
+      if (applying && !contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = contactMutationOnMac(mutationOperation, request);
+      if (result.preview) emit({ ok: true, preview: result.preview });
+      else emit({ ok: true, ...result.result });
+      return;
+    }
+    if (operation === "inspect" || operation === "remove") {
+      if (!contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac(operation, request.handle, request.token, spawnSync, request.ownerToken);
+      if (operation === "inspect") emit({ ok: true, preview: result.preview });
+      else emit({ ok: true, ...result.removal });
+      return;
+    }
+    if (operation === "undo") {
+      if (!contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac("undo", undefined, request.undoToken);
+      emit({ ok: true, ...result.undo });
+      return;
+    }
+    if (operation === "discard-unsaved") {
+      if (!contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac("discard-unsaved");
+      emit({ ok: true, discarded: result.discarded === true });
+      return;
+    }
+    throw new Error(
+      "operation must be read, candidates, vcard, audit, choose, custom, clear, open, compare, edit-prepare, "
+      + "edit, delete-prepare, delete, merge-prepare, merge, link-prepare, link, inspect, remove, undo, or discard-unsaved",
+    );
+  } catch (error) {
+    emit({ ok: false, error: safeError(error) });
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) void main();

--- a/paste.ts
+++ b/paste.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 /**
  * Blip clipboard paste helper — snapshots the Wayland clipboard ONCE and
- * reports what it held: an image (staged as a draft file) or text.
+ * reports what it held: a file, an image (staged as a draft file), or text.
  *
- *   bun paste.ts   →  {kind:"image", path, url} | {kind:"text", text} | {kind:"none"}
+ *   bun paste.ts   →  {kind:"file", path, url, name} | {kind:"image", path, url}
+ *                    | {kind:"text", text} | {kind:"none"}
  *
  * QML intercepts Ctrl+V and calls this instead of letting TextEdit paste,
  * because the decision (attach vs insert) needs the mime types, and probing
@@ -13,9 +14,9 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { lstatSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const RUNTIME = process.env.XDG_RUNTIME_DIR ?? `/run/user/${process.getuid?.() ?? 1000}`;
 export const DRAFT_DIR = join(RUNTIME, "blip");
@@ -29,6 +30,27 @@ export function pickImageType(types: string[]): string {
 
 export function extFor(mime: string): string {
   return { "image/png": "png", "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif" }[mime] ?? "img";
+}
+
+/** Preferred local-file clipboard format; GNOME carries copy/cut semantics. */
+export function pickFileType(types: string[]): string {
+  if (types.includes("x-special/gnome-copied-files")) return "x-special/gnome-copied-files";
+  if (types.includes("text/uri-list")) return "text/uri-list";
+  return "";
+}
+
+/** Extract the first safe local file from a Wayland file-copy payload. */
+export function localFileFromPayload(mime: string, payload: string): string {
+  const lines = payload.replace(/\r/g, "").split("\n").map((line) => line.trim()).filter(Boolean);
+  if (mime === "x-special/gnome-copied-files" && /^(copy|cut)$/i.test(lines[0] ?? "")) lines.shift();
+  const uri = lines.find((line) => !line.startsWith("#")) ?? "";
+  if (!uri.startsWith("file://")) return "";
+  try {
+    const path = fileURLToPath(uri);
+    return lstatSync(path).isFile() ? path : "";
+  } catch {
+    return "";
+  }
 }
 
 function gcDrafts(): void {
@@ -47,6 +69,18 @@ export function snapshotClipboard(runner = spawnSync): Record<string, string> {
   const types = runner("wl-paste", ["--list-types"], { encoding: "utf8", timeout: 4000 });
   if (types.status !== 0) return { kind: "none" };
   const offered = (types.stdout as string).trim().split("\n").filter(Boolean);
+
+  // File objects must win over their optional text representation. This is
+  // what makes Copy vCard → paste into another Blip conversation attach the
+  // .vcf instead of inserting its URI or source text into the composer.
+  const fileMime = pickFileType(offered);
+  if (fileMime !== "") {
+    const dump = runner("wl-paste", ["--no-newline", "-t", fileMime], { encoding: "utf8", timeout: 4000 });
+    if (dump.status === 0) {
+      const path = localFileFromPayload(fileMime, dump.stdout as string);
+      if (path !== "") return { kind: "file", path, url: pathToFileURL(path).href, name: basename(path) };
+    }
+  }
 
   const imageMime = pickImageType(offered);
   if (imageMime !== "") {

--- a/preferences.test.ts
+++ b/preferences.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_PREFERENCES,
+  MAX_PREFERENCES_BYTES,
+  normalizePreferences,
+  parsePreferences,
+  readBoundedPreferenceFile,
+  readPreferences,
+  writePreferences,
+} from "./preferences";
+
+const roots: string[] = [];
+function fixture(): { root: string; path: string } {
+  const root = mkdtempSync(join(tmpdir(), "blip-preferences-"));
+  roots.push(root);
+  return { root, path: join(root, "blip", "preferences.json") };
+}
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("preference schema", () => {
+  test("defaults normalize without changing appearance", () => {
+    expect(normalizePreferences(DEFAULT_PREFERENCES)).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  test("normalizes colors, integers, and bounded decimals", () => {
+    expect(normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      outgoingBubbleColor: "#AABBCC",
+      incomingBubbleColor: "#11223380",
+      backgroundOpacity: 0.733,
+      sidebarWidth: 333.8,
+    })).toEqual({
+      ...DEFAULT_PREFERENCES,
+      outgoingBubbleColor: "#aabbcc",
+      incomingBubbleColor: "#11223380",
+      backgroundOpacity: 0.73,
+      sidebarWidth: 334,
+    });
+  });
+
+  test("hides short-code conversations by default and validates the toggle", () => {
+    const legacy = { ...DEFAULT_PREFERENCES } as Record<string, unknown>;
+    delete legacy.hideShortCodeConversations;
+    expect(normalizePreferences(legacy).hideShortCodeConversations).toBe(true);
+    expect(normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      hideShortCodeConversations: false,
+    }).hideShortCodeConversations).toBe(false);
+    expect(() => normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      hideShortCodeConversations: "yes",
+    })).toThrow("boolean");
+  });
+
+  test("defaults legacy files to AM/PM conversation times and validates the choice", () => {
+    const legacy = { ...DEFAULT_PREFERENCES } as Record<string, unknown>;
+    delete legacy.use12HourConversationTimes;
+    expect(normalizePreferences(legacy).use12HourConversationTimes).toBe(true);
+    expect(normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      use12HourConversationTimes: false,
+    }).use12HourConversationTimes).toBe(false);
+    expect(() => normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      use12HourConversationTimes: "sometimes",
+    })).toThrow("boolean");
+  });
+
+  test("rejects every wrong top-level JSON type", () => {
+    for (const value of [null, [], "x", 1, true])
+      expect(() => normalizePreferences(value)).toThrow("JSON object");
+  });
+
+  test("rejects wrong versions, malformed colors, types, and ranges", () => {
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, schemaVersion: 2 })).toThrow("schemaVersion");
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, outgoingBubbleColor: "red" })).toThrow("outgoingBubbleColor");
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, density: "1" })).toThrow("finite number");
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, avatarSize: 1000 })).toThrow("between");
+  });
+
+  test("malformed JSON is reported without echoing its content", () => {
+    expect(() => parsePreferences('{"secret":"do not echo"')).toThrow("not valid JSON");
+  });
+});
+
+describe("bounded preference file", () => {
+  test("a missing file yields defaults", () => {
+    const { path } = fixture();
+    expect(readPreferences(path)).toEqual({
+      exists: false,
+      preferences: DEFAULT_PREFERENCES,
+    });
+  });
+
+  test("round-trips atomically with private directory and file modes", () => {
+    const { root, path } = fixture();
+    const custom = { ...DEFAULT_PREFERENCES, fontScale: 1.2, density: 0.85 };
+    writePreferences(path, custom);
+    expect(readPreferences(path)).toEqual({ exists: true, preferences: custom });
+    expect(lstatSync(join(root, "blip")).mode & 0o777).toBe(0o700);
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    expect(readFileSync(path, "utf8")).toContain('"fontScale": 1.2');
+  });
+
+  test("accepts exactly the byte cap and rejects one byte over before parsing", () => {
+    const { root, path } = fixture();
+    const dir = join(root, "blip");
+    writePreferences(path, DEFAULT_PREFERENCES);
+    writeFileSync(path, Buffer.alloc(MAX_PREFERENCES_BYTES, 0x20));
+    expect(readBoundedPreferenceFile(path)?.length).toBe(MAX_PREFERENCES_BYTES);
+    writeFileSync(path, Buffer.alloc(MAX_PREFERENCES_BYTES + 1, 0x20));
+    expect(() => readBoundedPreferenceFile(path)).toThrow("too large");
+    expect(lstatSync(dir).isDirectory()).toBe(true);
+  });
+
+  test("rejects a symlink instead of following it", () => {
+    const { root, path } = fixture();
+    const target = join(root, "target.json");
+    writePreferences(target, DEFAULT_PREFERENCES);
+    const dir = join(root, "blip");
+    writePreferences(join(dir, "seed.json"), DEFAULT_PREFERENCES);
+    symlinkSync(target, path);
+    expect(() => readBoundedPreferenceFile(path)).toThrow();
+    expect(() => writePreferences(path, DEFAULT_PREFERENCES)).toThrow("regular file");
+  });
+
+  test("rejects a nonblocking FIFO", () => {
+    const { root, path } = fixture();
+    const dir = join(root, "blip");
+    writePreferences(join(dir, "seed.json"), DEFAULT_PREFERENCES);
+    expect(Bun.spawnSync(["mkfifo", path]).exitCode).toBe(0);
+    expect(() => readBoundedPreferenceFile(path)).toThrow("regular file");
+  });
+
+  test("tightens a permissive preferences directory", () => {
+    const { root, path } = fixture();
+    const dir = join(root, "blip");
+    writePreferences(path, DEFAULT_PREFERENCES);
+    chmodSync(dir, 0o755);
+    writePreferences(path, DEFAULT_PREFERENCES);
+    expect(lstatSync(dir).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe("CLI streaming boundary", () => {
+  test("exits before an oversized producer closes stdin", async () => {
+    const { path } = fixture();
+    const child = Bun.spawn(["bun", join(import.meta.dir, "preferences.ts"), "write"], {
+      env: { ...process.env, BLIP_PREFERENCES_PATH: path },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    child.stdin.write(Buffer.alloc(MAX_PREFERENCES_BYTES + 1, 0x20));
+    child.stdin.flush();
+    const result = await Promise.race([
+      child.exited.then((code) => ({ code })),
+      Bun.sleep(1500).then(() => ({ code: -999 })),
+    ]);
+    expect(result.code).not.toBe(-999);
+    expect(result.code).not.toBe(0);
+    try { child.stdin.end(); } catch { /* child already closed the pipe */ }
+  });
+});

--- a/preferences.ts
+++ b/preferences.ts
@@ -1,0 +1,344 @@
+/**
+ * Blip appearance preferences.
+ *
+ * QML never reads the user-writable file directly. This helper owns a small,
+ * bounded JSON contract and emits only normalized values. The same helper
+ * writes atomically with private permissions, so preferences.json is safe to
+ * copy into a dotfiles repository and restore later.
+ *
+ *   bun preferences.ts read
+ *   printf '%s' '{...}' | bun preferences.ts write
+ *   bun preferences.ts reset
+ */
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { basename, dirname, isAbsolute, join } from "node:path";
+
+export const MAX_PREFERENCES_BYTES = 16 * 1024;
+export const MAX_HELPER_OUTPUT_BYTES = 4 * 1024;
+
+export type BubbleColor = "theme" | `#${string}`;
+
+export interface BlipPreferences {
+  schemaVersion: 1;
+  outgoingBubbleColor: BubbleColor;
+  incomingBubbleColor: BubbleColor;
+  backgroundOpacity: number;
+  fontScale: number;
+  density: number;
+  sidebarWidth: number;
+  avatarSize: number;
+  cornerScale: number;
+  hideShortCodeConversations: boolean;
+  use12HourConversationTimes: boolean;
+}
+
+export const DEFAULT_PREFERENCES: Readonly<BlipPreferences> = Object.freeze({
+  schemaVersion: 1,
+  outgoingBubbleColor: "theme",
+  incomingBubbleColor: "theme",
+  backgroundOpacity: 0.7,
+  fontScale: 1,
+  density: 1,
+  sidebarWidth: 320,
+  avatarSize: 30,
+  cornerScale: 1,
+  hideShortCodeConversations: true,
+  use12HourConversationTimes: true,
+});
+
+const NUMBER_RULES = {
+  backgroundOpacity: { min: 0.2, max: 1, digits: 2 },
+  fontScale: { min: 0.75, max: 1.5, digits: 2 },
+  density: { min: 0.7, max: 1.4, digits: 2 },
+  sidebarWidth: { min: 240, max: 520, digits: 0 },
+  avatarSize: { min: 24, max: 64, digits: 0 },
+  cornerScale: { min: 0, max: 2, digits: 2 },
+} as const;
+
+function own(value: Record<string, unknown>, key: string): unknown {
+  return Object.prototype.hasOwnProperty.call(value, key) ? value[key] : undefined;
+}
+
+function normalizedColor(value: unknown, key: string): BubbleColor {
+  if (typeof value !== "string") throw new Error(`${key} must be "theme" or a hex color`);
+  const color = value.trim().toLowerCase();
+  if (color === "theme") return color;
+  if (!/^#[0-9a-f]{6}([0-9a-f]{2})?$/.test(color))
+    throw new Error(`${key} must be "theme", #rrggbb, or #rrggbbaa`);
+  return color as BubbleColor;
+}
+
+function normalizedNumber(
+  value: unknown,
+  key: keyof typeof NUMBER_RULES,
+): number {
+  const rule = NUMBER_RULES[key];
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error(`${key} must be a finite number`);
+  if (value < rule.min || value > rule.max)
+    throw new Error(`${key} must be between ${rule.min} and ${rule.max}`);
+  if (rule.digits === 0) return Math.round(value);
+  const factor = 10 ** rule.digits;
+  return Math.round(value * factor) / factor;
+}
+
+function normalizedBoolean(value: unknown, key: string, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") throw new Error(`${key} must be a boolean`);
+  return value;
+}
+
+/** Strict for known fields, tolerant of unknown future fields. */
+export function normalizePreferences(value: unknown): BlipPreferences {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("preferences must be a JSON object");
+  const input = value as Record<string, unknown>;
+  if (own(input, "schemaVersion") !== 1)
+    throw new Error("schemaVersion must be 1");
+
+  return {
+    schemaVersion: 1,
+    outgoingBubbleColor: normalizedColor(own(input, "outgoingBubbleColor"), "outgoingBubbleColor"),
+    incomingBubbleColor: normalizedColor(own(input, "incomingBubbleColor"), "incomingBubbleColor"),
+    backgroundOpacity: normalizedNumber(own(input, "backgroundOpacity"), "backgroundOpacity"),
+    fontScale: normalizedNumber(own(input, "fontScale"), "fontScale"),
+    density: normalizedNumber(own(input, "density"), "density"),
+    sidebarWidth: normalizedNumber(own(input, "sidebarWidth"), "sidebarWidth"),
+    avatarSize: normalizedNumber(own(input, "avatarSize"), "avatarSize"),
+    cornerScale: normalizedNumber(own(input, "cornerScale"), "cornerScale"),
+    hideShortCodeConversations: normalizedBoolean(
+      own(input, "hideShortCodeConversations"),
+      "hideShortCodeConversations",
+      true,
+    ),
+    use12HourConversationTimes: normalizedBoolean(
+      own(input, "use12HourConversationTimes"),
+      "use12HourConversationTimes",
+      true,
+    ),
+  };
+}
+
+export function parsePreferences(text: string): BlipPreferences {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("preferences.json is not valid JSON");
+  }
+  return normalizePreferences(parsed);
+}
+
+function currentUid(): number {
+  const uid = typeof process.getuid === "function" ? process.getuid() : -1;
+  if (uid < 0) throw new Error("cannot determine the current user");
+  return uid;
+}
+
+function openPinnedDirectory(path: string, create: boolean): number {
+  if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+  );
+  const stat = fstatSync(fd);
+  if (!stat.isDirectory()) {
+    closeSync(fd);
+    throw new Error("preferences directory is not a directory");
+  }
+  if (stat.uid !== currentUid()) {
+    closeSync(fd);
+    throw new Error("preferences directory is not owned by the current user");
+  }
+  if ((stat.mode & 0o077) !== 0) fchmodSync(fd, 0o700);
+  return fd;
+}
+
+function pinnedPath(directoryFd: number, name: string): string {
+  return `/proc/self/fd/${directoryFd}/${name}`;
+}
+
+/** Read exactly one pinned, regular, owner-controlled file with a hard cap. */
+export function readBoundedPreferenceFile(path: string): string | null {
+  const directoryFd = openPinnedDirectory(dirname(path), false);
+  let fileFd = -1;
+  try {
+    try {
+      fileFd = openSync(
+        pinnedPath(directoryFd, basename(path)),
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+    } catch (error: any) {
+      if (error?.code === "ENOENT") return null;
+      throw error;
+    }
+    const stat = fstatSync(fileFd);
+    if (!stat.isFile()) throw new Error("preferences.json must be a regular file");
+    if (stat.uid !== currentUid()) throw new Error("preferences.json is not owned by the current user");
+    if (stat.size > MAX_PREFERENCES_BYTES) throw new Error("preferences.json is too large");
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.alloc(Math.min(4096, MAX_PREFERENCES_BYTES + 1 - total));
+      const count = readSync(fileFd, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > MAX_PREFERENCES_BYTES) throw new Error("preferences.json is too large");
+      chunks.push(chunk.subarray(0, count));
+    }
+    return Buffer.concat(chunks, total).toString("utf8");
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    closeSync(directoryFd);
+  }
+}
+
+export function readPreferences(path: string): { exists: boolean; preferences: BlipPreferences } {
+  let text: string | null;
+  try {
+    text = readBoundedPreferenceFile(path);
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return { exists: false, preferences: { ...DEFAULT_PREFERENCES } };
+    throw error;
+  }
+  if (text === null) return { exists: false, preferences: { ...DEFAULT_PREFERENCES } };
+  return { exists: true, preferences: parsePreferences(text) };
+}
+
+function verifyReplaceableTarget(directoryFd: number, name: string): void {
+  try {
+    const stat = lstatSync(pinnedPath(directoryFd, name));
+    if (!stat.isFile()) throw new Error("preferences.json must be a regular file");
+    if (stat.uid !== currentUid()) throw new Error("preferences.json is not owned by the current user");
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+/** Atomic, owner-only write inside a pinned config directory. */
+export function writePreferences(path: string, value: unknown): BlipPreferences {
+  if (!isAbsolute(path)) throw new Error("preferences path must be absolute");
+  const preferences = normalizePreferences(value);
+  const serialized = `${JSON.stringify(preferences, null, 2)}\n`;
+  if (Buffer.byteLength(serialized) > MAX_PREFERENCES_BYTES)
+    throw new Error("normalized preferences exceed the size limit");
+
+  const directoryFd = openPinnedDirectory(dirname(path), true);
+  const name = basename(path);
+  const tempName = `.${name}.tmp.${process.pid}.${randomBytes(6).toString("hex")}`;
+  const tempPath = pinnedPath(directoryFd, tempName);
+  let tempFd = -1;
+  let renamed = false;
+  try {
+    verifyReplaceableTarget(directoryFd, name);
+    tempFd = openSync(
+      tempPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    const bytes = Buffer.from(serialized, "utf8");
+    let offset = 0;
+    while (offset < bytes.length) offset += writeSync(tempFd, bytes, offset, bytes.length - offset);
+    fchmodSync(tempFd, 0o600);
+    fsyncSync(tempFd);
+    closeSync(tempFd);
+    tempFd = -1;
+    renameSync(tempPath, pinnedPath(directoryFd, name));
+    renamed = true;
+    chmodSync(pinnedPath(directoryFd, name), 0o600);
+    fsyncSync(directoryFd);
+    return preferences;
+  } finally {
+    if (tempFd >= 0) closeSync(tempFd);
+    if (!renamed) {
+      try { unlinkSync(tempPath); } catch { /* no temporary file */ }
+    }
+    closeSync(directoryFd);
+  }
+}
+
+export async function readStdinBounded(
+  input: AsyncIterable<Uint8Array | string> = process.stdin as any,
+  maximum = MAX_PREFERENCES_BYTES,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const raw of input) {
+    const chunk = typeof raw === "string" ? Buffer.from(raw) : Buffer.from(raw);
+    total += chunk.length;
+    if (total > maximum) throw new Error("preference input is too large");
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function safeError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : "preference operation failed";
+  return raw
+    .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180) || "preference operation failed";
+}
+
+function emit(value: unknown): void {
+  const output = JSON.stringify(value);
+  if (Buffer.byteLength(output) > MAX_HELPER_OUTPUT_BYTES)
+    throw new Error("preference helper output exceeded its contract");
+  process.stdout.write(`${output}\n`);
+}
+
+export function preferencesPath(): string {
+  const overridden = process.env.BLIP_PREFERENCES_PATH;
+  if (overridden) {
+    if (!isAbsolute(overridden)) throw new Error("BLIP_PREFERENCES_PATH must be absolute");
+    return overridden;
+  }
+  const home = process.env.HOME;
+  if (!home || !isAbsolute(home)) throw new Error("HOME must be an absolute path");
+  return join(home, ".config", "blip", "preferences.json");
+}
+
+async function main(): Promise<void> {
+  const operation = process.argv[2] || "read";
+  const path = preferencesPath();
+  try {
+    if (operation === "read") {
+      emit({ ok: true, ...readPreferences(path) });
+      return;
+    }
+    if (operation === "write") {
+      const text = await readStdinBounded();
+      const preferences = writePreferences(path, parsePreferences(text));
+      emit({ ok: true, exists: true, preferences });
+      return;
+    }
+    if (operation === "reset") {
+      const preferences = writePreferences(path, DEFAULT_PREFERENCES);
+      emit({ ok: true, exists: true, preferences });
+      return;
+    }
+    throw new Error("operation must be read, write, or reset");
+  } catch (error) {
+    emit({ ok: false, error: safeError(error) });
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) await main();

--- a/scripts/blip-setup
+++ b/scripts/blip-setup
@@ -32,11 +32,12 @@ conf_dir="$HOME/.config/blip"
 conf="$conf_dir/bridge.conf"
 
 # bridge.conf is DATA (audit #7): read the two keys we care about, never source it.
-prev_automation=""; prev_country=""
+prev_automation=""; prev_country=""; prev_contact_writes=""
 if [[ -r "$conf" ]]; then
   [[ -z "$host" ]] && host="$(sed -n 's/^host=//p' "$conf" | head -1 | tr -d '"\x27 ')"
   prev_automation="$(sed -n 's/^automation=//p' "$conf" | head -1 | tr -d '"\x27 ')"
   prev_country="$(sed -n 's/^country_code=//p' "$conf" | head -1 | tr -d '"\x27 ')"
+  prev_contact_writes="$(sed -n 's/^contact_writes=//p' "$conf" | head -1 | tr -d '"\x27 ')"
 fi
 if [[ -z "${host:-}" ]]; then
   read -r -p "Mac ssh target ([user@]host, Tailscale name works best): " host
@@ -59,6 +60,8 @@ mkdir -p "$conf_dir"
   echo "automation=${BLIP_AUTOMATION:-${prev_automation:-off}}"   # a re-run keeps a hand-set value
   echo "# country calling code for numbers typed without one (1 = US/Canada, 44 = UK, 49 = DE…)"
   echo "country_code=${prev_country:-1}"
+  echo "# on = show confirmed, undoable Mac Contacts repair controls"
+  echo "contact_writes=${BLIP_CONTACT_WRITES:-${prev_contact_writes:-off}}"
 } > "$conf"
 chmod 0600 "$conf"
 echo "✓ $conf"
@@ -107,6 +110,14 @@ if ssh -n -o ConnectTimeout=6 -o BatchMode=yes "$host" true 2>/dev/null; then
   if ! ssh "$host" "python3 -c 'import sqlite3, subprocess'" >/dev/null 2>&1; then
     echo "✗ python3 on $host cannot run: install Xcode Command Line Tools there —  xcode-select --install  — then re-run blip-setup" >&2
     exit 1
+  fi
+
+  # Contact writes require a second, Mac-local gate that the restricted Blip
+  # key cannot create for itself. Only an explicit setup environment opt-in
+  # installs it; ordinary setup remains read-only/open-only.
+  if [[ "${BLIP_CONTACT_WRITES:-off}" == on ]]; then
+    ssh "$host" 'umask 077; mkdir -p ~/.blip; printf "enabled-v1\n" > ~/.blip/contact-writes-enabled; chmod 0600 ~/.blip/contact-writes-enabled'
+    echo "✓ Mac contact-write gate enabled (explicit BLIP_CONTACT_WRITES=on)"
   fi
 
   # 4b. Dedicated key, confined on the Mac to blip-dispatch (restrict = no

--- a/scripts/sync-bridge.sh
+++ b/scripts/sync-bridge.sh
@@ -25,7 +25,8 @@ for t in imsg imsg-send contacts tcc-check; do
   fi
   install -m 0755 "$tmp/$t" "$dest/$t"
 done
-printf 'claude-on-mac %s (synced %s)\nvendored: imsg imsg-send contacts tcc-check\nsync: scripts/sync-bridge.sh <sha-or-tag>\n' \
+printf 'claude-on-mac %s (synced %s)\nvendored: imsg imsg-send contacts tcc-check\nblip extensions: NONE after sync; reapply pin-order and identity-resolver patches\nsync: scripts/sync-bridge.sh <sha-or-tag>\n' \
   "$rev" "$(date +%F)" > "$here/bridge/BRIDGE-VERSION"
+echo "! Reapply the Blip pin-order and identity-resolver extensions named in bridge/BRIDGE-VERSION before committing." >&2
 echo "✓ bridge/mac synced to claude-on-mac $rev"
 git -C "$here" status --short bridge/

--- a/thread.test.ts
+++ b/thread.test.ts
@@ -169,6 +169,7 @@ describe("decorate", () => {
     expect(b[0]!.groupStart).toBe(true);
     expect(b[0]!.groupEnd).toBe(true);
     expect(b[0]!.time).toBe("12:00 PM");
+    expect(b[0]!.handle).toBe("+15551234567");
   });
 
   test("the patterns reach the divider, the timestamp and the read receipt", () => {
@@ -436,10 +437,29 @@ describe("selectThread", () => {
     expect(seen).toContain("--chat");
     expect(seen[seen.indexOf("--chat") + 1]).toBe(guid);
   });
+
+  test("a coalesced group loads and selects every exact historical alias", () => {
+    const oldGuid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const raw = [
+      msg({ chat: oldGuid, ts: "2026-08-29 12:00:00", text: "old history" }),
+      msg({ chat: guid, ts: "2026-08-30 12:00:00", text: "new history" }),
+    ];
+    expect(selectThread(raw, guid, true, 80, [], [oldGuid]).map((m) => m.text))
+      .toEqual(["old history", "new history"]);
+    let seen: string[] = [];
+    const runner = ((_: string, args: string[]) => {
+      seen = args;
+      return { status: 0, stdout: JSON.stringify(raw), stderr: "" };
+    }) as never;
+    const out = loadThread(guid, 80, "2026-08-30", DEFAULT_FORMATS, runner, [oldGuid]);
+    expect(seen).not.toContain("--also-chat");
+    expect(seen[seen.indexOf("--chat") + 1]).toBe(guid);
+    expect(out.bubbles.map((bubble) => bubble.text)).toEqual(["old history", "new history"]);
+  });
 });
 
 describe("linkify", () => {
-  const { linkify } = require("./thread") as typeof import("./thread");
+  const { linkify, standaloneUrl } = require("./thread") as typeof import("./thread");
 
   test("no URL → empty string (PlainText fast path)", () => {
     expect(linkify("just words")).toBe("");
@@ -472,6 +492,11 @@ describe("linkify", () => {
 
   test("newlines become <br> in the rich path", () => {
     expect(linkify("https://a.io\nline2")).toBe('<a href="https://a.io">https://a.io</a><br>line2');
+  });
+
+  test("a standalone shared URL is recognized even when metadata canonicalizes it", () => {
+    expect(standaloneUrl("https://example.com/reel/one?tracking=abc")).toBe(true);
+    expect(standaloneUrl("look https://example.com/reel/one")).toBe(false);
   });
 });
 
@@ -508,6 +533,21 @@ describe("rich decoration", () => {
       today,
     );
     expect(out[0]!.attachments.map((a) => a.name)).toEqual(["real.pdf"]);
+  });
+
+  test("an unfurled card suppresses a URL-only body but keeps a real caption", () => {
+    const link = {
+      url: "https://example.com/reel/one",
+      title: "One reel",
+      summary: "",
+      image_id: "10",
+    };
+    const out = decorate([
+      msg({ text: "https://example.com/reel/one?tracking=abc", link }),
+      msg({ ts: "2026-08-30 12:01:00", text: "Look at this https://example.com/reel/one", link }),
+    ], today);
+    expect(out[0]!.linkOnly).toBe(true);
+    expect(out[1]!.linkOnly).toBe(false);
   });
 
   test("attachment placeholder char is stripped, chips pass through", () => {
@@ -548,6 +588,7 @@ describe("rich decoration", () => {
     expect(out[0]!.replyText).toBe("");
     expect(out[0]!.edited).toBe(false);
     expect(out[0]!.retracted).toBe(false);
+    expect(out[0]!.linkOnly).toBe(false);
   });
 });
 

--- a/thread.ts
+++ b/thread.ts
@@ -14,6 +14,7 @@ import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import {
   chatKey,
+  applyIdentityOverrides,
   dedupeSelfEcho,
   isGroupChat,
   loadState,
@@ -22,6 +23,7 @@ import {
   type LinkCard,
   type Tapback,
 } from "./collector";
+import { safeReadIdentityConfig } from "./identities";
 export { dedupeSelfEcho };
 
 const HOME = process.env.HOME ?? homedir();
@@ -54,6 +56,8 @@ export const GROUP_GAP_MINUTES = 15;
 export interface Bubble {
   ts: string;
   from_me: boolean;
+  /** Sender handle retained for contact actions; never rendered directly when a name exists. */
+  handle: string;
   name: string;
   text: string;
   /** Non-empty on the first message of a new calendar day: "Today", "Aug 28". */
@@ -76,6 +80,8 @@ export interface Bubble {
   edited: boolean;
   /** Rich-link preview card, null when the message has none. */
   link: LinkCard | null;
+  /** The body is only the shared URL already represented by `link`. */
+  linkOnly: boolean;
   /** An unsent message renders as a tombstone, not a bubble. */
   retracted: boolean;
   /** Screen/bubble effect short name ("confetti"), "" when none. */
@@ -201,6 +207,11 @@ export function minutesBetween(a: string, b: string): number {
   return Math.abs(pb - pa) / 60000;
 }
 
+/** Metadata often canonicalizes a shared URL by dropping tracking parameters. */
+export function standaloneUrl(text: string): boolean {
+  return /^(?:https?:\/\/|www\.)[^\s<>"']+$/i.test(String(text ?? "").trim());
+}
+
 // ---------------------------------------------------------------- decoration
 
 /**
@@ -241,14 +252,17 @@ export function decorate(msgs: ImsgMessage[], today: string, formats = DEFAULT_F
       next.ts.slice(0, 10) !== m.ts.slice(0, 10) ||
       !sameSender(m, next) ||
       minutesBetween(m.ts, next.ts) > GROUP_GAP_MINUTES;
+    const cleanText = (m.text ?? "").replace(/￼/g, "").trim();
+    const link = normalizeLink(m.link);
 
     out.push({
       ts: m.ts,
       from_me: m.from_me,
+      handle: m.handle ?? "",
       name: m.name ?? m.handle ?? "",
       // U+FFFC is the object-replacement placeholder Messages leaves where an
       // attachment sat; the chip row carries that information instead.
-      text: (m.text ?? "").replace(/￼/g, "").trim(),
+      text: cleanText,
       day: newDay ? dayLabel(m.ts, today, formats) : "",
       groupStart,
       groupEnd,
@@ -262,11 +276,12 @@ export function decorate(msgs: ImsgMessage[], today: string, formats = DEFAULT_F
       replyText: m.reply_to?.text ?? "",
       replyMine: m.reply_to?.from_me ?? false,
       edited: m.edited === true,
-      link: normalizeLink(m.link),
+      link,
+      linkOnly: link !== null && standaloneUrl(cleanText),
       retracted: m.retracted === true,
       effect: m.effect ?? "",
       audio: m.audio === true,
-      html: linkify((m.text ?? "").replace(/￼/g, "").trim()),
+      html: linkify(cleanText),
       failed: m.from_me && typeof m.error === "number" && m.error !== 0,
     });
   }
@@ -344,13 +359,16 @@ export function selectThread(
   group: boolean,
   limit: number,
   selfChats: string[] = [],
+  aliases: string[] = [],
 ): ImsgMessage[] {
   // Exact-filter DMs too: `imsg thread` matches the handle by SUBSTRING, so
   // +15551234567 can pull rows from +995551234567 into the wrong conversation
   // (Codex finding #3).
+  const accepted = new Set([chat, ...aliases]);
   // A DM is scoped by CHAT, not by sender: the same handle's messages in a
   // group carry the group's chat id and must stay out of the 1:1 thread.
-  let msgs = raw.filter((m) => chatKey(m) === chat || (!group && m.handle === chat && !isGroupChat(chatKey(m))));
+  let msgs = raw.filter((m) => accepted.has(chatKey(m)) ||
+    (!group && m.handle === chat && !isGroupChat(chatKey(m))));
   msgs = [...msgs].sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
   msgs = dedupeSelfEcho(msgs, selfChats);
   return msgs.length > limit ? msgs.slice(msgs.length - limit) : msgs;
@@ -364,6 +382,7 @@ export function loadThread(
   today: string,
   formats = DEFAULT_FORMATS,
   runner = spawnSync,
+  aliases: string[] = [],
 ): ThreadOutput {
   // Groups load by EXACT chat id (imsg ≥1.8.0 `thread --chat`). The old
   // recent-window scan cost ~20× the rows and missed anything older than
@@ -373,6 +392,10 @@ export function loadThread(
   // window (war room #14). A DM's chat_identifier IS the handle.
   const group = isGroupChat(chat);
   const args = ["--json", "--rich", "thread", "--chat", chat, String(limit)];
+  const safeAliases = [...new Set(aliases)]
+    .filter((alias) => alias !== chat && alias.length > 0 && alias.length <= 512 &&
+      !/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/.test(alias))
+    .slice(0, 15);
   const res = runner(`${HOME}/bin/imsg`, args, {
     encoding: "utf8",
     timeout: 15000, maxBuffer: 64 * 1024 * 1024,
@@ -388,7 +411,8 @@ export function loadThread(
   try {
     const parsed = JSON.parse(res.stdout as string);
     if (!Array.isArray(parsed)) throw new Error("not an array");
-    const msgs = selectThread(parsed as ImsgMessage[], chat, group, limit, loadState().selfChats);
+    const named = applyIdentityOverrides(parsed as ImsgMessage[], safeReadIdentityConfig());
+    const msgs = selectThread(named, chat, group, limit, loadState().selfChats, safeAliases);
     return { ok: true, online: true, error: "", bubbles: decorate(msgs, today, formats) };
   } catch (e) {
     return { ok: false, online: true, error: `bad JSON from imsg: ${e}`, bubbles: [] };
@@ -410,9 +434,16 @@ export function cliChatArg(raw: string): string {
 if (import.meta.main) {
   const chat = cliChatArg(process.argv[2] ?? "");
   const limit = Number(process.argv[3] ?? 80) || 80;
+  const aliases: string[] = [];
+  for (let i = 4; i < process.argv.length; i++) {
+    const arg = process.argv[i] ?? "";
+    if (arg.startsWith("--")) { i++; continue; }
+    aliases.push(arg);
+  }
   const today = localToday();
   try {
-    console.log(JSON.stringify(loadThread(chat, limit, today, formatsFromArgv(process.argv))));
+    console.log(JSON.stringify(loadThread(
+      chat, limit, today, formatsFromArgv(process.argv), spawnSync, aliases)));
   } catch (e) {
     console.log(JSON.stringify({ ok: false, online: false, error: String(e), bubbles: [] }));
   }

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { CACHE_DIR, bakeOrientation, cacheFileName, exifOrientation, fetchAttachment, isImageMime, jpegtranArgs, lruEvictions, sanitizeName, wantsJpeg } from "./fetch";
-import { extFor, pickImageType } from "./paste";
+import { extFor, localFileFromPayload, pickFileType, pickImageType, snapshotClipboard } from "./paste";
 import { resolveTarget, sendFile } from "./send-file";
 import { linkHost, linkify, normalizeLink, selectThread } from "./thread";
 import {
@@ -17,7 +17,7 @@ import {
 import { AVATAR_DIR, AVATAR_NONE_TTL_MS, AVATAR_TTL_MS, avatarArgs, avatarKey, fetchAvatar } from "./avatar";
 import { readFileSync, writeFileSync, unlinkSync, utimesSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 // A real 16×8 baseline JPEG (ImageMagick, -strip): no APP1 at all.
 const TINY_JPEG = Buffer.from(
@@ -186,6 +186,45 @@ describe("EXIF orientation is baked into cached JPEGs", () => {
     expect(sofSize(withExif(TINY_JPEG, 6))).toEqual([16, 8]);
     expect(sofSize(out)).toEqual([8, 16]);
     expect(exifOrientation(out)).toBe(1);                    // tag gone: no double rotation in Qt
+  });
+});
+
+describe("clipboard file paste", () => {
+  test("prefers a GNOME file object over URI-list and text", () => {
+    expect(pickFileType(["text/plain", "text/uri-list", "x-special/gnome-copied-files"]))
+      .toBe("x-special/gnome-copied-files");
+  });
+
+  test("extracts an existing local file from both supported payloads", () => {
+    const tmp = `${process.env.HOME}/.cache/blip-paste-${process.pid}.vcf`;
+    writeFileSync(tmp, "BEGIN:VCARD\nEND:VCARD\n");
+    const uri = new URL(`file://${tmp}`).href;
+    try {
+      expect(localFileFromPayload("x-special/gnome-copied-files", `copy\n${uri}\n`)).toBe(tmp);
+      expect(localFileFromPayload("text/uri-list", `# contact\r\n${uri}\r\n`)).toBe(tmp);
+    } finally { unlinkSync(tmp); }
+  });
+
+  test("rejects remote URIs and missing local files", () => {
+    expect(localFileFromPayload("text/uri-list", "https://example.com/person.vcf\n")).toBe("");
+    expect(localFileFromPayload("text/uri-list", "file:///definitely/missing/person.vcf\n")).toBe("");
+  });
+
+  test("snapshot returns a file attachment before attempting text", () => {
+    const tmp = `${process.env.HOME}/.cache/blip-snapshot-${process.pid}.vcf`;
+    writeFileSync(tmp, "BEGIN:VCARD\nEND:VCARD\n");
+    const calls: string[][] = [];
+    const runner = ((_cmd: string, args: string[]) => {
+      calls.push(args);
+      if (args.includes("--list-types")) {
+        return { status: 0, stdout: "text/plain\nx-special/gnome-copied-files\n" };
+      }
+      return { status: 0, stdout: `copy\n${new URL(`file://${tmp}`).href}\n` };
+    }) as never;
+    try {
+      expect(snapshotClipboard(runner)).toMatchObject({ kind: "file", path: tmp, name: basename(tmp) });
+      expect(calls.some((args) => args.includes("text"))).toBe(false);
+    } finally { unlinkSync(tmp); }
   });
 });
 

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -4,6 +4,16 @@ import { CACHE_DIR, bakeOrientation, cacheFileName, exifOrientation, fetchAttach
 import { extFor, pickImageType } from "./paste";
 import { resolveTarget, sendFile } from "./send-file";
 import { linkHost, linkify, normalizeLink, selectThread } from "./thread";
+import {
+  decodeEntities,
+  hostOf,
+  isPrivateAddress,
+  parseCard,
+  previewsEnabled,
+  previewKey,
+  safeUrl,
+  sniffImage,
+} from "./linkpreview";
 import { AVATAR_DIR, AVATAR_NONE_TTL_MS, AVATAR_TTL_MS, avatarArgs, avatarKey, fetchAvatar } from "./avatar";
 import { readFileSync, writeFileSync, unlinkSync, utimesSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -596,10 +606,6 @@ describe("country code + service (2.2.0)", () => {
 });
 
 describe("link previews for URLs Messages never decorated", () => {
-  const {
-    decodeEntities, hostOf, isPrivateAddress, parseCard, previewsEnabled, previewKey, safeUrl, sniffImage,
-  } = require("./linkpreview") as typeof import("./linkpreview");
-
   test("Open Graph wins, then Twitter, then the plain document", () => {
     const html = `<html><head>
       <title>fallback title</title>

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -4,6 +4,13 @@ import { readFileSync } from "node:fs";
 // The renderer moved from Panel.qml into BlipView.qml in 1.8.0 (shared with the app window).
 const panel = readFileSync(new URL("./BlipView.qml", import.meta.url), "utf8");
 const widget = readFileSync(new URL("./BarWidget.qml", import.meta.url), "utf8");
+const identitySettings = readFileSync(new URL("./IdentitySettings.qml", import.meta.url), "utf8");
+const contactCompare = readFileSync(new URL("./ContactCardCompare.qml", import.meta.url), "utf8");
+const contactEditor = readFileSync(new URL("./ContactCardEditor.qml", import.meta.url), "utf8");
+const settings = readFileSync(new URL("./BlipSettings.qml", import.meta.url), "utf8");
+const identities = readFileSync(new URL("./BlipIdentities.qml", import.meta.url), "utf8");
+const identityHelper = readFileSync(new URL("./identities.ts", import.meta.url), "utf8");
+const preferences = readFileSync(new URL("./BlipPreferences.qml", import.meta.url), "utf8");
 const window = readFileSync(new URL("./BlipWindow.qml", import.meta.url), "utf8");
 
 function handleTextKeySource() {
@@ -95,9 +102,222 @@ describe("QML safety invariants", () => {
     expect(widget).toContain("property var refreshQueue: []");
     expect(widget).not.toContain("property var queued: null");
     const success = panel.indexOf("if (d.ok === true)");
-    const mark = panel.indexOf("markThreadRead(root.threadRunningChat)");
+    const mark = panel.indexOf("markThreadRead(root.threadRunningChat,");
     expect(success).toBeGreaterThan(-1);
     expect(mark).toBeGreaterThan(success);
+  });
+
+  test("contact management and optional Blip display preferences are separate flows", () => {
+    expect(identitySettings).toContain("CHOOSE A CONVERSATION TO REVIEW");
+    expect(identitySettings).toContain("WHY THEY ARE HERE");
+    expect(identitySettings).toContain("Short codes and service senders can simply be left alone.");
+    expect(identitySettings).toContain("Review contact…");
+    expect(identitySettings).toContain("Review anyway…");
+    expect(identitySettings).toContain("var started = resolver.findCandidates(handle)");
+    expect(identitySettings).toContain("directContactPending = directEdit === true && started");
+    expect(identitySettings).toContain("Hide short-code senders");
+    expect(identitySettings).not.toContain(".slice(0, 12)");
+    expect(identitySettings).toContain("phone/email conversations to review");
+    expect(identitySettings).toContain("readonly property var auditableConversations: auditableThreads(threads)");
+    expect(identitySettings).toContain("resolver.audit.handleCount === auditableConversations.length");
+    expect(identitySettings).toContain("Named conversations are included");
+    expect(identitySettings).toContain("preferences.hideShortCodeConversations");
+    expect(identitySettings).toContain('preferences.setBoolean("hideShortCodeConversations", value)');
+    expect(settings).toContain("preferences: root.preferences");
+    expect(identitySettings).toContain("What do you want to do? These are separate workflows.");
+    expect(identitySettings).toContain("rowSpacing: root.space(12)");
+    expect(identitySettings).toContain("columnSpacing: root.space(12)");
+    expect(identitySettings).toContain("MANAGE MAC CONTACTS");
+    expect(identitySettings).toContain("This never creates a Blip display-name preference.");
+    expect(identitySettings).toContain("Skip this when you only want to deduplicate Contacts.");
+    // side-by-side workflow cards share the taller card's height, and each
+    // card's action pins to the bottom right through a flexible spacer
+    expect(identitySettings).toContain("Math.max(manageTask.implicitHeight, namingTask.implicitHeight)");
+    expect(identitySettings.split("Item { Layout.fillHeight: true }").length - 1).toBeGreaterThanOrEqual(2);
+    expect(identitySettings).toContain("OPTIONAL BLIP DISPLAY NAME");
+    expect(identitySettings).toContain("Save Contacts name as display preference");
+    expect(identitySettings).toContain("CUSTOM BLIP-ONLY DISPLAY NAME");
+    expect(identitySettings).toContain("it is temporary, never saved, and changes nothing in Contacts.");
+    expect(identitySettings).toContain("Viewing or opening a card makes no change");
+    expect(identitySettings).toContain("CHOOSE A CONVERSATION TO REVIEW");
+    expect(identitySettings.indexOf("WHY THEY ARE HERE"))
+      .toBeLessThan(identitySettings.indexOf("FIND CONTACT CLEANUP OPPORTUNITIES"));
+    expect(identitySettings.indexOf("FIND CONTACT CLEANUP OPPORTUNITIES"))
+      .toBeLessThan(identitySettings.indexOf("CHOOSE A CONVERSATION TO REVIEW"));
+    expect(identitySettings.indexOf("CHOOSE A CONVERSATION TO REVIEW"))
+      .toBeLessThan(identitySettings.indexOf("model: root.unresolved"));
+    expect(identitySettings).toContain("Refresh source cards");
+    expect(identitySettings).not.toContain("Check Mac Contacts again");
+    expect(identitySettings.indexOf("Refresh source cards"))
+      .toBeLessThan(identitySettings.indexOf("ContactCardCompare {"));
+    expect(identitySettings).toContain("root.resolver.comparison === null");
+    expect(identitySettings).toContain("visible: contactWorkspace.editorCard === null && root.resolver");
+    expect(identitySettings).toContain("root.resolver.candidates.length === 1");
+    expect(identitySettings).not.toContain("root.selectedChoiceIsSaved\n                  && (!root.resolver.comparison");
+    expect(identityHelper).not.toContain("requireSavedRepairOwner");
+    expect(identityHelper).not.toContain("save the correct Contacts name in Blip before repairing");
+    expect(identitySettings).not.toContain("MATCH REMEMBERED BY BLIP");
+    expect(identitySettings).not.toContain("Already saved in Blip\"");
+    expect(identitySettings).not.toContain('label: "Use"');
+    expect(identitySettings).not.toContain("Fix on Mac");
+  });
+
+  test("stale unsaved Contacts edits have an explicit two-step recovery", () => {
+    expect(identitySettings).toContain("Contacts is holding an unfinished in-memory edit.");
+    expect(identitySettings).toContain('? "Discard and close Contacts" : "Resolve pending edit…"');
+    expect(identitySettings).toContain("root.resolver.discardUnsavedContacts()");
+    expect(identities).toContain('start("discard-unsaved", {})');
+  });
+
+  test("contact cleanup scan is read-only triage, never a bulk merge", () => {
+    expect(identitySettings).toContain("FIND CONTACT CLEANUP OPPORTUNITIES");
+    expect(identitySettings).toContain("Run a read-only Mac Contacts scan");
+    // every Contacts mutation announces itself, and a finished scan refreshes
+    // quietly without clobbering the mutation's success notice
+    expect(identities).toContain("signal contactsMutated()");
+    expect(identities.split("contactsMutated()").length - 1).toBeGreaterThanOrEqual(5);
+    expect(identities).toContain('if (!quietAudit) notice = result.cached === true');
+    // a fingerprint cache hit reports freshness instead of a fake re-scan
+    expect(identities).toContain("Contacts hasn't changed since the last scan");
+    // the contacts page loads cleanup results on open (cheap when cached)
+    expect(identitySettings).toContain("function maybeAutoAudit()");
+    expect(identitySettings).toContain("root.resolver.auditContacts(root.reviewHandles(), true)");
+    // the scan runs on its OWN process, kicked immediately after a mutation,
+    // so it never contends with navigation or edits; the list page shows the
+    // in-flight state while previous results stay visible
+    expect(identities).toContain("id: auditWorker");
+    expect(identities).toContain("property bool auditRunning");
+    expect(identities).toContain("function consumeAudit(text)");
+    // in-flight scans animate a three-dot indicator (width-stable, monospace)
+    expect(identitySettings).toContain('"Scanning" + root.animatedDots');
+    // busy notices ("Consolidating the verified source cards…") animate too
+    expect(identitySettings).toContain('String(root.resolver.notice).replace(/…$/, "") + root.animatedDots');
+    expect(identitySettings).toContain("property int scanDotPhase");
+    // stale results gray out while a re-scan is in flight
+    expect(identitySettings).toContain("readonly property bool staleWhileScanning");
+    // dimming covers the cleanup-opportunities results AND the review list
+    expect(identitySettings.split("root.staleWhileScanning ? 0.45 : 1").length - 1).toBeGreaterThanOrEqual(7);
+    expect(identitySettings).toContain("likely duplicates");
+    expect(identitySettings).toContain("naming conflicts");
+    expect(identitySettings).toContain("Review duplicate…");
+    expect(identitySettings).toContain("Review conflict…");
+    expect(identitySettings).toContain("Focus on ");
+    expect(identitySettings).toContain("Every contact change still opens its own preview and confirmation.");
+    expect(identitySettings).not.toContain("Merge all");
+    expect(identities).toContain("function auditContacts(handles, quiet)");
+    expect(identities).toContain('auditWorker.command = ["bun", helperPath, "audit"]');
+    expect(identityHelper).toContain('operation === "audit"');
+  });
+
+  test("settings navigation keeps contact repair compact and separate from appearance", () => {
+    expect(settings).toContain('property string page: "contacts"');
+    expect(settings).toContain('visible: root.page === "contacts"');
+    expect(settings).toContain('visible: root.page === "appearance"');
+    expect(settings).toContain("width: Math.min(parent.width, root.space(1120))");
+    expect(identitySettings).toContain('label: "← All conversations"');
+    expect(identitySettings).toContain("visible: !root.reviewActive");
+    expect(identitySettings).toContain("visible: root.macReviewExpanded");
+    expect(identitySettings).toContain("function openContactManagement()");
+    expect(identitySettings).toContain("Manage Contacts…");
+    expect(identitySettings).toContain("sourceCandidate.cardsExpanded ? sourceCandidate.modelData.cards : []");
+    expect(identitySettings).toContain("root.candidateForToken(saved.contactToken)");
+    expect(settings).not.toContain("Saved as portable JSON files");
+    expect(settings).toContain("Layout.alignment: Qt.AlignTop");
+  });
+
+  test("silent settings refreshes preserve stable models and visible state", () => {
+    expect(identities).toContain("loading = quiet !== true");
+    expect(identities).toContain("if (serialized !== identitiesJson)");
+    expect(identities).toContain("pendingReviewHandle = requested");
+    expect(identities).toContain('if (!worker.running && root.activeHandle === "") root.load(true)');
+    expect(preferences).toContain("if (loaded && serialized === lastSerialized) return true");
+  });
+
+  test("Mac contact writes require preview, confirmation, and expose undo", () => {
+    expect(identitySettings).toContain('label: "Remove this " + root.handleNoun() + "…"');
+    // the undo offer shows only in the workspace of the contact it changed
+    expect(identitySettings).toContain("root.handleKey(root.resolver.undoHandle)");
+    // the conflict flow speaks in outcomes, not implementation terms: picking
+    // a person opens their cards; "session"/identities.json stay out of it
+    expect(identitySettings).toContain('"WORKING ON: "');
+    expect(identitySettings).toContain("Work on this person");
+    expect(identitySettings).toContain("Pick a person below. That only opens their cards for review");
+    expect(identitySettings).not.toContain("Select for this session");
+    expect(identitySettings).not.toContain("SELECTED FOR THIS SESSION");
+    expect(identitySettings).toContain('label: "Remove from Mac Contacts"');
+    expect(identitySettings).toContain("An undo receipt will be saved on the Mac");
+    expect(identitySettings).toContain('label: "Undo Mac change"');
+    expect(identities).toContain("function inspectOnMac(handle, token, ownerToken)");
+    expect(identities).toContain("function removeOnMac()");
+    expect(identities).toContain("function undoOnMac()");
+    expect(identities).toContain("repairPreview.writeEnabled");
+    expect(identities).toContain("validToken(repairPreview.ownerToken)");
+  });
+
+  test("contact comparison is local and linking has a separate upstream confirmation", () => {
+    expect(identitySettings).toContain("Manage " + '" + sourceCandidate.modelData.recordCount');
+    expect(identitySettings).toContain("ContactCardCompare");
+    expect(contactCompare).toContain('title: "Compare source cards"');
+    expect(contactCompare).toContain('title: "Consolidate into one card"');
+    expect(contactCompare).toContain('title: "Or link cards · optional"');
+    expect(contactCompare).not.toContain("step: \"");
+    expect(contactCompare).toContain("Reload cards from Mac");
+    expect(contactCompare).toContain("Back to contact tasks");
+    expect(contactCompare).toContain("DIFFERENCES ONLY");
+    expect(contactCompare).toContain("sharedRowMap");
+    expect(contactCompare).toContain("MERGED PREVIEW");
+    expect(contactCompare).toContain("function displayFieldLabel(fieldType, value)");
+    expect(contactCompare).toContain('detail.toLowerCase() === fieldType.toLowerCase()');
+    expect(contactCompare).toContain("displayFieldLabel(group.name, item.label)");
+    expect(contactCompare).toContain('displayFieldLabel("Address", address.label)');
+    expect(contactCompare).toContain("Prepare link in Contacts…");
+    expect(contactCompare).toContain("CONFIRM AN UPSTREAM CONTACTS CHANGE");
+    expect(contactCompare).toContain("Checking makes no changes");
+    expect(contactCompare).toContain("Edit in Blip…");
+    expect(contactCompare).toContain("cardBox.modelData.sourceName");
+    expect(identitySettings).toContain("sourceCard.modelData.sourceName");
+    expect(contactCompare).toContain("Text.PlainText");
+    expect(contactCompare).not.toContain("Array.isArray(card.phones)");
+    expect(identities).toContain("function compareCards(handle, ownerToken, otherOwnerToken)");
+    expect(identities).toContain("function prepareLink()");
+    expect(identities).toContain("function linkCards()");
+    expect(identities).toContain("linkPreview.ready");
+    expect(identities).toContain("expectedAction: linkPreview.action");
+  });
+
+  test("the contact workspace edits, deletes, and consolidates only after preview", () => {
+    expect(contactCompare).toContain("ContactCardEditor");
+    expect(contactCompare).toContain("Merge into \" + modelData.sourceName");
+    expect(panel).toContain('iconText: "⚙"');
+    expect(panel).toContain('tooltipText: "Settings"\n            bordered: false');
+    expect(panel).toContain('iconText: "＋"');
+    expect(panel).toContain('tooltipText: "New message (n)"\n            bordered: false');
+    expect(contactEditor).toContain("Review changes…");
+    expect(contactEditor).toContain("Delete this source card…");
+    expect(contactEditor).toContain("Review merged contact…");
+    expect(contactEditor).toContain("REVIEW CONSOLIDATION");
+    expect(contactEditor).toContain("This is a read-only preview. Nothing below has been saved to Contacts.");
+    expect(contactEditor).toContain("MERGED CONTACT TO KEEP");
+    expect(contactEditor).toContain("DELETE AFTER MERGE");
+    expect(contactEditor).toContain("FINAL CONFIRMATION");
+    expect(contactEditor).toContain("Back to edit");
+    expect(contactEditor).toContain("Save to Mac Contacts");
+    expect(contactEditor).toContain("Merge and delete source cards");
+    expect(contactEditor).toContain("function cleanLabel(value)");
+    expect(contactEditor).toContain("originalLabel: text(item.label)");
+    expect(contactEditor).toContain('value === cleanLabel(original) ? original : value');
+    expect(contactEditor.indexOf('label: valueList.emptyLabel')).toBeGreaterThan(
+      contactEditor.indexOf('model: parent.model'),
+    );
+    expect(contactEditor.indexOf('label: "Add address"')).toBeGreaterThan(
+      contactEditor.indexOf('model: root.previewOpen ? null : addresses'),
+    );
+    expect(contactEditor).toContain("Text.PlainText");
+    expect(identities).toContain("function prepareCardEdit(card, draft)");
+    expect(identities).toContain("function prepareCardDelete(card)");
+    expect(identities).toContain("function prepareConsolidation(targetCard, draft)");
+    expect(identities).toContain("function applyMutation()");
+    expect(identities).toContain("mutationPreview.planHash");
   });
 
   test("app window routes n, slash, digits, and Esc through catch helpers", () => {
@@ -115,13 +335,13 @@ describe("QML safety invariants", () => {
     expect(fn.indexOf('text === "/"')).toBeLessThan(fn.indexOf("inThread"));
     expect(fn.indexOf('text === "n"')).toBeLessThan(fn.indexOf("inThread"));
     expect(fn.indexOf('text >= "1"')).toBeLessThan(fn.indexOf("inThread"));
-    expect(fn).toContain("if (i < 0 || i >= threads.length) return false");
-    expect(fn).toContain("openThread(threads[i])");
+    expect(fn).toContain("if (i < 0 || i >= navigationThreads.length) return false");
+    expect(fn).toContain("openThread(navigationThreads[i])");
   });
 
   test("sidebar rows show the 1-9 jump digit", () => {
     expect(panel).toContain("function threadHotkey");
-    expect(panel.split("text: root.threadHotkey(modelData)").length - 1).toBe(2);
+    expect(panel.split("text: root.threadHotkey(modelData)").length - 1).toBe(1);
     const catcher = panel.slice(panel.indexOf("function catchNavText"), panel.indexOf("function catchEscape"));
     expect(catcher).toContain('text >= "1" && text <= "9"');
     expect(catcher).toContain("root.draftPath");
@@ -147,6 +367,5 @@ describe("QML safety invariants", () => {
     expect(panel).toContain("running: root.newMode");
     expect(panel).toContain("newSearchTimer.restart()");
     expect(panel).not.toContain("forceLayout");
-    expect(panel.indexOf("onAccepted: root.acceptNewField()")).toBeGreaterThan(-1);
-  });
+    expect(panel.indexOf("onAccepted: root.acceptNewField()")).toBeGreaterThan(-1);  });
 });


### PR DESCRIPTION
This lets Blip manage Mac contacts from Linux. My address book had accumulated years of duplicates across iCloud, Gmail, Exchange, and On My Mac, and fixing them meant walking over to the Mac — so now Blip can compare cards side by side across accounts, edit them, consolidate duplicates into a chosen surviving card, merge two differently-named cards when someone changes their name, and run a read-only scan that finds the cleanup candidates for you.

Getting writes to actually work was most of the effort. macOS 15.5 has three broken Contacts scripting verbs (add-to-person fails with "No error. (0)", removals with "Message not understood", and person deletion just doesn't), and one damaged stored row makes CNContactStore fail whole saves with a persistent Cocoa error 134092. The bridge works around all of it: unchanged labeled values are reused instead of rebuilt so contactsd never faults the bad rows, every mutating stage retries on a fresh store session, and when the native path still can't save, the same reviewed plan goes through Contacts.app's own write path. Cleanup scans are cached against a per-account store fingerprint, so re-opening the page answers in ~0.1s when nothing changed on the Mac instead of re-scanning 19k cards.

The safety rails follow the rules already in CLAUDE.md: handles travel over stdin and never argv, everything crossing ssh is bounded JSON, every mutation shows a hashed preview that's revalidated at apply time, destructive saves write an undo receipt first, session-only candidate selection stays separate from saved display rules in `identities.json`, and Blip never touches the AddressBook SQLite database. Cross-name merges require the user to explicitly present both cards — no guessing that two names are the same person.

Tests: 350 in `bun test`, 41 in `bridge/mac/contacts_test.py`, plus `imsg_test.py`. I've been running this against my real contacts for a while now — the workarounds above all came from cards in my own address book that refused to save.

Independent of #21 — either can land alone. They share the preferences groundwork and both touch BlipView/BlipSettings, so whichever lands second gets an immediate rebase from me.
