### PR TITLE
Appearance settings, correct-scale rendering, and popout polish

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -24,14 +24,22 @@ BarWidget {
   readonly property string collectorPath:
     decodeURIComponent(Qt.resolvedUrl("collector.ts").toString().replace(/^file:\/\//, ""))
 
+  // One validated preference source for both render surfaces. The popout and
+  // app update together, and external dotfile restores are picked up live.
+  BlipPreferences { id: preferences }
+
   // Clock and date patterns from this widget's shell.json entry — Qt format
   // strings, exactly as Omarchy's clock takes `format`. Qt formats the list
   // with them and thread.ts formats the bubbles with the same strings, so the
-  // two never disagree. Unset, the time follows the locale (an AM/PM marker
-  // means 12-hour) and dates read the way Messages writes them.
+  // two never disagree. An explicit shell.json format wins; otherwise the
+  // portable Blip preference decides 12- vs 24-hour, and an unloaded
+  // preference file falls back to the locale (an AM/PM marker = 12-hour).
   readonly property string localeTimeFormat:
     /ap/i.test(Qt.locale().timeFormat(Locale.ShortFormat)) ? "h:mm AP" : "HH:mm"
-  readonly property string timeFormat: formatSetting("timeFormat", localeTimeFormat)
+  readonly property string preferredTimeFormat: preferences.loaded
+    ? (preferences.use12HourConversationTimes ? "h:mm AP" : "HH:mm")
+    : localeTimeFormat
+  readonly property string timeFormat: formatSetting("timeFormat", preferredTimeFormat)
   readonly property string dateFormat: formatSetting("dateFormat", "MMM d")
   readonly property string dateFormatWithYear: formatSetting("dateFormatWithYear", "MMM d, yyyy")
   function formatSetting(name, fallback) { var v = String(setting(name, "")); return v === "" ? fallback : v }
@@ -112,6 +120,7 @@ BarWidget {
     target.bar = root.bar
     target.anchorItem = button
     target.hostWidget = root
+    target.preferences = preferences
   }
   onBarChanged: injectPanel()
 
@@ -137,7 +146,10 @@ BarWidget {
     id: windowLoader
     active: root.leader                // created at start so it can self-restore
     source: Qt.resolvedUrl("BlipWindow.qml")
-    onLoaded: item.hostWidget = root
+    onLoaded: {
+      item.hostWidget = root
+      item.preferences = preferences
+    }
   }
   readonly property bool windowVisible: windowLoader.item ? windowLoader.item.visible === true : false
   function hideWindow() {
@@ -174,6 +186,14 @@ BarWidget {
     Quickshell.execDetached(["sh", "-c",
       'for i in 1 2 3 4 5 6 7 8; do a=$(hyprctl clients -j | jq -r \'.[] | select(.title | startswith("Blip")) | .address\' | head -1); [ -n "$a" ] && break; sleep 0.15; done; ' +
       '[ -n "$a" ] && hyprctl dispatch "hl.dsp.focus({ window = \\"address:$a\\" })" >/dev/null'])
+  }
+  function showSettings(page) {
+    showApp()
+    Qt.callLater(function() {
+      if (!windowLoader.item) return
+      windowLoader.item.visible = true
+      windowLoader.item.openSettings(page)
+    })
   }
   /** Either surface open → keep the deep (complete) thread list. */
   function anySurfaceOpen() {
@@ -242,9 +262,21 @@ BarWidget {
   }
   property bool collectorReserved: false // a queued run owns the next event-loop turn
 
-  function refresh(deep, markRead, readChat, seen) {
+  function normalizedReadAliases(readChat, values) {
+    var chat = String(readChat || "")
+    var source = Array.isArray(values) ? values : []
+    var out = []
+    for (var i = 0; i < source.length && out.length < 15; i++) {
+      var alias = String(source[i] || "")
+      if (alias !== "" && alias !== chat && out.indexOf(alias) < 0) out.push(alias)
+    }
+    return out
+  }
+
+  function refresh(deep, markRead, readChat, seen, readAliases) {
     var req = { deep: deep === true, markRead: markRead === true,
-                readChat: String(readChat || ""), seen: String(seen || "") }
+                readChat: String(readChat || ""), seen: String(seen || ""),
+                readAliases: normalizedReadAliases(readChat, readAliases) }
     if (collector.running || collectorReserved) { enqueueRefresh(req); return }
     runRefresh(req)
   }
@@ -256,9 +288,11 @@ BarWidget {
     // entry per ping). mark-all stays FIFO and is never overwritten.
     if (!req.markRead) {
       for (var i = 0; i < q.length; i++) {
-        if (!q[i].markRead && q[i].readChat === req.readChat) {
+        if (!q[i].markRead && q[i].readChat === req.readChat
+            && JSON.stringify(q[i].readAliases || []) === JSON.stringify(req.readAliases)) {
           q[i] = { deep: q[i].deep || req.deep, markRead: false, readChat: req.readChat,
-                   seen: req.seen > q[i].seen ? req.seen : q[i].seen }
+                   seen: req.seen > q[i].seen ? req.seen : q[i].seen,
+                   readAliases: req.readAliases }
           refreshQueue = q
           return
         }
@@ -273,6 +307,8 @@ BarWidget {
     if (req.markRead) args.push("--mark-read")
     if (req.readChat !== "") {
       args.push("--read", req.readChat)
+      for (var i = 0; i < req.readAliases.length; i++)
+        args.push("--read-alias", req.readAliases[i])
       if (req.seen !== "") args.push("--seen", req.seen)
     }
     collector.command = args
@@ -317,7 +353,7 @@ BarWidget {
     return out
   }
 
-  function markThreadRead(chat) {
+  function markThreadRead(chat, aliases) {
     var c = String(chat)
     var lastTs = ""
     var list = threads.map(function(t) {
@@ -328,7 +364,7 @@ BarWidget {
     noteLocalRead(c, lastTs)
     threads = list
     unread = list.reduce(function(n, t) { return n + (Number(t.unread) || 0) }, 0)
-    refresh(true, false, c, lastTs)
+    refresh(true, false, c, lastTs, aliases)
   }
 
   function markAllRead() {
@@ -366,6 +402,10 @@ BarWidget {
   function activeSeenTs() {
     var s = readingSurface()
     return s ? String(s.activeLastTs || "") : ""
+  }
+  function activeReadAliases() {
+    var s = readingSurface()
+    return s && s.active ? s.active.aliases || [] : []
   }
 
   Process {
@@ -465,7 +505,7 @@ BarWidget {
     // (startup, or after a garbled one) go deep regardless, so the first
     // open finds the complete, pinned list already in memory.
     onTriggered: root.refresh(root.anySurfaceOpen() || root.deepThreads.length === 0, false,
-                              root.activeReadChat(), root.activeSeenTs())
+                              root.activeReadChat(), root.activeSeenTs(), root.activeReadAliases())
   }
 
   // ------------------------------------------------- real-time push
@@ -517,7 +557,8 @@ BarWidget {
       // Carrying the open thread's chat means a message landing in the
       // conversation the user is READING is counted read in this same run —
       // no badge flash, no second round-trip.
-      root.refresh(root.anySurfaceOpen(), false, root.activeReadChat(), root.activeSeenTs())
+      root.refresh(root.anySurfaceOpen(), false, root.activeReadChat(), root.activeSeenTs(),
+                   root.activeReadAliases())
       // Reload the OPEN conversation in parallel — waiting for the collector
       // and then reloading serially added a visible second of latency.
       // Both surfaces: each gates itself on its own surfaceOpen.
@@ -628,7 +669,8 @@ BarWidget {
   // ------------------------------------------------------------ IPC
   // IPC that sends or reads message content is a deputy for any local
   // process (Codex audit #3). It is opt-in: automation=on in bridge.conf.
-  // status/open/close/toggle/window/app stay available — they expose nothing.
+  // status/open/close/toggle/window/app/settings/panelsettings stay
+  // available — they expose nothing.
   property bool automationOn: false
   /** `ui_font=theme` in bridge.conf: never use SF Pro even when it is present. */
   property bool uiFontTheme: false
@@ -671,6 +713,12 @@ BarWidget {
     function newchat(query: string): string { if (!root.automationOn) return root.automationOff; return panelLoader.item ? panelLoader.item.newChatFor(query) : "no panel" }
     function window(): string { root.toggleWindow(); return root.windowVisible ? "window shown" : "window hidden" }
     function app(): string { root.showApp(); return "app shown + focused" }
+    function settings(): string { root.showSettings(); return "settings shown" }
+    function appearance(): string { root.showSettings("appearance"); return "appearance settings shown" }
+    // Same pages inside the POPOUT (the window keeps `settings`/`appearance`).
+    function panelsettings(page: string): string {
+      return panelLoader.item ? panelLoader.item.openSettings(page) : "no panel"
+    }
     function windowgoto(chat: string): string {
       if (!root.automationOn) return root.automationOff
       root.ensureWindow()

--- a/BlipPreferences.qml
+++ b/BlipPreferences.qml
@@ -1,0 +1,289 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Live, file-backed appearance preferences shared by the popout and app.
+// preferences.ts is the trust boundary: it caps and validates the writable
+// JSON before this long-lived shell process sees a small normalized object.
+Item {
+  id: root
+  visible: false
+  implicitWidth: 0
+  implicitHeight: 0
+
+  readonly property string home: Quickshell.env("HOME")
+  readonly property string configPath: home + "/.config/blip/preferences.json"
+  readonly property string helperPath:
+    decodeURIComponent(Qt.resolvedUrl("preferences.ts").toString().replace(/^file:\/\//, ""))
+
+  property string outgoingBubbleColor: "theme"
+  property string incomingBubbleColor: "theme"
+  property real backgroundOpacity: 0.70
+  property real fontScale: 1.0
+  property real density: 1.0
+  property int sidebarWidth: 320
+  property int avatarSize: 30
+  property real cornerScale: 1.0
+  property bool hideShortCodeConversations: true
+  property bool use12HourConversationTimes: true
+
+  property bool loaded: false
+  property bool exists: false
+  property bool saving: false
+  property bool dirty: false
+  property string error: ""
+  property string notice: "Loading preferences…"
+  property string lastSerialized: ""
+
+  function defaults() {
+    return {
+      schemaVersion: 1,
+      outgoingBubbleColor: "theme",
+      incomingBubbleColor: "theme",
+      backgroundOpacity: 0.70,
+      fontScale: 1.0,
+      density: 1.0,
+      sidebarWidth: 320,
+      avatarSize: 30,
+      cornerScale: 1.0,
+      hideShortCodeConversations: true,
+      use12HourConversationTimes: true
+    }
+  }
+
+  function snapshot() {
+    return {
+      schemaVersion: 1,
+      outgoingBubbleColor: outgoingBubbleColor,
+      incomingBubbleColor: incomingBubbleColor,
+      backgroundOpacity: Math.round(backgroundOpacity * 100) / 100,
+      fontScale: Math.round(fontScale * 100) / 100,
+      density: Math.round(density * 100) / 100,
+      sidebarWidth: Math.round(sidebarWidth),
+      avatarSize: Math.round(avatarSize),
+      cornerScale: Math.round(cornerScale * 100) / 100,
+      hideShortCodeConversations: hideShortCodeConversations,
+      use12HourConversationTimes: use12HourConversationTimes
+    }
+  }
+
+  function finiteIn(value, low, high) {
+    return typeof value === "number" && isFinite(value) && value >= low && value <= high
+  }
+
+  function validColor(value) {
+    return typeof value === "string" &&
+      (value === "theme" || /^#[0-9a-f]{6}([0-9a-f]{2})?$/.test(value))
+  }
+
+  // Defense in depth: verify the helper's normalized object again before any
+  // value is retained by the shell or used in geometry.
+  function applyPreferences(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value) || value.schemaVersion !== 1)
+      return false
+    if (!validColor(value.outgoingBubbleColor) || !validColor(value.incomingBubbleColor)) return false
+    if (!finiteIn(value.backgroundOpacity, 0.2, 1.0)) return false
+    if (!finiteIn(value.fontScale, 0.75, 1.5)) return false
+    if (!finiteIn(value.density, 0.7, 1.4)) return false
+    if (!finiteIn(value.sidebarWidth, 240, 520)) return false
+    if (!finiteIn(value.avatarSize, 24, 64)) return false
+    if (!finiteIn(value.cornerScale, 0, 2)) return false
+    if (typeof value.hideShortCodeConversations !== "boolean") return false
+    if (typeof value.use12HourConversationTimes !== "boolean") return false
+
+    var normalized = {
+      schemaVersion: 1,
+      outgoingBubbleColor: value.outgoingBubbleColor,
+      incomingBubbleColor: value.incomingBubbleColor,
+      backgroundOpacity: Math.round(value.backgroundOpacity * 100) / 100,
+      fontScale: Math.round(value.fontScale * 100) / 100,
+      density: Math.round(value.density * 100) / 100,
+      sidebarWidth: Math.round(value.sidebarWidth),
+      avatarSize: Math.round(value.avatarSize),
+      cornerScale: Math.round(value.cornerScale * 100) / 100,
+      hideShortCodeConversations: value.hideShortCodeConversations,
+      use12HourConversationTimes: value.use12HourConversationTimes
+    }
+    var serialized = JSON.stringify(normalized)
+    // Keep bindings and slider delegates untouched when the periodic bounded
+    // read returns the same file contents.
+    if (loaded && serialized === lastSerialized) return true
+    outgoingBubbleColor = normalized.outgoingBubbleColor
+    incomingBubbleColor = normalized.incomingBubbleColor
+    backgroundOpacity = normalized.backgroundOpacity
+    fontScale = normalized.fontScale
+    density = normalized.density
+    sidebarWidth = normalized.sidebarWidth
+    avatarSize = normalized.avatarSize
+    cornerScale = normalized.cornerScale
+    hideShortCodeConversations = normalized.hideShortCodeConversations
+    use12HourConversationTimes = normalized.use12HourConversationTimes
+    lastSerialized = serialized
+    return true
+  }
+
+  function safeError(value) {
+    return String(value || "Preference operation failed")
+      .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+      .replace(/\s+/g, " ").trim().slice(0, 180)
+  }
+
+  function consumeRead(raw) {
+    if (raw.length > 4096) {
+      error = "Preference helper returned too much data"
+      return
+    }
+    try {
+      var result = JSON.parse(raw.trim())
+      if (!result || result.ok !== true) {
+        error = safeError(result ? result.error : "Preference helper failed")
+        loaded = true
+        return
+      }
+      if (!applyPreferences(result.preferences)) {
+        error = "Preference helper returned an invalid schema"
+        loaded = true
+        return
+      }
+      exists = result.exists === true
+      error = ""
+      loaded = true
+      notice = exists ? "Loaded preferences.json" : "Using defaults; creating preferences.json…"
+      if (!exists) scheduleSave()
+    } catch (e) {
+      error = "Preference helper returned invalid JSON"
+      loaded = true
+    }
+  }
+
+  function load(force) {
+    if (reader.running || writer.running) return
+    if (!force && dirty) return
+    if (force) {
+      dirty = false
+      saveTimer.stop()
+    }
+    reader.command = ["bun", helperPath, "read"]
+    reader.running = true
+  }
+
+  function scheduleSave() {
+    dirty = true
+    notice = "Unsaved changes…"
+    saveTimer.restart()
+  }
+
+  function writeNow() {
+    if (writer.running) {
+      saveTimer.restart()
+      return
+    }
+    writer.payload = JSON.stringify(snapshot())
+    writer.resultOk = false
+    writer.stdinEnabled = true
+    dirty = false
+    saving = true
+    notice = "Saving…"
+    writer.command = ["bun", helperPath, "write"]
+    writer.running = true
+  }
+
+  function setColor(key, value) {
+    var color = String(value || "").trim().toLowerCase()
+    if (!validColor(color)) return false
+    if (key === "outgoingBubbleColor") outgoingBubbleColor = color
+    else if (key === "incomingBubbleColor") incomingBubbleColor = color
+    else return false
+    scheduleSave()
+    return true
+  }
+
+  function setNumber(key, value) {
+    var number = Number(value)
+    if (key === "backgroundOpacity" && finiteIn(number, 0.2, 1.0)) backgroundOpacity = number
+    else if (key === "fontScale" && finiteIn(number, 0.75, 1.5)) fontScale = number
+    else if (key === "density" && finiteIn(number, 0.7, 1.4)) density = number
+    else if (key === "sidebarWidth" && finiteIn(number, 240, 520)) sidebarWidth = Math.round(number)
+    else if (key === "avatarSize" && finiteIn(number, 24, 64)) avatarSize = Math.round(number)
+    else if (key === "cornerScale" && finiteIn(number, 0, 2)) cornerScale = number
+    else return false
+    scheduleSave()
+    return true
+  }
+
+  function setBoolean(key, value) {
+    if (typeof value !== "boolean") return false
+    if (key === "hideShortCodeConversations") hideShortCodeConversations = value
+    else if (key === "use12HourConversationTimes") use12HourConversationTimes = value
+    else return false
+    scheduleSave()
+    return true
+  }
+
+  function restoreDefaults() {
+    applyPreferences(defaults())
+    scheduleSave()
+  }
+
+  Timer {
+    id: saveTimer
+    interval: 350
+    onTriggered: root.writeNow()
+  }
+
+  // A restored dotfile is picked up without restarting the shell. Polling the
+  // bounded helper avoids feeding the writable file itself into FileView.
+  Timer {
+    interval: 5000
+    repeat: true
+    running: true
+    onTriggered: root.load(false)
+  }
+
+  Process {
+    id: reader
+    stdout: StdioCollector { onStreamFinished: root.consumeRead(text) }
+  }
+
+  Process {
+    id: writer
+    property string payload: ""
+    property bool resultOk: false
+    stdout: StdioCollector {
+      onStreamFinished: {
+        if (text.length > 4096) {
+          root.error = "Preference writer returned too much data"
+          return
+        }
+        try {
+          var result = JSON.parse(text.trim())
+          writer.resultOk = result && result.ok === true
+          if (!writer.resultOk) root.error = root.safeError(result ? result.error : "Preference write failed")
+          else if (!root.dirty && !root.applyPreferences(result.preferences)) {
+            writer.resultOk = false
+            root.error = "Preference writer returned an invalid schema"
+          }
+        } catch (e) {
+          root.error = "Preference writer returned invalid JSON"
+        }
+      }
+    }
+    onStarted: {
+      write(payload)
+      stdinEnabled = false
+    }
+    onExited: function(code, status) {
+      root.saving = false
+      if (code === 0 && resultOk) {
+        root.exists = true
+        root.error = ""
+        root.notice = "Saved to preferences.json"
+      } else if (root.error === "") {
+        root.error = "Could not save preferences.json"
+      }
+      if (root.dirty) saveTimer.restart()
+    }
+  }
+
+  Component.onCompleted: load(false)
+}

--- a/BlipSettings.qml
+++ b/BlipSettings.qml
@@ -1,0 +1,1011 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import QtQuick.Layouts
+import QtQuick.Shapes
+import qs.Commons
+import qs.Ui
+
+// In-app appearance editor. Changes apply immediately through the shared
+// BlipPreferences object and are debounced to ~/.config/blip/preferences.json.
+FocusScope {
+  id: root
+
+  property var preferences: null
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property color outgoingFill: accent
+  property color outgoingText: "#ffffff"
+  property color incomingFill: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
+  property color incomingText: foreground
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  property var hostWidget: null
+  property string localError: ""
+  property bool resetArmed: false
+  property string page: "appearance"
+  // The popout matches this width while settings are showing: the appearance
+  // workspace needs it for preview-beside-controls (two-column at space(700),
+  // with headroom that absorbs the panel's fixed padding at every density).
+  readonly property real wideWidth: space(980)
+  readonly property bool editorActive: outgoingSetting.editorActive || incomingSetting.editorActive
+
+  // The page's own chrome must not re-lay-out while the user drags an
+  // appearance slider — only the live preview tracks the moving values.
+  // Chrome scales are frozen each time settings opens.
+  property real chromeFontScale: 1.0
+  property real chromeDensity: 1.0
+  property real chromeCornerScale: 1.0
+  function freezeChrome() {
+    chromeFontScale = fontScale
+    chromeDensity = density
+    chromeCornerScale = cornerScale
+  }
+  onVisibleChanged: if (visible) freezeChrome()
+  Component.onCompleted: freezeChrome()
+
+  signal closeRequested()
+
+  function fontSize(value) { return Math.max(1, Math.round(value * chromeFontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * chromeDensity)) }
+  function corner(value) { return Math.max(0, Math.round(value * chromeCornerScale)) }
+  function liveFontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function liveSpace(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function liveCorner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function focusDefault() { forceActiveFocus() }
+  function showPage(value) {
+    page = "appearance"
+    settingsFlick.contentY = 0
+  }
+
+  Keys.onEscapePressed: root.closeRequested()
+
+  ColumnLayout {
+    anchors.fill: parent
+    spacing: root.space(10)
+
+    RowLayout {
+      Layout.fillWidth: true
+      PanelHero {
+        Layout.fillWidth: true
+        title: "Blip settings"
+        meta: "Appearance"
+        detail: ""
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+      }
+      PanelActionButton {
+        Layout.alignment: Qt.AlignTop
+        focusable: true
+        iconText: "×"
+        tooltipText: "Close settings (Esc)"
+        bordered: true
+        foreground: root.foreground
+        hoverColor: root.accent
+        fontFamily: root.fontFamily
+        fontSize: root.fontSize(Style.font.icon)
+        onClicked: root.closeRequested()
+      }
+    }
+
+    PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
+
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: root.space(8)
+      ActionButton {
+        label: "Appearance"
+        selected: root.page === "appearance"
+        onClicked: root.showPage("appearance")
+      }
+      Text {
+        // fillWidth + elide: the popout is narrow, and an unbounded implicit
+        // width here silently stretches the whole settings column past it.
+        Layout.fillWidth: true
+        horizontalAlignment: Text.AlignRight
+        elide: Text.ElideRight
+        text: "Changes preview and apply live"
+        textFormat: Text.PlainText
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+
+    PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
+
+    Flickable {
+      id: settingsFlick
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+      contentWidth: width
+      contentHeight: settingsContent.implicitHeight
+      clip: true
+      boundsBehavior: Flickable.StopAtBounds
+      interactive: contentHeight > height
+      QQC.ScrollBar.vertical: QQC.ScrollBar { policy: QQC.ScrollBar.AsNeeded }
+
+      MouseArea {
+        anchors.fill: parent
+        z: -1
+        acceptedButtons: Qt.NoButton
+        onWheel: function(wheel) {
+          var delta = wheel.pixelDelta.y !== 0 ? wheel.pixelDelta.y * 3.0 : wheel.angleDelta.y * 4.5
+          var maximum = Math.max(0, settingsFlick.contentHeight - settingsFlick.height)
+          settingsFlick.contentY = Math.max(0, Math.min(maximum, settingsFlick.contentY - delta))
+          wheel.accepted = true
+        }
+      }
+
+      ColumnLayout {
+        id: settingsContent
+        // Appearance uses the full window so the preview can be as large as
+        // possible.
+        width: parent.width
+        anchors.horizontalCenter: parent.horizontalCenter
+        spacing: root.space(16)
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          visible: root.page === "appearance"
+          spacing: root.space(16)
+
+        Text {
+          Layout.fillWidth: true
+          text: "Changes apply live. The files under ~/.config/blip can be tracked in dotfiles or restored later."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.bodySmall)
+        }
+
+        GridLayout {
+          id: appearanceWorkspace
+          Layout.fillWidth: true
+          // Preview-beside-controls whenever both columns can breathe. The
+          // preview is a uniform-scale miniature, so it stays useful narrow;
+          // keep this threshold well below the wide-popout width and the app
+          // window's plausible sizes — space() shrinks with density while the
+          // panel's padding does not, and a threshold close to the supplied
+          // width flipped the popout back to stacked at low density.
+          columns: width >= root.space(700) ? 2 : 1
+          columnSpacing: root.space(24)
+          rowSpacing: root.space(22)
+
+          AppearancePreview {
+            Layout.fillWidth: true
+            Layout.minimumWidth: appearanceWorkspace.columns === 2 ? root.space(360) : 0
+            Layout.alignment: Qt.AlignTop
+          }
+
+          ColumnLayout {
+            // The controls pin to the right at a fixed measure; the preview
+            // takes everything else.
+            Layout.fillWidth: appearanceWorkspace.columns === 1
+            Layout.minimumWidth: appearanceWorkspace.columns === 2 ? root.space(300) : 0
+            Layout.preferredWidth: root.space(400)
+            Layout.maximumWidth: appearanceWorkspace.columns === 2
+              ? root.space(400) : Number.POSITIVE_INFINITY
+            Layout.alignment: Qt.AlignTop
+            spacing: root.space(14)
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "COLORS"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              fontSize: root.fontSize(Style.font.caption)
+            }
+
+            ColorSetting {
+              id: outgoingSetting
+              Layout.fillWidth: true
+              title: "Outgoing bubbles"
+              preferenceKey: "outgoingBubbleColor"
+              currentValue: root.preferences ? root.preferences.outgoingBubbleColor : "theme"
+              resolvedColor: root.outgoingFill
+            }
+
+            ColorSetting {
+              id: incomingSetting
+              Layout.fillWidth: true
+              title: "Incoming bubbles"
+              preferenceKey: "incomingBubbleColor"
+              currentValue: root.preferences ? root.preferences.incomingBubbleColor : "theme"
+              resolvedColor: root.incomingFill
+            }
+
+            PanelSectionHeader {
+              Layout.fillWidth: true
+              text: "LAYOUT"
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+              fontSize: root.fontSize(Style.font.caption)
+            }
+
+            ColumnLayout {
+              Layout.fillWidth: true
+              spacing: root.space(5)
+              Text {
+                text: "Conversation list time"
+                textFormat: Text.PlainText
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.bodySmall)
+                font.bold: true
+              }
+              RowLayout {
+                spacing: root.space(7)
+                ActionButton {
+                  label: "12-hour (AM/PM)"
+                  selected: !root.preferences || root.preferences.use12HourConversationTimes
+                  onClicked: if (root.preferences)
+                    root.preferences.setBoolean("use12HourConversationTimes", true)
+                }
+                ActionButton {
+                  label: "24-hour"
+                  selected: root.preferences && !root.preferences.use12HourConversationTimes
+                  onClicked: if (root.preferences)
+                    root.preferences.setBoolean("use12HourConversationTimes", false)
+                }
+              }
+            }
+
+            PreferenceSlider {
+              Layout.fillWidth: true
+              title: "Window opacity"
+              preferenceKey: "backgroundOpacity"
+              currentValue: root.preferences ? root.preferences.backgroundOpacity : 0.70
+              from: 0.20; to: 1.0; stepSize: 0.05; decimals: 0; multiplier: 100; suffix: "%"
+            }
+            PreferenceSlider {
+              Layout.fillWidth: true
+              title: "Font scale"
+              preferenceKey: "fontScale"
+              currentValue: root.preferences ? root.preferences.fontScale : 1.0
+              from: 0.75; to: 1.50; stepSize: 0.05; decimals: 0; multiplier: 100; suffix: "%"
+            }
+            PreferenceSlider {
+              Layout.fillWidth: true
+              title: "Density"
+              preferenceKey: "density"
+              currentValue: root.preferences ? root.preferences.density : 1.0
+              from: 0.70; to: 1.40; stepSize: 0.05; decimals: 0; multiplier: 100; suffix: "%"
+            }
+            PreferenceSlider {
+              Layout.fillWidth: true
+              title: "Sidebar width"
+              preferenceKey: "sidebarWidth"
+              currentValue: root.preferences ? root.preferences.sidebarWidth : 320
+              from: 240; to: 520; stepSize: 10; decimals: 0; multiplier: 1; suffix: " px"
+            }
+            PreferenceSlider {
+              Layout.fillWidth: true
+              title: "Avatar size"
+              preferenceKey: "avatarSize"
+              currentValue: root.preferences ? root.preferences.avatarSize : 30
+              from: 24; to: 64; stepSize: 2; decimals: 0; multiplier: 1; suffix: " px"
+            }
+            PreferenceSlider {
+              Layout.fillWidth: true
+              title: "Corner roundness"
+              preferenceKey: "cornerScale"
+              currentValue: root.preferences ? root.preferences.cornerScale : 1.0
+              from: 0; to: 2.0; stepSize: 0.10; decimals: 1; multiplier: 1; suffix: "×"
+            }
+
+            Text {
+              Layout.fillWidth: true
+              visible: root.localError !== "" || (root.preferences && root.preferences.error !== "")
+              text: root.localError !== "" ? root.localError : String(root.preferences ? root.preferences.error : "")
+              textFormat: Text.PlainText
+              wrapMode: Text.WordWrap
+              color: root.urgent
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+            }
+
+            Text {
+              Layout.fillWidth: true
+              text: root.preferences
+                ? (root.preferences.saving ? "Saving…" : root.preferences.notice) + "\n" + root.preferences.configPath
+                : "Preferences unavailable"
+              textFormat: Text.PlainText
+              wrapMode: Text.WrapAnywhere
+              color: Qt.darker(root.foreground, 1.45)
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+            }
+
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: root.space(8)
+              ActionButton {
+                label: "Reload file"
+                onClicked: {
+                  root.resetArmed = false
+                  root.localError = ""
+                  if (root.preferences) root.preferences.load(true)
+                }
+              }
+              Item { Layout.fillWidth: true }
+              ActionButton {
+                label: root.resetArmed ? "Confirm reset" : "Reset to defaults"
+                danger: root.resetArmed
+                onClicked: {
+                  if (!root.resetArmed) {
+                    root.resetArmed = true
+                    return
+                  }
+                  root.resetArmed = false
+                  root.localError = ""
+                  if (root.preferences) root.preferences.restoreDefaults()
+                }
+              }
+            }
+          }
+        }
+
+        Item { Layout.preferredHeight: root.space(6) }
+        }
+      }
+    }
+  }
+
+  // A uniformly scaled miniature of the real app window. Everything inside
+  // previewWindow is laid out at REAL app dimensions — the raw-px sidebar,
+  // spaceReal avatars, BlipWindow's edge inset — and shrunk by one scale
+  // transform, so the preview is to scale instead of per-part approximations.
+  component AppearancePreview: Rectangle {
+    id: appearancePreview
+
+    readonly property real opacityValue: root.preferences ? root.preferences.backgroundOpacity : 0.70
+    readonly property int configuredSidebar: root.preferences ? root.preferences.sidebarWidth : 320
+    readonly property int configuredAvatar: root.preferences ? root.preferences.avatarSize : 30
+    // Mirrors BlipView: chronological rows use spaceReal(avatarSize); pinned
+    // tiles use 1.75× with a space(48) floor.
+    readonly property int rowAvatarSize: Math.max(1, Math.round(Style.spaceReal(configuredAvatar)))
+    readonly property int pinAvatarSize: Math.max(
+      Math.round(Style.spaceReal(configuredAvatar) * 1.75), root.liveSpace(48))
+    // The miniature previews the app window's DEFAULT geometry (1040×720,
+    // BlipWindow's implicit size) rather than the live window's. Mirroring
+    // the live window made 100% structurally impossible — the card sits
+    // inside that same window minus the controls column — while a fixed
+    // reference reaches an honest, pixel-true 100% whenever the workspace
+    // offers that much room, even in a modest window.
+    readonly property real appWidth: 1040
+    readonly property real appHeight: 720
+    // Fit by width AND height so the whole miniature stays visible without
+    // scrolling; never upscale past 100%.
+    readonly property real previewScale: Math.max(0.05, Math.min(1,
+      (width - root.space(24)) / appWidth,
+      Math.max(root.space(220), root.height - root.space(250)) / appHeight))
+
+    implicitHeight: previewColumn.implicitHeight + root.space(24)
+    radius: root.corner(root.space(12))
+    color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.06)
+    border.width: 1
+    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.24)
+    clip: true
+
+    ColumnLayout {
+      id: previewColumn
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(9)
+
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.space(8)
+        Text {
+          text: "LIVE APP PREVIEW"
+          textFormat: Text.PlainText
+          color: root.accent
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+          font.bold: true
+        }
+        Text {
+          // fillWidth + elide keeps the metrics from colliding with the
+          // title when the preview column is narrow.
+          Layout.fillWidth: true
+          horizontalAlignment: Text.AlignRight
+          elide: Text.ElideRight
+          text: appearancePreview.configuredSidebar + " px sidebar · "
+            + appearancePreview.configuredAvatar + " px avatars · "
+            + Math.round(appearancePreview.previewScale * 100) + "% scale"
+          textFormat: Text.PlainText
+          color: Qt.darker(root.foreground, 1.4)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+      }
+
+      Item {
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.round(appearancePreview.appHeight * appearancePreview.previewScale)
+
+        Rectangle {
+          id: previewWindow
+          // centered when the height cap leaves spare width
+          x: Math.round((parent.width
+               - appearancePreview.appWidth * appearancePreview.previewScale) / 2)
+          width: appearancePreview.appWidth
+          height: appearancePreview.appHeight
+          transformOrigin: Item.TopLeft
+          scale: appearancePreview.previewScale
+          radius: root.liveCorner(root.liveSpace(12))
+          color: Qt.rgba(Color.background.r, Color.background.g, Color.background.b,
+                         appearancePreview.opacityValue)
+          border.width: 1
+          border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.28)
+          clip: true
+
+          RowLayout {
+            // BlipWindow's edge inset, then the sidebar's own gutters — the
+            // same geometry the real split view builds.
+            anchors.fill: parent
+            anchors.margins: root.liveSpace(12)
+            spacing: 0
+
+            Item {
+              Layout.preferredWidth: appearancePreview.configuredSidebar
+              Layout.fillHeight: true
+
+              ColumnLayout {
+                anchors.fill: parent
+                anchors.leftMargin: root.liveSpace(6)
+                anchors.rightMargin: root.liveSpace(18)
+                anchors.topMargin: root.liveSpace(10)
+                anchors.bottomMargin: root.liveSpace(10)
+                spacing: root.liveSpace(8)
+
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: root.liveSpace(8)
+                  Text {
+                    text: "Blip"
+                    textFormat: Text.PlainText
+                    color: root.foreground
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.title
+                    font.bold: true
+                  }
+                  Text {
+                    Layout.fillWidth: true
+                    text: "ALL CAUGHT UP"
+                    textFormat: Text.PlainText
+                    color: Qt.darker(root.foreground, 1.4)
+                    font.family: root.fontFamily
+                    font.pixelSize: root.liveFontSize(Style.font.caption)
+                    font.bold: true
+                    font.letterSpacing: 1.2
+                    elide: Text.ElideRight
+                  }
+                  Text {
+                    text: "⚙"
+                    textFormat: Text.PlainText
+                    color: root.accent
+                    font.family: root.fontFamily
+                    font.pixelSize: root.liveFontSize(Style.font.icon)
+                  }
+                }
+
+                Rectangle {
+                  Layout.fillWidth: true
+                  implicitHeight: 1
+                  color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.20)
+                }
+
+                Rectangle {
+                  Layout.fillWidth: true
+                  Layout.topMargin: root.liveSpace(6)
+                  implicitHeight: root.liveSpace(34)
+                  radius: root.liveCorner(root.liveSpace(6))
+                  color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+                  border.width: 1
+                  border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.24)
+                  Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left
+                    anchors.leftMargin: root.liveSpace(9)
+                    text: "🔍 search all messages"
+                    textFormat: Text.PlainText
+                    color: Qt.darker(root.foreground, 1.4)
+                    font.family: root.fontFamily
+                    font.pixelSize: root.liveFontSize(Style.font.bodySmall)
+                  }
+                }
+
+                GridLayout {
+                  id: previewPinGrid
+                  Layout.fillWidth: true
+                  Layout.topMargin: root.liveSpace(6)
+                  columns: appearancePreview.configuredSidebar < 400 ? 3 : 4
+                  columnSpacing: root.liveSpace(6)
+                  rowSpacing: root.liveSpace(8)
+
+                  Repeater {
+                    model: [
+                      { initials: "AR", label: "Alex", chosen: true },
+                      { initials: "D", label: "Design", chosen: false },
+                      { initials: "M", label: "Morgan", chosen: false },
+                      { initials: "S", label: "Sam", chosen: false }
+                    ].slice(0, previewPinGrid.columns)
+                    delegate: PreviewAvatar {
+                      required property var modelData
+                      Layout.fillWidth: true
+                      diameter: appearancePreview.pinAvatarSize
+                      initials: modelData.initials
+                      label: modelData.label
+                      selected: modelData.chosen
+                    }
+                  }
+                }
+
+                PreviewThreadRow {
+                  Layout.fillWidth: true
+                  diameter: appearancePreview.rowAvatarSize
+                  initials: "JD"
+                  name: "Jordan Diaz"
+                  detail: "See you at seven"
+                  time: root.preferences && !root.preferences.use12HourConversationTimes ? "19:04" : "7:04 PM"
+                }
+                PreviewThreadRow {
+                  Layout.fillWidth: true
+                  diameter: appearancePreview.rowAvatarSize
+                  initials: "T"
+                  name: "Trail crew"
+                  detail: "You: Sounds good"
+                  time: "Yesterday"
+                }
+                Item { Layout.fillHeight: true }
+              }
+            }
+
+            Rectangle {
+              Layout.preferredWidth: 1
+              Layout.fillHeight: true
+              color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.20)
+            }
+
+            Item {
+              Layout.fillWidth: true
+              Layout.fillHeight: true
+
+              ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: root.liveSpace(12)
+                spacing: root.liveSpace(10)
+                Text {
+                  Layout.fillWidth: true
+                  text: "Jordan Diaz"
+                  textFormat: Text.PlainText
+                  color: root.foreground
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.title
+                  font.bold: true
+                }
+                Rectangle {
+                  Layout.fillWidth: true
+                  implicitHeight: 1
+                  color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.20)
+                }
+                Item { Layout.fillHeight: true }
+                RowLayout {
+                  Layout.fillWidth: true
+                  PreviewBubble {
+                    mine: false
+                    label: "Their bubble"
+                    fillColor: root.incomingFill
+                    textColor: root.incomingText
+                  }
+                  Item { Layout.fillWidth: true }
+                }
+                RowLayout {
+                  Layout.fillWidth: true
+                  Item { Layout.fillWidth: true }
+                  PreviewBubble {
+                    mine: true
+                    label: "Your bubble"
+                    fillColor: root.outgoingFill
+                    textColor: root.outgoingText
+                  }
+                }
+                Text {
+                  Layout.alignment: Qt.AlignHCenter
+                  text: root.preferences && !root.preferences.use12HourConversationTimes ? "19:04" : "7:04 PM"
+                  textFormat: Text.PlainText
+                  color: Qt.darker(root.foreground, 1.45)
+                  font.family: root.fontFamily
+                  font.pixelSize: root.liveFontSize(Style.font.caption)
+                }
+                Rectangle {
+                  Layout.fillWidth: true
+                  implicitHeight: root.liveSpace(34)
+                  radius: root.liveCorner(root.liveSpace(6))
+                  color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+                  border.width: 1
+                  border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.24)
+                  Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left
+                    anchors.leftMargin: root.liveSpace(9)
+                    text: "iMessage"
+                    textFormat: Text.PlainText
+                    color: Qt.darker(root.foreground, 1.5)
+                    font.family: root.fontFamily
+                    font.pixelSize: root.liveFontSize(Style.font.caption)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Mirrors BlipView's PinnedConversation geometry: avatar + name centered
+  // in the tile, selection shown as the rounded background the app uses.
+  component PreviewAvatar: Item {
+    id: previewAvatarItem
+    property real diameter: root.liveSpace(30)
+    property string initials: "A"
+    property string label: "Alex"
+    property bool selected: false
+    implicitHeight: previewAvatarContent.implicitHeight + root.liveSpace(12)
+
+    Rectangle {
+      anchors.fill: parent
+      radius: root.liveCorner(root.liveSpace(12))
+      color: previewAvatarItem.selected
+        ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+        : "transparent"
+    }
+
+    Column {
+      id: previewAvatarContent
+      anchors.centerIn: parent
+      width: parent.width - root.liveSpace(8)
+      spacing: root.liveSpace(4)
+
+      Item {
+        width: parent.width
+        height: previewAvatarItem.diameter
+
+        Rectangle {
+          anchors.horizontalCenter: parent.horizontalCenter
+          width: previewAvatarItem.diameter
+          height: width
+          radius: width / 2
+          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+          Text {
+            anchors.centerIn: parent
+            text: previewAvatarItem.initials
+            textFormat: Text.PlainText
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.liveFontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+        }
+      }
+      Text {
+        width: parent.width
+        horizontalAlignment: Text.AlignHCenter
+        text: previewAvatarItem.label
+        textFormat: Text.PlainText
+        elide: Text.ElideRight
+        maximumLineCount: 1
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.liveFontSize(Style.font.caption)
+      }
+    }
+  }
+
+  component PreviewThreadRow: RowLayout {
+    id: previewThread
+    property real diameter: root.liveSpace(24)
+    property string initials: "A"
+    property string name: "Alex"
+    property string detail: "Message preview"
+    property string time: "7:04 PM"
+    spacing: root.liveSpace(8)
+
+    // the unread-dot gutter the real rows reserve
+    Rectangle {
+      width: root.liveSpace(9); height: width; radius: width / 2
+      color: root.outgoingFill
+      opacity: 0
+    }
+
+    Rectangle {
+      implicitWidth: previewThread.diameter
+      implicitHeight: previewThread.diameter
+      radius: width / 2
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+      Text {
+        anchors.centerIn: parent
+        text: previewThread.initials
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.liveFontSize(Style.font.caption)
+      }
+    }
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: root.liveSpace(1)
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.liveSpace(6)
+        Text {
+          Layout.fillWidth: true
+          text: previewThread.name
+          textFormat: Text.PlainText
+          elide: Text.ElideRight
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: root.liveFontSize(Style.font.bodySmall)
+        }
+        Text {
+          text: previewThread.time
+          textFormat: Text.PlainText
+          color: Qt.darker(root.foreground, 1.45)
+          font.family: root.fontFamily
+          font.pixelSize: root.liveFontSize(Style.font.caption)
+        }
+      }
+      Text {
+        Layout.fillWidth: true
+        text: previewThread.detail
+        textFormat: Text.PlainText
+        elide: Text.ElideRight
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: root.liveFontSize(Style.font.caption)
+      }
+    }
+  }
+
+  component PreviewBubble: Item {
+    id: previewBubble
+    property bool mine: false
+    property string label: ""
+    property color fillColor: root.incomingFill
+    property color textColor: root.incomingText
+
+    Layout.preferredWidth: Math.ceil(previewLabel.implicitWidth) + root.liveSpace(22)
+    Layout.preferredHeight: Math.ceil(previewLabel.implicitHeight) + root.liveSpace(14)
+
+    Shape {
+      anchors.fill: parent
+      antialiasing: true
+      ShapePath {
+        id: previewPath
+        readonly property real r: Math.min(
+          root.liveCorner(root.liveSpace(16)), previewBubble.width / 2, previewBubble.height / 2
+        )
+        strokeColor: "transparent"
+        fillColor: previewBubble.fillColor
+        startX: r
+        startY: 0
+        PathLine { x: previewBubble.width - previewPath.r; y: 0 }
+        PathQuad {
+          x: previewBubble.width; y: previewPath.r
+          controlX: previewBubble.width; controlY: 0
+        }
+        PathLine {
+          x: previewBubble.width
+          y: previewBubble.mine ? previewBubble.height : previewBubble.height - previewPath.r
+        }
+        PathQuad {
+          x: previewBubble.mine ? previewBubble.width : previewBubble.width - previewPath.r
+          y: previewBubble.height
+          controlX: previewBubble.width; controlY: previewBubble.height
+        }
+        PathLine { x: previewBubble.mine ? previewPath.r : 0; y: previewBubble.height }
+        PathQuad {
+          x: 0
+          y: previewBubble.mine ? previewBubble.height - previewPath.r : previewBubble.height
+          controlX: 0; controlY: previewBubble.height
+        }
+        PathLine { x: 0; y: previewPath.r }
+        PathQuad {
+          x: previewPath.r; y: 0
+          controlX: 0; controlY: 0
+        }
+      }
+    }
+
+    Text {
+      id: previewLabel
+      anchors.centerIn: parent
+      text: previewBubble.label
+      textFormat: Text.PlainText
+      color: previewBubble.textColor
+      font.family: root.fontFamily
+      font.pixelSize: root.liveFontSize(Style.font.bodySmall)
+    }
+  }
+
+  component ColorSetting: ColumnLayout {
+    id: colorSetting
+    property string title: ""
+    property string preferenceKey: ""
+    property string currentValue: "theme"
+    property color resolvedColor: root.accent
+    readonly property bool editorActive: field.activeFocus
+    spacing: root.space(5)
+
+    function syncField() {
+      if (!field.activeFocus) field.text = currentValue === "theme" ? "" : currentValue
+    }
+    function focusField() { field.forceActiveFocus() }
+    function commit() {
+      var candidate = field.text.trim().toLowerCase()
+      if (candidate === "" || candidate === "theme") candidate = "theme"
+      if (candidate !== "theme" && !/^#[0-9a-f]{6}([0-9a-f]{2})?$/.test(candidate)) {
+        root.localError = title + ": use #rrggbb, #rrggbbaa, or Theme"
+        return
+      }
+      root.localError = ""
+      if (root.preferences) root.preferences.setColor(preferenceKey, candidate)
+      syncField()
+    }
+    onCurrentValueChanged: syncField()
+    Component.onCompleted: syncField()
+
+    Text {
+      text: colorSetting.title
+      textFormat: Text.PlainText
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.bodySmall)
+      font.bold: true
+    }
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: root.space(8)
+      Rectangle {
+        width: root.space(28); height: width
+        radius: root.corner(root.space(8))
+        color: colorSetting.resolvedColor
+        border.width: 1
+        border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.45)
+      }
+      TextField {
+        id: field
+        Layout.fillWidth: true
+        placeholderText: "theme"
+        foreground: root.foreground
+        accent: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+        maximumLength: 9
+        onAccepted: colorSetting.commit()
+        onEditingFinished: colorSetting.commit()
+      }
+      ActionButton {
+        label: "Theme"
+        onClicked: {
+          field.text = ""
+          root.localError = ""
+          if (root.preferences) root.preferences.setColor(colorSetting.preferenceKey, "theme")
+        }
+      }
+    }
+  }
+
+  component PreferenceSlider: ColumnLayout {
+    id: sliderRow
+    property string title: ""
+    property string preferenceKey: ""
+    property real currentValue: 0
+    property real from: 0
+    property real to: 1
+    property real stepSize: 0.1
+    property int decimals: 0
+    property real multiplier: 1
+    property string suffix: ""
+    spacing: root.space(4)
+
+    onCurrentValueChanged: if (!slider.pressed) slider.value = currentValue
+
+    RowLayout {
+      Layout.fillWidth: true
+      Text {
+        Layout.fillWidth: true
+        text: sliderRow.title
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+      }
+      Text {
+        text: (slider.value * sliderRow.multiplier).toFixed(sliderRow.decimals) + sliderRow.suffix
+        textFormat: Text.PlainText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+    }
+    QQC.Slider {
+      id: slider
+      Layout.fillWidth: true
+      from: sliderRow.from
+      to: sliderRow.to
+      stepSize: sliderRow.stepSize
+      value: sliderRow.currentValue
+      onMoved: {
+        root.resetArmed = false
+        root.localError = ""
+        if (root.preferences) root.preferences.setNumber(sliderRow.preferenceKey, value)
+      }
+      background: Rectangle {
+        x: slider.leftPadding
+        y: slider.topPadding + slider.availableHeight / 2 - height / 2
+        implicitWidth: 200
+        implicitHeight: root.space(4)
+        width: slider.availableWidth
+        height: implicitHeight
+        radius: height / 2
+        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+        Rectangle {
+          width: slider.visualPosition * parent.width
+          height: parent.height
+          radius: parent.radius
+          color: root.accent
+        }
+      }
+      handle: Rectangle {
+        x: slider.leftPadding + slider.visualPosition * (slider.availableWidth - width)
+        y: slider.topPadding + slider.availableHeight / 2 - height / 2
+        implicitWidth: root.space(16)
+        implicitHeight: width
+        radius: width / 2
+        color: root.accent
+        border.width: slider.activeFocus ? 2 : 1
+        border.color: root.foreground
+      }
+    }
+  }
+
+  component ActionButton: Rectangle {
+    id: action
+    property string label: ""
+    property bool danger: false
+    property bool selected: false
+    signal clicked()
+    implicitWidth: actionText.implicitWidth + root.space(18)
+    implicitHeight: actionText.implicitHeight + root.space(12)
+    radius: root.corner(root.space(8))
+    color: actionHover.hovered
+      ? Qt.rgba((danger ? root.urgent : root.accent).r,
+                (danger ? root.urgent : root.accent).g,
+                (danger ? root.urgent : root.accent).b, 0.18)
+      : selected ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.18)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.06)
+    border.width: 1
+    border.color: danger ? root.urgent : selected ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.35)
+    Text {
+      id: actionText
+      anchors.centerIn: parent
+      text: action.label
+      textFormat: Text.PlainText
+      color: action.danger ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: action.danger || action.selected
+    }
+    HoverHandler { id: actionHover; cursorShape: Qt.PointingHandCursor }
+    TapHandler { onTapped: action.clicked() }
+  }
+}

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Shapes
 import Quickshell
 import Quickshell.Io
 import QtQuick.Effects
@@ -22,6 +23,7 @@ FocusScope {
 
   // ---- host contract (docs/app-design-review.md) ----------------------
   property var hostWidget: null
+  property var preferences: null
   /** Qt format strings, owned by the host widget (see BarWidget). Empty when no host is
    *  attached or the host has none, which thread.ts and Qt both read as "use the defaults". */
   readonly property string timeFormat: (hostWidget && hostWidget.timeFormat) || ""
@@ -69,7 +71,7 @@ FocusScope {
   readonly property color dim: Qt.darker(foreground, 1.45)
   /** An editor owns the keyboard — the host's key catcher must stand down. */
   readonly property bool editorActive:
-    composeField.activeFocus || searchField.activeFocus || newField.activeFocus || bubbleFocused
+    settingsMode || composeField.activeFocus || searchField.activeFocus || newField.activeFocus || bubbleFocused
   readonly property alias composeEditor: composeField
   readonly property real contentHeightHint: listContent.implicitHeight
   /** The view wants keyboard navigation focus back (list mode). */
@@ -84,15 +86,56 @@ FocusScope {
   readonly property color cyan: accent            // legacy name; accents/links
   readonly property color okColor: accent
 
-  readonly property color mineFill: accent
+  // App-local scale tokens layered on the live Omarchy theme. Defaults are
+  // exactly the pre-preferences values, so installing this layer is visual
+  // no-op until the user changes preferences.json or the Settings UI.
+  readonly property real fontScale: preferences ? preferences.fontScale : 1.0
+  readonly property real density: preferences ? preferences.density : 1.0
+  readonly property real cornerScale: preferences ? preferences.cornerScale : 1.0
+  readonly property int avatarSize: preferences ? preferences.avatarSize : 30
+  readonly property int groupMessageAvatarSize: Math.max(
+    root.space(24), Math.round(Style.spaceReal(root.avatarSize) * 0.9)
+  )
+  readonly property int groupMessageAvatarSlot: groupMessageAvatarSize + root.space(8)
+  readonly property string outgoingColorSetting: preferences ? preferences.outgoingBubbleColor : "theme"
+  readonly property string incomingColorSetting: preferences ? preferences.incomingBubbleColor : "theme"
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function opaqueOver(fill, background) {
+    var alpha = fill.a
+    return Qt.rgba(
+      fill.r * alpha + background.r * (1 - alpha),
+      fill.g * alpha + background.g * (1 - alpha),
+      fill.b * alpha + background.b * (1 - alpha), 1
+    )
+  }
+  function contrastText(fill) {
+    var alpha = fill.a
+    var red = fill.r * alpha + Color.background.r * (1 - alpha)
+    var green = fill.g * alpha + Color.background.g * (1 - alpha)
+    var blue = fill.b * alpha + Color.background.b * (1 - alpha)
+    return (0.299 * red + 0.587 * green + 0.114 * blue) > 0.35 ? "#1a1a1a" : "#ffffff"
+  }
+  function richMessageHtml(html, linkColor) {
+    var color = String(linkColor || "").toLowerCase()
+    if (!/^#[0-9a-f]{6}$/.test(color)) color = "#ffffff"
+    return String(html || "").replace(
+      /<a href=/g,
+      '<a style="color: ' + color + '; text-decoration: underline;" href='
+    )
+  }
+
+  readonly property color mineFill: outgoingColorSetting === "theme" ? accent : outgoingColorSetting
   // Bubble text picks black/white by which CONTRASTS better with the fill:
   // (L+0.05)/0.15 vs 1.05/(L+0.05) cross over near L≈0.35. A 0.6 threshold
   // chose white on medium accents where dark text is clearly more legible
   // (e.g. Evergreen #4a9a68: white 3.4:1 vs dark 5.1:1).
-  readonly property color mineText:
-    (0.299 * mineFill.r + 0.587 * mineFill.g + 0.114 * mineFill.b) > 0.35 ? "#1a1a1a" : "#ffffff"
-  readonly property color theirsFill: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
-  readonly property color theirsText: foreground
+  readonly property color mineText: contrastText(mineFill)
+  readonly property color theirsFill: incomingColorSetting === "theme"
+    ? Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
+    : incomingColorSetting
+  readonly property color theirsText: incomingColorSetting === "theme" ? foreground : contrastText(theirsFill)
 
   readonly property string home: Quickshell.env("HOME")
   readonly property string threadScript:
@@ -133,19 +176,41 @@ FocusScope {
   // The cache under ~/.cache/blip/att is global, so results never go stale on
   // a thread switch — no ownership tracking needed, unlike thread loads.
   property var attFiles: ({})
+  property var attMetrics: ({})
   property var fetchQueue: []
   property string fetchingId: ""
   // Compose draft attachment (one per message in v1).
   property string draftPath: ""
   property string draftLabel: ""
+  // A previewable draft shows the picture itself in the compose chip; other
+  // files (a pasted vCard, a PDF) keep the filename pill. Local pastes and
+  // drops are trusted files the user just chose, so the extension decides.
+  readonly property bool draftIsImage: {
+    var dot = draftPath.lastIndexOf(".")
+    if (dot < 0) return false
+    return ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]
+      .indexOf(draftPath.slice(dot + 1).toLowerCase()) !== -1
+  }
   // What the in-flight file send / paste belong to, so late completions
   // can't clobber a NEWER draft or land in a DIFFERENT conversation.
   property string sendDraftPath: ""
   property string pasteChat: ""
 
   readonly property var threads: hostWidget ? hostWidget.threads : []
-  readonly property var pinnedThreads: root.threads.filter(function(t) { return t.pinned === true })
-  readonly property var unpinnedThreads: root.threads.filter(function(t) { return t.pinned !== true })
+  // Messages.app owns pin membership and order. Pinned conversations leave
+  // the chronological list and render first as the familiar avatar grid.
+  readonly property var pinnedThreads: {
+    var out = []
+    for (var i = 0; i < threads.length; i++) if (threads[i].pinned === true) out.push(threads[i])
+    return out.sort(function(a, b) {
+      var ao = Number(a.pin_order); var bo = Number(b.pin_order)
+      if (ao !== bo) return ao - bo
+      return String(a.last_ts) < String(b.last_ts) ? 1 : -1
+    })
+  }
+  readonly property var regularThreads: threads.filter(function(thread) { return thread.pinned !== true })
+  readonly property var unpinnedThreads: regularThreads
+  readonly property var navigationThreads: pinnedThreads.concat(regularThreads)
   readonly property bool online: hostWidget ? hostWidget.online : false
   readonly property int unread: hostWidget ? hostWidget.unread : 0
 
@@ -226,10 +291,20 @@ FocusScope {
   property string threadRunningChat: "" // chat owned by the current threadProc
   property string bubblesJson: ""       // last rendered bubbles, for no-op reload detection
   property bool firstLoad: true         // first load of the open thread pins to bottom
+  property bool settingsMode: false
+  // The popout doubles its width for the whole settings surface: appearance
+  // puts the preview beside the controls, and the contacts review/compare
+  // workflows need the same room. One width also means no resize jump when
+  // switching between the tabs.
+  readonly property bool settingsWide: settingsMode
+  readonly property real settingsWideWidth: settingsView.wideWidth
   property string pendingThreadChat: "" // latest chat requested while it runs
+  property var pendingThreadAliases: [] // historical ids coalesced into that chat
+  property var threadRunningAliases: []
   property string sendChat: ""          // immutable context for the current send
   property string sendText: ""
   property string reloadChat: ""
+  property string contextMessageText: ""
 
   function threadIndex(thread) {
     for (var i = 0; i < root.threads.length; i++) {
@@ -280,7 +355,7 @@ FocusScope {
           if (!flick.stick) { pushPending = true }  // reading history — defer
           else {
             pinToBottom = true
-            requestThreadLoad(String(t.chat))
+            requestThreadLoad(String(t.chat), t.aliases || [])
           }
         }
       }
@@ -289,6 +364,21 @@ FocusScope {
   }
   // Same rule as collector.isGroupChat(): anything that is not a phone/email.
   function isGroupId(c) { c = String(c || ""); return c !== "" && !/^\+?[0-9]{5,}$/.test(c) && c.indexOf("@") < 0 }
+  // Bubble right-clicks stay about the MESSAGE (copy).
+  function openMessageContext(messageText) {
+    contextMessageText = String(messageText || "")
+    if (contextMessageText === "") return
+    messageOnlyMenu.popup()
+  }
+  function threadContainsChat(thread, chat) {
+    if (!thread) return false
+    var wanted = String(chat || "")
+    if (String(thread.chat || "") === wanted) return true
+    var aliases = Array.isArray(thread.aliases) ? thread.aliases : []
+    for (var i = 0; i < aliases.length; i++)
+      if (String(aliases[i]) === wanted) return true
+    return false
+  }
   readonly property bool activeIsGroup: inThread && isGroupId(active.chat)
 
   /**
@@ -307,12 +397,14 @@ FocusScope {
 
   /** Back to the list view, scrolled to top — the host calls this on open. */
   function resetToList() {
+    settingsMode = false
     active = null
     bubbles = []
     note = ""
     cursor = -1
     loading = false
     pendingThreadChat = ""
+    pendingThreadAliases = []
     composeField.text = ""
     searching = false
     searchResults = []
@@ -334,10 +426,24 @@ FocusScope {
     note = ""
     loading = false
     pendingThreadChat = ""
+    pendingThreadAliases = []
     composeField.text = ""
     clearDraft()   // a queued file must never survive into another thread
     pinToBottom = false
     Qt.callLater(function() { threadFlick.contentY = 0; root.navigationFocusRequested() })
+  }
+
+  function openSettings(page) {
+    exitSearch()
+    exitNew()
+    settingsMode = true
+    settingsView.showPage("appearance")
+    Qt.callLater(settingsView.focusDefault)
+  }
+
+  function closeSettings() {
+    settingsMode = false
+    Qt.callLater(root.focusDefault)
   }
 
   function openThread(t) {
@@ -352,23 +458,27 @@ FocusScope {
     loading = true
     composeField.text = ""
     clearDraft()   // a queued file must never survive into another thread
-    requestThreadLoad(String(t.chat))
+    requestThreadLoad(String(t.chat), t.aliases || [])
     Qt.callLater(function() { composeField.forceActiveFocus() })
   }
 
-  function requestThreadLoad(chat) {
+  function requestThreadLoad(chat, aliases) {
     pendingThreadChat = String(chat || "")
+    pendingThreadAliases = Array.isArray(aliases) ? aliases.slice(0, 16) : []
     if (!threadProc.running) startNextThreadLoad()
   }
 
   function startNextThreadLoad() {
     if (threadProc.running || pendingThreadChat === "") return
     threadRunningChat = pendingThreadChat
+    threadRunningAliases = pendingThreadAliases
     pendingThreadChat = ""
+    pendingThreadAliases = []
     threadProc.command = ["bun", root.threadScript, threadRunningChat, "80",
                           "--time-format", root.timeFormat,
                           "--date-format", root.dateFormat,
                           "--date-format-with-year", root.dateFormatWithYear]
+      .concat(threadRunningAliases)
     threadProc.running = true
   }
 
@@ -603,6 +713,7 @@ FocusScope {
     newNote = ""
     newCursor = 0
     newQueryRan = ""
+    // Defer focus until the visibility change has completed its layout pass.
     Qt.callLater(function() {
       newField.forceActiveFocus()
       newField.selectAll()
@@ -617,7 +728,7 @@ FocusScope {
     newQueryRan = ""
     newField.text = ""
     newField.focus = false
-    root.navigationFocusRequested()
+    Qt.callLater(root.navigationFocusRequested)
   }
 
   // Same identity discipline as message search: a stale completion must
@@ -847,7 +958,7 @@ FocusScope {
     if (!flick.stick) { pushPending = true; return }
     if (threadProc.running && pendingThreadChat !== "") return
     pinToBottom = true
-    requestThreadLoad(String(active.chat))
+    requestThreadLoad(String(active.chat), active.aliases || [])
   }
 
   /** IPC hook (`newchat <query>`): drive the composer path minus the keyboard. */
@@ -874,7 +985,7 @@ FocusScope {
   function openSearchHit(hit) {
     searching = false
     for (var i = 0; i < threads.length; i++) {
-      if (String(threads[i].chat) === String(hit.chat)) { openThread(threads[i]); return }
+      if (threadContainsChat(threads[i], hit.chat)) { openThread(threads[i]); return }
     }
     openThread({ chat: hit.chat, guid: "", name: hit.name, handle: hit.handle,
                  service: hit.service, last_ts: hit.ts, last_text: "",
@@ -1004,7 +1115,8 @@ FocusScope {
               // Nothing changed — do NOT rebuild the Repeater (a rebuild
               // resets scroll and re-decodes every image). Push pings mostly
               // produce identical content; this makes them free.
-              if (root.hostWidget && root.readActive) root.hostWidget.markThreadRead(root.threadRunningChat)
+              if (root.hostWidget && root.readActive)
+                root.hostWidget.markThreadRead(root.threadRunningChat, root.threadRunningAliases)
               return
             }
             root.bubblesJson = j
@@ -1015,7 +1127,8 @@ FocusScope {
             root.firstLoad = false
             Qt.callLater(root.autoFetchImages)
             // A dot means "looked at", so clear it only after content loaded.
-            if (root.hostWidget && root.readActive) root.hostWidget.markThreadRead(root.threadRunningChat)
+            if (root.hostWidget && root.readActive)
+              root.hostWidget.markThreadRead(root.threadRunningChat, root.threadRunningAliases)
           } else {
             root.bubbles = []
             root.note = String(d.error || "could not load this thread")
@@ -1030,6 +1143,7 @@ FocusScope {
       var completedChat = root.threadRunningChat
       var belongsHere = root.inThread && String(root.active.chat) === completedChat
       root.threadRunningChat = ""
+      root.threadRunningAliases = []
       if (belongsHere && root.pendingThreadChat === "") root.loading = false
       if (belongsHere && code !== 0) root.note = "thread loader failed (exit " + code + ")"
       if (root.pendingThreadChat !== "") Qt.callLater(root.startNextThreadLoad)
@@ -1080,6 +1194,15 @@ FocusScope {
           var m = Object.assign({}, root.attFiles)
           m[id] = d.ok === true ? String(d.url || "") : ""
           root.attFiles = m
+          var ratio = Number(d.pixelRatio)
+          var pixelWidth = Number(d.pixelWidth)
+          var pixelHeight = Number(d.pixelHeight)
+          if (!isFinite(ratio) || ratio < 1 || ratio > 4) ratio = 1
+          if (!isFinite(pixelWidth) || pixelWidth < 1 || pixelWidth > 100000) pixelWidth = 0
+          if (!isFinite(pixelHeight) || pixelHeight < 1 || pixelHeight > 100000) pixelHeight = 0
+          var metrics = Object.assign({}, root.attMetrics)
+          metrics[id] = { pixelRatio: ratio, pixelWidth: pixelWidth, pixelHeight: pixelHeight }
+          root.attMetrics = metrics
           if (d.ok === true && root.fetchJobOpen) {
             if (root.openableMime(root.fetchJobMime)) {
               Quickshell.execDetached(["xdg-open", String(d.url || "")])
@@ -1101,7 +1224,7 @@ FocusScope {
     }
   }
 
-  // Clipboard snapshot (Ctrl+V): image → draft chip, text → insert at cursor.
+  // Clipboard snapshot (Ctrl+V): file/image → draft chip, text → composer.
   Process {
     id: pasteProc
     stdout: StdioCollector {
@@ -1111,7 +1234,7 @@ FocusScope {
         if (!root.inThread || String(root.active.chat) !== root.pasteChat) return
         try {
           var d = JSON.parse(text.trim())
-          if (d.kind === "image") root.setDraft(String(d.path || ""))
+          if (d.kind === "file" || d.kind === "image") root.setDraft(String(d.path || ""))
           else if (d.kind === "text") {
             composeField.insert(composeField.cursorPosition, String(d.text || ""))
           }
@@ -1270,26 +1393,29 @@ FocusScope {
     interval: 1500
     onTriggered: if (root.inThread && String(root.active.chat) === root.reloadChat) {
       root.loading = true
-      root.requestThreadLoad(root.reloadChat)
+      root.requestThreadLoad(root.reloadChat, root.active ? root.active.aliases || [] : [])
     }
   }
 
   // ---- keyboard navigation (the host's PanelKeyCatcher calls these)
   function moveCursor(dy) {
-    if (inThread || threads.length === 0 || dy === 0) return
-    cursor = (cursor + dy + threads.length) % threads.length
+    if (settingsMode || inThread || navigationThreads.length === 0 || dy === 0) return
+    cursor = (cursor + dy + navigationThreads.length) % navigationThreads.length
   }
   function activateCursor() {
-    if (!inThread && cursor >= 0) openThread(threads[cursor])
+    if (!inThread && cursor >= 0) openThread(navigationThreads[cursor])
   }
   function handleTextKey(text) {
+    if (settingsMode) return false
     if (text === "/") { startSearch(); return true }
     if (text === "n" || text === "N") { startNew(); return true }
     if (text >= "1" && text <= "9") {
       if (searching || newMode) return false
       var i = Number(text) - 1
-      if (i < 0 || i >= threads.length) return false
-      openThread(threads[i])
+      // navigationThreads = pinned first, then chronological — the order
+      // the sidebar actually shows.
+      if (i < 0 || i >= navigationThreads.length) return false
+      openThread(navigationThreads[i])
       return true
     }
     if ((inThread && !splitView) || searching || newMode) return false
@@ -1315,24 +1441,32 @@ FocusScope {
    *  something was unwound, false if the host should close. */
   function unwind() {
     if (shareUrl !== "") { closeShare(); return true }
+    if (settingsMode) { closeSettings(); return true }
     if (catchEscape()) return true
     if (inThread) { back(); return true }
     return false
   }
   function focusDefault() {
-    if (inThread) composeField.forceActiveFocus()
+    if (settingsMode) settingsView.focusDefault()
+    else if (inThread) composeField.forceActiveFocus()
     else navigationFocusRequested()
   }
 
   // ---- layout: one pane (popout) or two (window). Both panes always exist —
   // hiding, not unloading, keeps image state, selection, and scroll position.
   property bool splitView: false
-  property int sidebarWidth: 320
+  property int sidebarWidth: preferences ? preferences.sidebarWidth : 320
   readonly property bool listShowing: splitView || !inThread
+  // The app's two panes share one header track. Keeping it independent of
+  // whether a conversation has metadata prevents the separator and body from
+  // jumping when the first conversation is selected.
+  readonly property real splitHeaderHeight: Math.ceil(Math.max(
+    Style.font.title + Style.font.caption + Style.space(4), root.space(34)))
 
   RowLayout {
     anchors.fill: parent
     spacing: 0
+    visible: !root.settingsMode
 
     // ------------------------------------------------------- thread pane
     Item {
@@ -1343,22 +1477,110 @@ FocusScope {
       Layout.preferredWidth: root.splitView ? root.sidebarWidth : -1
       ColumnLayout {
         anchors.fill: parent
-        // Gutters for the app: the popout's card supplies its own padding,
-        // the window's panes had text flush against the borders (Fred).
-        anchors.leftMargin: root.splitView ? Style.space(18) : 0
-        anchors.rightMargin: root.splitView ? Style.space(18) : 0
-        anchors.topMargin: root.splitView ? Style.space(10) : 0
-        anchors.bottomMargin: root.splitView ? Style.space(10) : 0
-        spacing: Style.space(root.splitView ? 14 : 8)
-        PanelHero {
+        // BlipWindow already supplies the outer edge inset. Keep only a small
+        // inner gutter here so the sidebar does not pay for the same padding
+        // twice; retain the larger right gutter beside the pane divider.
+        anchors.leftMargin: root.splitView ? root.space(6) : 0
+        anchors.rightMargin: root.splitView ? root.space(18) : 0
+        anchors.topMargin: root.splitView ? root.space(10) : 0
+        anchors.bottomMargin: root.splitView ? root.space(10) : 0
+        spacing: root.space(8)
+        RowLayout {
           Layout.fillWidth: true
-          title: "Blip"
-          meta: (!root.online
-                ? "Mac unreachable — bridge offline"
-                : (root.unread > 0 ? root.unread + " unread" : "all caught up"))
-          detail: ""   // Fred: not needed — and it squeezed the title to "B…"
-          foreground: root.foreground
-          fontFamily: root.fontFamily
+          Layout.preferredHeight: root.splitView
+            ? root.splitHeaderHeight
+            : Math.max(sidebarHero.implicitHeight, headerActions.implicitHeight)
+          spacing: root.space(8)
+          PanelHero {
+            id: sidebarHero
+            visible: !root.splitView
+            Layout.fillWidth: true
+            title: "Blip"
+            meta: (!root.online
+                  ? "Mac unreachable — bridge offline"
+                  : (root.unread > 0 ? root.unread + " unread" : "all caught up"))
+            detail: ""   // Fred: not needed — and it squeezed the title to "B…"
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+          }
+
+          // The wide app uses a single line so its rule aligns with the
+          // conversation pane. The popout keeps PanelHero's stacked status.
+          RowLayout {
+            visible: root.splitView
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            spacing: root.space(8)
+            Text {
+              text: "Blip"
+              textFormat: Text.PlainText
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.title
+              font.bold: true
+            }
+            Text {
+              Layout.fillWidth: true
+              text: (!root.online
+                    ? "MAC UNREACHABLE — BRIDGE OFFLINE"
+                    : (root.unread > 0 ? root.unread + " UNREAD" : "ALL CAUGHT UP"))
+              textFormat: Text.PlainText
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+              font.letterSpacing: 1.2
+              elide: Text.ElideRight
+            }
+          }
+          // Popout header actions, ordered by function: start a conversation,
+          // promote to the app window, then configuration — the gear stays
+          // rightmost on both surfaces. Real buttons (PanelActionButton, the
+          // stock panels' control): a hand-rolled Text+MouseArea version lost
+          // its clicks to the panel's dismiss layer and CLOSED the panel.
+          RowLayout {
+            id: headerActions
+            Layout.alignment: Qt.AlignVCenter
+            spacing: root.space(4)
+            PanelActionButton {
+              visible: !root.splitView && root.online && root.listShowing
+                       && !root.newMode && !root.searchShowing
+              iconText: "＋"
+              tooltipText: "New message (n)"
+              bordered: false
+              foreground: root.foreground
+              hoverColor: root.accent
+              fontFamily: root.fontFamily
+              fontSize: root.fontSize(Style.font.icon)
+              onClicked: root.startNew()
+            }
+            // Open the full app window. Hidden in the app itself (it IS the
+            // window) and in the search/new views, like ＋.
+            PanelActionButton {
+              visible: !root.splitView && root.online && root.listShowing
+                       && !root.newMode && !root.searchShowing
+              iconText: "⇱"
+              tooltipText: "Open the app window (SUPER+M)"
+              bordered: false
+              foreground: root.foreground
+              hoverColor: root.accent
+              fontFamily: root.fontFamily
+              fontSize: root.fontSize(Style.font.icon)
+              onClicked: root.openApp()
+            }
+            PanelActionButton {
+              id: sidebarSettings
+              focusable: true
+              iconText: "⚙"
+              tooltipText: "Settings"
+              bordered: false
+              foreground: root.foreground
+              hoverColor: root.accent
+              fontFamily: root.fontFamily
+              fontSize: root.fontSize(Style.font.icon)
+              onClicked: root.openSettings()
+            }
+          }
         }
 
         PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
@@ -1368,6 +1590,10 @@ FocusScope {
           id: threadFlick
           Layout.fillWidth: true
           Layout.fillHeight: true
+          // Match the search-to-pins gap below. This margin belongs to the
+          // sidebar body rather than the shared header track, so both pane
+          // separators remain aligned.
+          Layout.topMargin: root.splitView ? root.space(6) : 0
           contentWidth: width
           contentHeight: listContent.implicitHeight
           clip: true
@@ -1403,7 +1629,12 @@ FocusScope {
           ColumnLayout {
             id: listContent
             width: parent.width
-            spacing: root.inThread ? Style.space(2) : Style.space(root.splitView ? 10 : 6)
+            // Selecting a conversation must not compact or move the sidebar.
+            // In split view, 10 units plus the pinned section's 4-unit margin
+            // mirrors the 8 + 6 units above the search field.
+            spacing: root.splitView
+              ? root.space(10)
+              : root.space(root.inThread ? 2 : 6)
 
             // ------------------------------------------------- OFFLINE
             Text {
@@ -1415,7 +1646,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               wrapMode: Text.WordWrap
             }
             // Reachable but broken — say exactly what to fix (Full Disk Access,
@@ -1428,44 +1659,24 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.urgent
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               wrapMode: Text.WordWrap
             }
 
             // ---------------------------------------------- LIST VIEW
             RowLayout {
               Layout.fillWidth: true
+              // The ＋/⇱ buttons live in the header now; this row remains for
+              // the search/new section label and the mark-all-read action.
               visible: root.online && root.listShowing
+                       && (root.newMode || root.searchShowing || root.unread > 0)
               PanelSectionHeader {
                 Layout.fillWidth: true
-                text: root.newMode ? "NEW MESSAGE" : root.searchShowing ? "SEARCH" : "MESSAGES"
+                visible: root.newMode || root.searchShowing
+                text: root.newMode ? "NEW MESSAGE" : "SEARCH"
                 foreground: root.foreground
                 fontFamily: root.fontFamily
-              }
-              // A real button (PanelActionButton = the stock panels' control).
-              // The hand-rolled Text+MouseArea version lost its clicks to the
-              // panel's dismiss layer — clicking it CLOSED the panel.
-              PanelActionButton {
-                visible: !root.newMode && !root.searchShowing && !root.splitView
-                iconText: "＋"
-                tooltipText: "New message (n)"
-                bordered: true
-                foreground: root.foreground
-                hoverColor: root.accent
-                fontFamily: root.fontFamily
-                onClicked: root.startNew()
-              }
-              // Open the full app window. Hidden in the app itself (it IS the
-              // window) and in the split/search/new views, like ＋.
-              PanelActionButton {
-                visible: !root.newMode && !root.searchShowing && !root.splitView
-                iconText: "⇱"
-                tooltipText: "Open the app window (SUPER+M)"
-                bordered: true
-                foreground: root.foreground
-                hoverColor: root.accent
-                fontFamily: root.fontFamily
-                onClicked: root.openApp()
+                fontSize: root.fontSize(Style.font.caption)
               }
               // Local only: moves readMark/readMarks in state.json so the
               // badge and dots clear. Nothing is written back to the Mac —
@@ -1479,7 +1690,7 @@ FocusScope {
                 textFormat: Text.PlainText
                 color: markAllHover.hovered ? root.mineFill : root.cyan
                 font.family: root.fontFamily
-                font.pixelSize: Style.font.caption
+                font.pixelSize: root.fontSize(Style.font.caption)
                 font.underline: markAllHover.hovered
                 HoverHandler { id: markAllHover; cursorShape: Qt.PointingHandCursor }
                 TapHandler { onTapped: root.markAllRead() }
@@ -1499,7 +1710,7 @@ FocusScope {
               foreground: root.foreground
               accent: root.accent
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               onAccepted: root.acceptNewField()
               Keys.onEscapePressed: root.exitNew()
               Keys.onPressed: function(event) {
@@ -1519,7 +1730,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
             }
 
             Repeater {
@@ -1528,8 +1739,8 @@ FocusScope {
                 required property var modelData
                 required property int index
                 Layout.fillWidth: true
-                implicitHeight: contactRow.implicitHeight + Style.space(12)
-                radius: Style.cornerRadius
+                implicitHeight: contactRow.implicitHeight + root.space(12)
+                radius: root.corner(Style.cornerRadius)
                 color: contactHover.hovered || root.newCursor === index
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
@@ -1540,16 +1751,16 @@ FocusScope {
                   anchors.left: parent.left
                   anchors.right: parent.right
                   anchors.verticalCenter: parent.verticalCenter
-                  anchors.leftMargin: Style.space(8)
-                  anchors.rightMargin: Style.space(8)
-                  spacing: Style.space(8)
+                  anchors.leftMargin: root.space(8)
+                  anchors.rightMargin: root.space(8)
+                  spacing: root.space(8)
                   Text {
                     text: String(modelData.name || "")
                     textFormat: Text.PlainText
                     elide: Text.ElideRight
                     color: root.foreground
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.bodySmall
+                    font.pixelSize: root.fontSize(Style.font.bodySmall)
                     font.bold: true
                   }
                   Text {
@@ -1559,7 +1770,7 @@ FocusScope {
                     elide: Text.ElideRight
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
                   }
                 }
               }
@@ -1573,120 +1784,13 @@ FocusScope {
               foreground: root.foreground
               accent: root.accent
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               onAccepted: root.acceptSearchField()
               onActiveFocusChanged: if (activeFocus && !root.searching) root.searching = true
               Keys.onEscapePressed: root.exitSearch()
               Keys.onPressed: function(event) {
                 if (event.key === Qt.Key_Down) { root.moveSearchCursor(1); event.accepted = true }
                 else if (event.key === Qt.Key_Up) { root.moveSearchCursor(-1); event.accepted = true }
-              }
-            }
-
-            // Read-only mirror of Messages' pinned section. These tiles have
-            // no preview: the Mac owns pinning, while Blip only renders the
-            // ordered avatars and names above the ordinary conversation rows.
-            GridLayout {
-              id: pinnedGrid
-              Layout.fillWidth: true
-              visible: root.online && root.listShowing && !root.searchShowing && !root.newMode
-                       && root.pinnedThreads.length > 0
-              columns: 3
-              columnSpacing: Style.space(8)
-              rowSpacing: Style.space(10)
-              Layout.topMargin: Style.space(8)
-              Layout.bottomMargin: Style.space(8)
-
-              Repeater {
-                model: pinnedGrid.visible ? root.pinnedThreads : []
-                delegate: Rectangle {
-                  required property var modelData
-                  Layout.fillWidth: true
-                  Layout.preferredWidth: Math.max(1, (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3)
-                  implicitHeight: pinnedColumn.implicitHeight + Style.space(4)
-                  radius: Style.cornerRadius
-                  // j/k walk root.threads, and pinned threads sort FIRST in it —
-                  // without this the cursor was invisible for those presses.
-                  color: pinnedHover.hovered || root.cursor === root.threadIndex(modelData)
-                    ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
-                    : "transparent"
-
-                  HoverHandler { id: pinnedHover }
-                  TapHandler { onTapped: root.openThread(modelData) }
-
-                  ColumnLayout {
-                    id: pinnedColumn
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.top: parent.top
-                    spacing: Style.space(4)
-
-                    Rectangle {
-                      id: pinnedAvatar
-                      Layout.alignment: Qt.AlignHCenter
-                      width: Math.min(88, Math.max(56,
-                        (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3 * 0.62))
-                      height: width
-                      radius: width / 2
-                      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
-                      readonly property string avatarHandle: root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")
-                      Component.onCompleted: root.requestAvatar(avatarHandle)
-
-                      Image {
-                        id: pinnedAvatarImg
-                        anchors.fill: parent
-                        visible: false
-                        source: root.avatarFiles[pinnedAvatar.avatarHandle] || ""
-                        asynchronous: true
-                        fillMode: Image.PreserveAspectCrop
-                        autoTransform: true
-                        sourceSize.width: 192
-                        sourceSize.height: 192
-                        onStatusChanged: if (status === Image.Error && pinnedAvatar.avatarHandle !== "") {
-                          var m = Object.assign({}, root.avatarFiles); m[pinnedAvatar.avatarHandle] = ""; root.avatarFiles = m
-                        }
-                      }
-                      Item {
-                        id: pinnedAvatarMask
-                        anchors.fill: parent
-                        visible: false
-                        layer.enabled: true
-                        Rectangle { anchors.fill: parent; radius: width / 2 }
-                      }
-                      MultiEffect {
-                        anchors.fill: parent
-                        source: pinnedAvatarImg
-                        visible: pinnedAvatarImg.status === Image.Ready
-                        maskEnabled: true
-                        maskSource: pinnedAvatarMask
-                      }
-                      Text {
-                        anchors.centerIn: parent
-                        visible: pinnedAvatarImg.status !== Image.Ready
-                        text: root.avatarInitials(modelData)
-                        color: root.foreground
-                        font.family: root.fontFamily
-                        font.pixelSize: Style.font.body
-                        font.bold: true
-                      }
-                    }
-
-                    // No number under the tile (Fred, 2.3.1). 1-9 still jumps —
-                    // handleTextKey indexes threads[] directly and never needed
-                    // the label; the digit was a hint, not the mechanism.
-                    Text {
-                      Layout.fillWidth: true
-                      text: String(modelData.name || modelData.chat)
-                      textFormat: Text.PlainText
-                      horizontalAlignment: Text.AlignHCenter
-                      elide: Text.ElideRight
-                      color: root.foreground
-                      font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
-                      font.bold: modelData.unread > 0
-                    }
-                  }
-                }
               }
             }
 
@@ -1697,7 +1801,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
             }
 
             Repeater {
@@ -1706,8 +1810,8 @@ FocusScope {
                 required property var modelData
                 required property int index
                 Layout.fillWidth: true
-                implicitHeight: hitCol.implicitHeight + Style.space(12)
-                radius: Style.cornerRadius
+                implicitHeight: hitCol.implicitHeight + root.space(12)
+                radius: root.corner(Style.cornerRadius)
                 color: hitHover.hovered || root.searchCursor === index
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
@@ -1719,9 +1823,9 @@ FocusScope {
                   anchors.left: parent.left
                   anchors.right: parent.right
                   anchors.verticalCenter: parent.verticalCenter
-                  anchors.leftMargin: Style.space(8)
-                  anchors.rightMargin: Style.space(8)
-                  spacing: Style.space(2)
+                  anchors.leftMargin: root.space(8)
+                  anchors.rightMargin: root.space(8)
+                  spacing: root.space(2)
                   RowLayout {
                     Layout.fillWidth: true
                     Text {
@@ -1733,7 +1837,7 @@ FocusScope {
                       elide: Text.ElideRight
                       color: root.foreground
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.bodySmall
+                      font.pixelSize: root.fontSize(Style.font.bodySmall)
                       font.bold: true
                     }
                     Text {
@@ -1741,7 +1845,7 @@ FocusScope {
                       textFormat: Text.PlainText
                       color: root.dim
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
+                      font.pixelSize: root.fontSize(Style.font.caption)
                     }
                   }
                   Text {
@@ -1755,7 +1859,40 @@ FocusScope {
                     wrapMode: Text.WordWrap
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
+                  }
+                }
+              }
+            }
+
+            // Messages.app's pinning plist supplies both membership and order.
+            // Keep the same visual grammar: large circular contacts in a grid,
+            // then the remaining conversations in chronological rows.
+            ColumnLayout {
+              Layout.fillWidth: true
+              visible: root.online && root.listShowing && !root.searchShowing
+                       && !root.newMode && root.pinnedThreads.length > 0
+              // Match the header-to-search breathing room: listContent's
+              // spacing supplies most of this gap and this margin supplies
+              // the difference from the outer divider spacing.
+              Layout.topMargin: root.space(root.splitView ? 4 : 2)
+              spacing: root.space(7)
+
+              GridLayout {
+                id: pinnedGrid
+                Layout.fillWidth: true
+                columns: root.splitView && root.sidebarWidth < 400 ? 3 : 4
+                columnSpacing: root.space(6)
+                rowSpacing: root.space(8)
+
+                Repeater {
+                  model: root.pinnedThreads
+                  delegate: PinnedConversation {
+                    required property var modelData
+                    required property int index
+                    Layout.fillWidth: true
+                    thread: modelData
+                    selected: root.cursor === index
                   }
                 }
               }
@@ -1768,137 +1905,177 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
               wrapMode: Text.WordWrap
             }
 
-            Repeater {
-              model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.unpinnedThreads : []
-              delegate: Rectangle {
-                required property var modelData
-                required property int index
+            // Chronological rows are CONTIGUOUS: the wrapper zeroes the list
+            // spacing and each row absorbs half the old gap as inner padding,
+            // so the hover highlight fills the whole area up to the hairline
+            // separator (which sits exactly on the row boundary).
+            ColumnLayout {
+              id: chronoRows
+              Layout.fillWidth: true
+              visible: root.online && root.listShowing && !root.searchShowing && !root.newMode
+              spacing: 0
 
-                Layout.fillWidth: true
-                implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 20 : 12)
-                radius: Style.cornerRadius
-                color: rowHover.hovered || root.cursor === root.threadIndex(modelData)
-                  ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
-                  : "transparent"
+              // Which row is showing its highlight — a separator touching a
+              // highlighted row (its own, or the previous row's hairline just
+              // above it) hides so the hover shape reads as one clean block.
+              property int hoveredRow: -1
+              function rowActive(i) {
+                return chronoRows.hoveredRow === i
+                  || (i >= 0 && i < root.regularThreads.length
+                      && root.cursor === root.threadIndex(root.regularThreads[i]))
+              }
 
-                HoverHandler { id: rowHover }
-                TapHandler { onTapped: root.openThread(modelData) }
+              Repeater {
+                model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.regularThreads : []
+                delegate: Rectangle {
+                  required property var modelData
+                  required property int index
 
-                RowLayout {
-                  id: rowRow
-                  anchors.fill: parent
-                  anchors.margins: Style.space(6)
-                  spacing: Style.space(8)
+                  Layout.fillWidth: true
+                  implicitHeight: rowRow.implicitHeight + root.space(root.splitView ? 30 : 18)
+                  radius: root.corner(Style.cornerRadius)
+                  color: rowHover.hovered || root.cursor === root.threadIndex(modelData)
+                    ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+                    : "transparent"
 
-                  // the iMessage blue dot — present only while the thread has
-                  // unread inbound; the slot stays so names line up.
-                  Rectangle {
-                    width: Style.space(9); height: width; radius: width / 2
-                    color: root.mineFill
-                    opacity: modelData.unread > 0 ? 1 : 0
+                  HoverHandler {
+                    id: rowHover
+                    onHoveredChanged: {
+                      if (hovered) chronoRows.hoveredRow = index
+                      else if (chronoRows.hoveredRow === index) chronoRows.hoveredRow = -1
+                    }
                   }
+                  TapHandler { onTapped: root.openThread(modelData) }
 
-                  // avatar circle — the contact's photo when Contacts has one,
-                  // initials otherwise (the iMessage sidebar look)
-                  Rectangle {
-                    id: avatarCircle
-                    // Messages' sidebar avatar is large relative to the row;
-                    // 30 looked like a contact list, not a conversation list.
-                    width: Style.space(34); height: width; radius: width / 2
-                    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
-                    // A group binds to ITS OWN chat id (its Messages group photo); a DM to
-                    // the person. Binding a group to `handle` showed whoever spoke last —
-                    // their cached contact photo one minute, initials the next.
-                    readonly property string avatarHandle: root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")
-                    Component.onCompleted: root.requestAvatar(avatarHandle)
-                    Image {
-                      id: avatarImg
-                      anchors.fill: parent
-                      visible: false
-                      source: root.avatarFiles[avatarCircle.avatarHandle] || ""
-                      asynchronous: true
-                      fillMode: Image.PreserveAspectCrop
-                      autoTransform: true
-                      sourceSize.width: 96
-                      sourceSize.height: 96
-                      // a stale/corrupt cache file → initials, and no retry this session
-                      onStatusChanged: if (status === Image.Error && avatarCircle.avatarHandle !== "") {
-                        var m = Object.assign({}, root.avatarFiles); m[avatarCircle.avatarHandle] = ""; root.avatarFiles = m
+                  RowLayout {
+                    id: rowRow
+                    anchors.fill: parent
+                    anchors.margins: root.space(6)
+                    spacing: root.space(8)
+
+                    // the iMessage blue dot — present only while the thread has
+                    // unread inbound; the slot stays so names line up.
+                    Rectangle {
+                      width: root.space(9); height: width; radius: width / 2
+                      color: root.mineFill
+                      opacity: modelData.unread > 0 ? 1 : 0
+                    }
+
+                    // avatar circle — the contact's photo when Contacts has one,
+                    // initials otherwise (the iMessage sidebar look)
+                    Rectangle {
+                      id: avatarCircle
+                      width: Math.max(1, Math.round(Style.spaceReal(root.avatarSize))); height: width; radius: width / 2
+                      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+                      // A group binds to ITS OWN chat id (its Messages group photo); a DM to
+                      // the person. Binding a group to `handle` showed whoever spoke last —
+                      // their cached contact photo one minute, initials the next.
+                      readonly property string avatarHandle: root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")
+                      Component.onCompleted: root.requestAvatar(avatarHandle)
+                      Image {
+                        id: avatarImg
+                        anchors.fill: parent
+                        visible: false
+                        source: root.avatarFiles[avatarCircle.avatarHandle] || ""
+                        asynchronous: true
+                        fillMode: Image.PreserveAspectCrop
+                        autoTransform: true
+                        sourceSize.width: 96
+                        sourceSize.height: 96
+                        // a stale/corrupt cache file → initials, and no retry this session
+                        onStatusChanged: if (status === Image.Error && avatarCircle.avatarHandle !== "") {
+                          var m = Object.assign({}, root.avatarFiles); m[avatarCircle.avatarHandle] = ""; root.avatarFiles = m
+                        }
                       }
-                    }
-                    Item {
-                      id: avatarMask
-                      anchors.fill: parent
-                      visible: false
-                      layer.enabled: true
-                      Rectangle { anchors.fill: parent; radius: width / 2 }
-                    }
-                    MultiEffect {
-                      anchors.fill: parent
-                      source: avatarImg
-                      visible: avatarImg.status === Image.Ready
-                      maskEnabled: true
-                      maskSource: avatarMask
-                    }
-                    Text {
-                      anchors.centerIn: parent
-                      visible: avatarImg.status !== Image.Ready
-                      text: root.avatarInitials(modelData)
-                      color: root.foreground
-                      font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
-                      font.bold: true
-                    }
-                  }
-
-                  ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: Style.space(1)
-                    RowLayout {
-                      Layout.fillWidth: true
-                      spacing: Style.space(6)
+                      Item {
+                        id: avatarMask
+                        anchors.fill: parent
+                        visible: false
+                        layer.enabled: true
+                        Rectangle { anchors.fill: parent; radius: width / 2 }
+                      }
+                      MultiEffect {
+                        anchors.fill: parent
+                        source: avatarImg
+                        visible: avatarImg.status === Image.Ready
+                        maskEnabled: true
+                        maskSource: avatarMask
+                      }
                       Text {
-                        Layout.fillWidth: true
-                        text: String(modelData.name || modelData.chat)
-                        textFormat: Text.PlainText
-                        elide: Text.ElideRight
+                        anchors.centerIn: parent
+                        visible: avatarImg.status !== Image.Ready
+                        text: root.avatarInitials(modelData)
                         color: root.foreground
                         font.family: root.fontFamily
-                        font.pixelSize: Style.font.bodySmall
-                        // Messages keeps the name semibold ALWAYS; unread is
-                        // carried by the dot and the blue timestamp, not by
-                        // the name suddenly changing weight.
-                        font.weight: modelData.unread > 0 ? Font.Bold : Font.DemiBold
-                      }
-                      Text {
-                        text: root.fmtTime(modelData.last_ts)
-                        textFormat: Text.PlainText
-                        color: modelData.unread > 0 ? root.mineFill : root.dim
-                        font.family: root.fontFamily
-                        font.pixelSize: Style.font.caption
+                        font.pixelSize: root.fontSize(Style.font.caption)
+                        font.bold: true
                       }
                     }
-                    // TWO lines, wrapped — the single most recognisable thing
-                    // about the Messages sidebar. One elided line reads like a
-                    // mail client; two lines of preview reads like Messages.
-                    Text {
+
+                    ColumnLayout {
                       Layout.fillWidth: true
-                      text: (modelData.last_from_me ? "You: " : "") + String(modelData.last_text || "")
-                      textFormat: Text.PlainText
-                      wrapMode: Text.Wrap
-                      elide: Text.ElideRight
-                      maximumLineCount: 2
-                      color: root.dim
-                      font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
-                      lineHeight: 1.15
+                      spacing: root.space(1)
+                      RowLayout {
+                        Layout.fillWidth: true
+                        spacing: root.space(6)
+                        Text {
+                          Layout.fillWidth: true
+                          text: String(modelData.name || modelData.chat)
+                          textFormat: Text.PlainText
+                          elide: Text.ElideRight
+                          color: root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: root.fontSize(Style.font.bodySmall)
+                          // Messages keeps the name semibold ALWAYS; unread is
+                          // carried by the dot and the blue timestamp, not by
+                          // the name suddenly changing weight.
+                          font.weight: modelData.unread > 0 ? Font.Bold : Font.DemiBold
+                        }
+                        Text {
+                          text: root.fmtTime(modelData.last_ts)
+                          textFormat: Text.PlainText
+                          color: modelData.unread > 0 ? root.mineFill : root.dim
+                          font.family: root.fontFamily
+                          font.pixelSize: root.fontSize(Style.font.caption)
+                        }
+                      }
+                      // TWO lines, wrapped — the single most recognisable thing
+                      // about the Messages sidebar. One elided line reads like a
+                      // mail client; two lines of preview reads like Messages.
+                      Text {
+                        Layout.fillWidth: true
+                        text: (modelData.last_from_me ? "You: " : "") + String(modelData.last_text || "")
+                        textFormat: Text.PlainText
+                        wrapMode: Text.Wrap
+                        elide: Text.ElideRight
+                        maximumLineCount: 2
+                        color: root.dim
+                        font.family: root.fontFamily
+                        font.pixelSize: root.fontSize(Style.font.caption)
+                        lineHeight: 1.15
+                      }
                     }
+
                   }
 
+                  // Messages separates chronological conversations with a
+                  // hairline that begins after the avatar rather than cutting
+                  // through the unread-dot/avatar gutter.
+                  Rectangle {
+                    anchors.left: parent.left
+                    anchors.leftMargin: root.space(6 + 9 + 8) + avatarCircle.width + root.space(8)
+                    anchors.right: parent.right
+                    anchors.rightMargin: root.space(6)
+                    anchors.bottom: parent.bottom
+                    height: Math.max(1, Math.round(Style.spaceReal(1)))
+                    visible: index < root.regularThreads.length - 1
+                             && !chronoRows.rowActive(index) && !chronoRows.rowActive(index + 1)
+                    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.10)
+                  }
                 }
               }
             }
@@ -1925,17 +2102,26 @@ FocusScope {
         anchors.fill: parent
         // Gutters for the app: the popout's card supplies its own padding,
         // the window's panes had text flush against the borders (Fred).
-        anchors.leftMargin: root.splitView ? Style.space(18) : 0
-        anchors.rightMargin: root.splitView ? Style.space(18) : 0
-        anchors.topMargin: root.splitView ? Style.space(10) : 0
-        anchors.bottomMargin: root.splitView ? Style.space(10) : 0
-        spacing: Style.space(8)
+        anchors.leftMargin: root.splitView ? root.space(18) : 0
+        anchors.rightMargin: root.splitView ? root.space(18) : 0
+        anchors.topMargin: root.splitView ? root.space(10) : 0
+        anchors.bottomMargin: root.splitView ? root.space(10) : 0
+        spacing: root.space(8)
         RowLayout {
           Layout.fillWidth: true
-          spacing: Style.space(8)
+          Layout.preferredHeight: root.splitView
+            ? root.splitHeaderHeight
+            : conversationHero.implicitHeight
+          spacing: root.space(8)
           PanelHero {
+            id: conversationHero
+            visible: !root.splitView
             Layout.fillWidth: true
-            title: root.inThread ? String(root.active.name || root.active.chat) : "Select a conversation"
+            // Pinned group names are Messages' user-facing title. `name` can
+            // still be the opaque chatNNN id carried by message rows.
+            title: root.inThread
+              ? String(root.active.pin_name || root.active.name || root.active.chat)
+              : "Select a conversation"
             meta: root.inThread
               ? (root.activeIsGroup
                   ? (root.isSendable(root.active) ? "group" : "group · read-only (id unknown)")
@@ -1947,17 +2133,60 @@ FocusScope {
             foreground: root.foreground
             fontFamily: root.fontFamily
           }
+
+          // Match the sidebar's fixed one-line header in the app. Keeping the
+          // title and metadata inline makes empty and selected states identical
+          // in height, so the separator, message viewport, and composer stay put.
+          RowLayout {
+            id: splitConversationHero
+            visible: root.splitView
+            Layout.alignment: Qt.AlignVCenter
+            spacing: root.space(8)
+            Text {
+              Layout.maximumWidth: Math.max(root.space(160), conversationPane.width * 0.50)
+              text: root.inThread
+                ? String(root.active.pin_name || root.active.name || root.active.chat)
+                : "Select a conversation"
+              textFormat: Text.PlainText
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.title
+              font.bold: true
+              elide: Text.ElideRight
+            }
+            Text {
+              Layout.maximumWidth: Math.max(root.space(120), conversationPane.width * 0.32)
+              visible: root.inThread
+              text: !root.inThread
+                ? ""
+                : (root.activeIsGroup
+                  ? (root.isSendable(root.active) ? "GROUP" : "GROUP · READ-ONLY (ID UNKNOWN)")
+                  : String(root.active.handle))
+              textFormat: Text.PlainText
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+              font.letterSpacing: 1.2
+              elide: Text.ElideRight
+            }
+          }
+          Item {
+            id: conversationHeaderSpacer
+            visible: root.splitView
+            Layout.fillWidth: true
+          }
           // The app's NEW button lives up here (where "Esc = back" used to be).
           PanelActionButton {
             visible: root.splitView && !root.newMode
-            Layout.alignment: Qt.AlignTop
-            Layout.topMargin: Style.space(6)
+            Layout.alignment: Qt.AlignVCenter
             iconText: "＋"
             tooltipText: "New message (n)"
-            bordered: true
+            bordered: false
             foreground: root.foreground
             hoverColor: root.accent
             fontFamily: root.fontFamily
+            fontSize: root.fontSize(Style.font.icon)
             onClicked: root.startNew()
           }
         }
@@ -2035,7 +2264,7 @@ FocusScope {
           ColumnLayout {
             id: content
             width: parent.width
-            spacing: root.inThread ? Style.space(2) : Style.space(6)
+            spacing: root.inThread ? root.space(2) : root.space(6)
 
             // ------------------------------------------- CONVERSATION
             Text {
@@ -2045,7 +2274,7 @@ FocusScope {
               horizontalAlignment: Text.AlignHCenter
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
             }
 
             Repeater {
@@ -2054,9 +2283,23 @@ FocusScope {
                 id: bubbleRow
                 required property var modelData
                 readonly property bool mine: modelData.from_me === true
+                readonly property bool incomingGroup: root.activeIsGroup && !mine
+                readonly property bool runEndsHere: incomingGroup && modelData.groupEnd === true
+                readonly property bool hasTextBubble:
+                  !modelData.retracted &&
+                  (String(modelData.text || "") !== "" || (modelData.attachments || []).length === 0) &&
+                  modelData.linkOnly !== true
+                readonly property bool hasLinkCard: !modelData.retracted && !!modelData.link
+                readonly property int attachmentCount:
+                  modelData.retracted ? 0 : (modelData.attachments || []).length
 
                 Layout.fillWidth: true
-                spacing: Style.space(2)
+                spacing: root.space(2)
+
+                TapHandler {
+                  acceptedButtons: Qt.RightButton
+                  onTapped: root.openMessageContext(String(modelData.text || ""))
+                }
 
                 // day divider — "Today", "Yesterday", "Aug 28"
                 Text {
@@ -2066,23 +2309,24 @@ FocusScope {
                   horizontalAlignment: Text.AlignHCenter
                   color: root.dim
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.caption
+                  font.pixelSize: root.fontSize(Style.font.caption)
                   font.bold: true
-                  topPadding: Style.space(10)
-                  bottomPadding: Style.space(4)
+                  topPadding: root.space(10)
+                  bottomPadding: root.space(4)
                 }
 
                 // in a group, iMessage names the sender above each run of theirs
                 Text {
                   Layout.alignment: Qt.AlignLeft
-                  Layout.leftMargin: Style.space(10)
-                  Layout.topMargin: Style.space(6)
+                  Layout.leftMargin: root.space(10)
+                    + (bubbleRow.incomingGroup ? root.groupMessageAvatarSlot : 0)
+                  Layout.topMargin: root.space(6)
                   visible: root.activeIsGroup && !bubbleRow.mine && modelData.groupStart === true
                   text: String(modelData.name || "")
                   textFormat: Text.PlainText
                   color: root.dim
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.caption
+                  font.pixelSize: root.fontSize(Style.font.caption)
                 }
 
                 // "You unsent a message" tombstone replaces a retracted bubble
@@ -2091,14 +2335,20 @@ FocusScope {
                   visible: modelData.retracted === true
                   spacing: 0
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
+                  GroupMessageAvatarSlot {
+                    reserve: bubbleRow.incomingGroup
+                    handle: String(modelData.handle || "")
+                    name: String(modelData.name || "")
+                    showAvatar: bubbleRow.runEndsHere
+                  }
                   Text {
                     text: (bubbleRow.mine ? "You" : String(modelData.name || "They")) + " unsent a message"
                     textFormat: Text.PlainText
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
                     font.italic: true
-                    padding: Style.space(4)
+                    padding: root.space(4)
                   }
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }
                 }
@@ -2107,28 +2357,34 @@ FocusScope {
                 RowLayout {
                   Layout.fillWidth: true
                   visible: !modelData.retracted && String(modelData.replyText || "") !== ""
-                  Layout.topMargin: modelData.groupStart ? Style.space(6) : 0
+                  Layout.topMargin: modelData.groupStart ? root.space(6) : 0
                   spacing: 0
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
+                  GroupMessageAvatarSlot {
+                    reserve: bubbleRow.incomingGroup
+                    handle: String(modelData.handle || "")
+                    name: String(modelData.name || "")
+                    showAvatar: false
+                  }
                   Rectangle {
-                    Layout.preferredWidth: Math.min(Math.ceil(replySnippet.implicitWidth) + Style.space(18), Math.round(content.width * 0.7))
-                    Layout.preferredHeight: Math.ceil(replySnippet.implicitHeight) + Style.space(10)
-                    radius: Style.space(12)
+                    Layout.preferredWidth: Math.min(Math.ceil(replySnippet.implicitWidth) + root.space(18), Math.round(content.width * 0.7))
+                    Layout.preferredHeight: Math.ceil(replySnippet.implicitHeight) + root.space(10)
+                    radius: root.corner(root.space(12))
                     color: "transparent"
                     border.color: root.dim
                     border.width: 1
                     opacity: 0.75
                     Text {
                       id: replySnippet
-                      x: Style.space(9); y: Style.space(5)
-                      width: Math.round(content.width * 0.7) - Style.space(18)
+                      x: root.space(9); y: root.space(5)
+                      width: Math.round(content.width * 0.7) - root.space(18)
                       text: "↩ " + (modelData.replyMine ? "You: " : "") + String(modelData.replyText || "")
                       textFormat: Text.PlainText
                       elide: Text.ElideRight
                       maximumLineCount: 1
                       color: root.dim
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
+                      font.pixelSize: root.fontSize(Style.font.caption)
                     }
                   }
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }
@@ -2165,20 +2421,45 @@ FocusScope {
                     readonly property string attId: String(modelData.id || "")
                     // undefined = not fetched, "" = failed, else file:// url
                     readonly property var fileUrl: root.attFiles[chipRow.attId]
+                    readonly property var imageMetrics: root.attMetrics[chipRow.attId] || ({})
                     readonly property bool failed: chipRow.fileUrl === ""
                     readonly property bool showImage:
                       root.isImageMime(chipRow.modelData.mime) &&
                       chipRow.fileUrl !== undefined && chipRow.fileUrl !== ""
                     Layout.fillWidth: true
-                    Layout.topMargin: index === 0 && bubbleRow.modelData.groupStart ? Style.space(6) : 0
+                    Layout.topMargin: index === 0 && bubbleRow.modelData.groupStart ? root.space(6) : 0
                     spacing: 0
                     Item { Layout.fillWidth: true; visible: bubbleRow.mine }
+                    GroupMessageAvatarSlot {
+                      reserve: bubbleRow.incomingGroup
+                      handle: String(bubbleRow.modelData.handle || "")
+                      name: String(bubbleRow.modelData.name || "")
+                      showAvatar: bubbleRow.runEndsHere &&
+                        !bubbleRow.hasTextBubble && !bubbleRow.hasLinkCard &&
+                        index === bubbleRow.attachmentCount - 1
+                    }
 
                     // fetched image renders inline, like Messages; click = full view
                     Image {
                       id: attImage
                       visible: chipRow.showImage
-                      readonly property real maxW: Math.round(content.width * 0.6)
+                      // A phone screenshot can be thousands of source pixels
+                      // wide. Size media in logical UI units so a wide desktop
+                      // window (especially on a 2× display) does not turn it
+                      // into a nearly full-width wall.
+                      readonly property real maxW: Math.min(
+                        Math.round(content.width * 0.6), root.space(380)
+                      )
+                      readonly property real pixelRatio:
+                        Number(chipRow.imageMetrics.pixelRatio || 1)
+                      readonly property real naturalWidth:
+                        Number(chipRow.imageMetrics.pixelWidth || 0) > 0
+                          ? Number(chipRow.imageMetrics.pixelWidth) / pixelRatio
+                          : implicitWidth
+                      readonly property real naturalHeight:
+                        Number(chipRow.imageMetrics.pixelHeight || 0) > 0
+                          ? Number(chipRow.imageMetrics.pixelHeight) / pixelRatio
+                          : implicitHeight
                       source: chipRow.showImage ? chipRow.fileUrl : ""
                       asynchronous: true
                       fillMode: Image.PreserveAspectFit
@@ -2199,19 +2480,19 @@ FocusScope {
                         m[chipRow.attId] = ""
                         root.attFiles = m
                       }
-                      Layout.preferredWidth: status === Image.Ready ? Math.min(maxW, implicitWidth) : maxW
-                      Layout.preferredHeight: status === Image.Ready && implicitWidth > 0
-                        ? Layout.preferredWidth * implicitHeight / implicitWidth
-                        : Style.space(120)
+                      Layout.preferredWidth: status === Image.Ready ? Math.min(maxW, naturalWidth) : maxW
+                      Layout.preferredHeight: status === Image.Ready && naturalWidth > 0
+                        ? Layout.preferredWidth * naturalHeight / naturalWidth
+                        : root.space(120)
                       HoverHandler { cursorShape: Qt.PointingHandCursor }
                       TapHandler { onTapped: root.openAttachment(chipRow.modelData) }
                     }
 
                     Rectangle {
                       visible: !chipRow.showImage
-                      Layout.preferredWidth: Math.ceil(chipText.implicitWidth) + Style.space(18)
-                      Layout.preferredHeight: Math.ceil(chipText.implicitHeight) + Style.space(12)
-                      radius: Style.space(14)
+                      Layout.preferredWidth: Math.ceil(chipText.implicitWidth) + root.space(18)
+                      Layout.preferredHeight: Math.ceil(chipText.implicitHeight) + root.space(12)
+                      radius: root.corner(root.space(14))
                       color: bubbleRow.mine ? root.mineFill : root.theirsFill
                       opacity: 0.85
                       Text {
@@ -2226,7 +2507,7 @@ FocusScope {
                         textFormat: Text.PlainText
                         color: bubbleRow.mine ? root.mineText : root.theirsText
                         font.family: root.fontFamily
-                        font.pixelSize: Style.font.caption
+                        font.pixelSize: root.fontSize(Style.font.caption)
                       }
                       HoverHandler { cursorShape: Qt.PointingHandCursor }
                       TapHandler { onTapped: root.openAttachment(chipRow.modelData) }
@@ -2248,7 +2529,9 @@ FocusScope {
                   onBareUrlChanged: if (bareUrl !== "") root.requestPreview(bareUrl)
                   visible: !modelData.retracted && (!!modelData.link || !!fetched)
                   Layout.fillWidth: true
-                  Layout.topMargin: modelData.groupStart ? Style.space(6) : 0
+                  Layout.topMargin: (modelData.groupStart ? root.space(6) : 0)
+                    + ((modelData.tapbacks || []).length > 0
+                      ? root.space(23) : 0)
                   spacing: 0
                   // same anchoring as the chips: a card image completing ABOVE
                   // the viewport must not shove the reader's position.
@@ -2263,82 +2546,108 @@ FocusScope {
                       flick.contentY = Math.max(0, flick.contentY + d)
                   }
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
-                  Rectangle {
-                    id: linkCard
-                    readonly property var link: modelData.link || linkRow.fetched || ({})
-                    // Apple's preview is an attachment id fetched over ssh;
-                    // ours is already a file on disk.
-                    readonly property string imgUrl: modelData.link
-                      ? (link.image_id ? String(root.attFiles[String(link.image_id)] || "") : "")
-                      : String((linkRow.fetched && linkRow.fetched.image) || "")
-                    Layout.preferredWidth: Math.min(Math.round(content.width * 0.62), Style.space(380))
-                    Layout.preferredHeight: linkCol.implicitHeight
-                    radius: Style.space(14)
-                    clip: true
-                    color: bubbleRow.mine ? root.mineFill : root.theirsFill
-                    ColumnLayout {
-                      id: linkCol
+                  GroupMessageAvatarSlot {
+                    reserve: bubbleRow.incomingGroup
+                    handle: String(modelData.handle || "")
+                    name: String(modelData.name || "")
+                    showAvatar: bubbleRow.runEndsHere && !bubbleRow.hasTextBubble
+                  }
+                  Item {
+                    id: linkCardWrap
+                    Layout.preferredWidth: Math.min(Math.round(content.width * 0.62), root.space(380))
+                    Layout.preferredHeight: linkCard.height
+
+                    Rectangle {
+                      id: linkCard
                       width: parent.width
-                      spacing: 0
-                      Image {
-                        id: linkImage
-                        visible: linkCard.imgUrl !== "" && status === Image.Ready
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: visible && implicitWidth > 0
-                          ? Math.min(Style.space(220), Math.round(linkCard.width * implicitHeight / implicitWidth))
-                          : 0
-                        source: linkCard.imgUrl
-                        asynchronous: true
-                        fillMode: Image.PreserveAspectCrop
-                        autoTransform: true
-                        sourceSize.width: 800
-                        sourceSize.height: 800
-                      }
+                      height: linkCol.implicitHeight
+                      readonly property var link: modelData.link || linkRow.fetched || ({})
+                      // Apple's preview is an attachment id fetched over ssh;
+                      // ours is already a file on disk.
+                      readonly property string imgUrl: modelData.link
+                        ? (link.image_id ? String(root.attFiles[String(link.image_id)] || "") : "")
+                        : String((linkRow.fetched && linkRow.fetched.image) || "")
+                      radius: root.corner(root.space(14))
+                      clip: true
+                      color: bubbleRow.mine ? root.mineFill : root.theirsFill
                       ColumnLayout {
-                        Layout.fillWidth: true
-                        Layout.margins: Style.space(10)
-                        spacing: Style.space(2)
-                        Text {
+                        id: linkCol
+                        width: parent.width
+                        spacing: 0
+                        Image {
+                          id: linkImage
+                          visible: linkCard.imgUrl !== "" && status === Image.Ready
                           Layout.fillWidth: true
-                          visible: text !== ""
-                          text: String(linkCard.link.title || "")
-                          textFormat: Text.PlainText
-                          wrapMode: Text.Wrap
-                          maximumLineCount: 2
-                          elide: Text.ElideRight
-                          color: bubbleRow.mine ? root.mineText : root.theirsText
-                          font.family: root.fontFamily
-                          font.pixelSize: Style.font.bodySmall
-                          font.bold: true
+                          // Link artwork is often portrait or square. Preserve
+                          // its natural aspect ratio instead of clipping every
+                          // preview to the old shallow 220-unit banner.
+                          Layout.preferredHeight: visible && implicitWidth > 0
+                            ? Math.min(root.space(480),
+                                Math.round(linkCard.width * implicitHeight / implicitWidth))
+                            : 0
+                          source: linkCard.imgUrl
+                          asynchronous: true
+                          fillMode: Image.PreserveAspectFit
+                          autoTransform: true
+                          sourceSize.width: 960
+                          sourceSize.height: 960
                         }
-                        Text {
+                        ColumnLayout {
                           Layout.fillWidth: true
-                          visible: text !== ""
-                          text: String(linkCard.link.summary || "")
-                          textFormat: Text.PlainText
-                          wrapMode: Text.Wrap
-                          maximumLineCount: 2
-                          elide: Text.ElideRight
-                          color: bubbleRow.mine ? root.mineText : root.theirsText
-                          opacity: 0.85
-                          font.family: root.fontFamily
-                          font.pixelSize: Style.font.caption
+                          Layout.margins: root.space(10)
+                          spacing: root.space(2)
+                          Text {
+                            Layout.fillWidth: true
+                            visible: text !== ""
+                            text: String(linkCard.link.title || "")
+                            textFormat: Text.PlainText
+                            wrapMode: Text.Wrap
+                            maximumLineCount: 2
+                            elide: Text.ElideRight
+                            color: bubbleRow.mine ? root.mineText : root.theirsText
+                            font.family: root.fontFamily
+                            font.pixelSize: root.fontSize(Style.font.bodySmall)
+                            font.bold: true
+                          }
+                          Text {
+                            Layout.fillWidth: true
+                            visible: text !== ""
+                            text: String(linkCard.link.summary || "")
+                            textFormat: Text.PlainText
+                            wrapMode: Text.Wrap
+                            maximumLineCount: 2
+                            elide: Text.ElideRight
+                            color: bubbleRow.mine ? root.mineText : root.theirsText
+                            opacity: 0.85
+                            font.family: root.fontFamily
+                            font.pixelSize: root.fontSize(Style.font.caption)
+                          }
+                          Text {
+                            Layout.fillWidth: true
+                            text: root.linkHost(String(linkCard.link.url || ""))
+                            textFormat: Text.PlainText
+                            elide: Text.ElideRight
+                            color: bubbleRow.mine ? root.mineText : root.theirsText
+                            opacity: 0.6
+                            font.family: root.fontFamily
+                            font.pixelSize: root.fontSize(Style.font.caption)
+                          }
                         }
-                        Text {
-                          Layout.fillWidth: true
-                          text: root.linkHost(String(linkCard.link.url || ""))
-                          textFormat: Text.PlainText
-                          elide: Text.ElideRight
-                          color: bubbleRow.mine ? root.mineText : root.theirsText
-                          opacity: 0.6
-                          font.family: root.fontFamily
-                          font.pixelSize: Style.font.caption
-                        }
+                      }
+                      HoverHandler { cursorShape: Qt.PointingHandCursor }
+                      TapHandler { onTapped: root.openLink(String(linkCard.link.url || "")) }
+                      TapHandler {
+                        acceptedButtons: Qt.RightButton
+                        onTapped: root.openShare(String(linkCard.link.url || ""))
                       }
                     }
-                    HoverHandler { cursorShape: Qt.PointingHandCursor }
-                    TapHandler { onTapped: root.openLink(String(linkCard.link.url || "")) }
-                    TapHandler { acceptedButtons: Qt.RightButton; onTapped: root.openShare(String(linkCard.link.url || "")) }
+
+                    TapbackReaction {
+                      mine: bubbleRow.mine
+                      // Messages anchors the reaction to the unfurled card,
+                      // including when the shared URL also has a caption.
+                      reactions: modelData.tapbacks || []
+                    }
                   }
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }
                 }
@@ -2348,47 +2657,108 @@ FocusScope {
                 // when the delegate's own width collapses to its content.
                 RowLayout {
                   Layout.fillWidth: true
-                  // a tapback pill overlaps the top edge — leave room for it
-                  Layout.topMargin: (modelData.groupStart ? Style.space(6) : 0)
-                                    + ((modelData.tapbacks || []).length > 0 ? Style.space(12) : 0)
+                  // A Messages-sized tapback pill overlaps the top edge —
+                  // reserve its raised portion so adjacent runs stay clear.
+                  Layout.topMargin: (modelData.groupStart ? root.space(6) : 0)
+                                    + ((modelData.tapbacks || []).length > 0 && !modelData.link
+                                      ? root.space(23) : 0)
                   visible: !modelData.retracted &&
                            (String(modelData.text || "") !== "" || (modelData.attachments || []).length === 0) &&
-                           // a message that is ONLY the URL shows just the card,
-                           // like Messages — for Apple's card and for ours
-                           !(modelData.link && String(modelData.text || "").trim() === String(modelData.link.url)) &&
+                           // URL-only messages show just the unfurled card. The
+                           // model handles Apple's canonicalized URL, while the
+                           // live check covers cards Blip fetched itself.
+                           modelData.linkOnly !== true &&
                            !(!modelData.link && !!linkRow.fetched
                              && String(modelData.text || "").trim() === linkRow.bareUrl)
                   spacing: 0
 
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
+                  GroupMessageAvatarSlot {
+                    reserve: bubbleRow.incomingGroup
+                    handle: String(modelData.handle || "")
+                    name: String(modelData.name || "")
+                    showAvatar: bubbleRow.runEndsHere
+                  }
 
-                  Rectangle {
+                  Item {
                     id: bubble
-                    readonly property real maxInner: Math.round(content.width * 0.78) - Style.space(22)
-                    Layout.preferredWidth: Math.ceil(bubbleText.contentWidth) + Style.space(22)
-                    Layout.preferredHeight: Math.ceil(bubbleText.contentHeight) + Style.space(14)
-                    radius: Style.space(16)
-                    color: bubbleRow.mine ? root.mineFill : root.theirsFill
+                    readonly property bool expressiveEmoji: modelData.emojiOnly === true
+                    readonly property real maxInner: Math.round(content.width * 0.78) - root.space(22)
+                    readonly property real bubbleRadius: root.corner(root.space(16))
+                    readonly property color color: bubbleRow.mine ? root.mineFill : root.theirsFill
+                    Layout.preferredWidth: Math.ceil(bubbleText.contentWidth)
+                      + (expressiveEmoji ? 0 : root.space(22))
+                    Layout.preferredHeight: Math.ceil(bubbleText.contentHeight)
+                      + (expressiveEmoji ? 0 : root.space(14))
 
-                    // iMessage squares off the corner nearest the sender on the
-                    // last bubble of a run — the "tail" without drawing a tail.
-                    // Per-corner radius (Qt 6.7+), NOT a second Rectangle over
-                    // the corner: theirsFill is translucent, and stacking two
-                    // copies of it double-alphas the overlap into a visibly
-                    // lighter square (seen on every received run-ending bubble).
-                    bottomLeftRadius: modelData.groupEnd === true && !bubbleRow.mine ? 0 : radius
-                    bottomRightRadius: modelData.groupEnd === true && bubbleRow.mine ? 0 : radius
+                    // One path draws the rounded bubble and its squared sender
+                    // corner. The old translucent Rectangle + overlapping
+                    // corner Rectangle composited twice and made that corner
+                    // visibly darker on incoming bubbles.
+                    Shape {
+                      visible: !bubble.expressiveEmoji
+                      anchors.fill: parent
+                      antialiasing: true
+                      ShapePath {
+                        id: bubblePath
+                        readonly property real r: Math.min(
+                          bubble.bubbleRadius, bubble.width / 2, bubble.height / 2
+                        )
+                        readonly property bool squareRight:
+                          modelData.groupEnd === true && bubbleRow.mine
+                        readonly property bool squareLeft:
+                          modelData.groupEnd === true && !bubbleRow.mine
+                        strokeColor: "transparent"
+                        fillColor: bubble.color
+                        startX: r
+                        startY: 0
+                        PathLine { x: bubble.width - bubblePath.r; y: 0 }
+                        PathQuad {
+                          x: bubble.width; y: bubblePath.r
+                          controlX: bubble.width; controlY: 0
+                        }
+                        PathLine {
+                          x: bubble.width
+                          y: bubblePath.squareRight ? bubble.height : bubble.height - bubblePath.r
+                        }
+                        PathQuad {
+                          x: bubblePath.squareRight ? bubble.width : bubble.width - bubblePath.r
+                          y: bubble.height
+                          controlX: bubble.width; controlY: bubble.height
+                        }
+                        PathLine {
+                          x: bubblePath.squareLeft ? 0 : bubblePath.r
+                          y: bubble.height
+                        }
+                        PathQuad {
+                          x: 0
+                          y: bubblePath.squareLeft ? bubble.height : bubble.height - bubblePath.r
+                          controlX: 0; controlY: bubble.height
+                        }
+                        PathLine { x: 0; y: bubblePath.r }
+                        PathQuad {
+                          x: bubblePath.r; y: 0
+                          controlX: 0; controlY: 0
+                        }
+                      }
+                    }
 
                     // TextEdit, not Text: read-only but selectable, so a message
                     // can be highlighted and Ctrl+C'd like any other text.
                     TextEdit {
                       id: bubbleText
-                      x: Style.space(11); y: Style.space(7)
+                      x: bubble.expressiveEmoji ? 0 : root.space(11)
+                      y: bubble.expressiveEmoji ? 0 : root.space(7)
                       width: bubble.maxInner
                       // html is pre-escaped + linkified in thread.ts (tested);
                       // plain messages keep the cheap PlainText path.
                       readonly property bool hasLink: String(modelData.html || "") !== ""
-                      text: hasLink ? String(modelData.html) : String(modelData.text || "")
+                      text: hasLink
+                        ? root.richMessageHtml(
+                            modelData.html,
+                            bubbleRow.mine ? root.mineText : root.theirsText
+                          )
+                        : String(modelData.text || "")
                       textFormat: hasLink ? TextEdit.RichText : TextEdit.PlainText
                       // No onLinkActivated: the TapHandler below opens links (it
                       // survives selectByMouse); having both opened every link twice.
@@ -2400,7 +2770,11 @@ FocusScope {
                       selectionColor: bubbleRow.mine ? "#ffffff" : root.mineFill
                       selectedTextColor: bubbleRow.mine ? root.mineFill : "#ffffff"
                       font.family: root.fontFamily
-                      font.pixelSize: Style.font.bodySmall
+                      // macOS renders one-to-three emoji as expressive content:
+                      // roughly four body-text heights and without a chat bubble.
+                      font.pixelSize: bubble.expressiveEmoji
+                        ? Math.round(root.fontSize(Style.font.bodySmall) * 4.1)
+                        : root.fontSize(Style.font.bodySmall)
                       onActiveFocusChanged: root.bubbleFocused = activeFocus
                       Keys.onEscapePressed: { deselect(); composeField.forceActiveFocus() }
                       // Ctrl+C through wl-copy: Qt's own clipboard does not reliably
@@ -2426,39 +2800,22 @@ FocusScope {
                       }
                     }
 
-                    // right-click on a LINK = share sheet; anywhere else = copy the whole message
+                    // A link keeps its share action; any other bubble opens the
+                    // copy-message menu for this conversation.
                     TapHandler {
                       acceptedButtons: Qt.RightButton
                       onTapped: function(eventPoint) {
                         var p = bubbleText.mapFromItem(bubble, eventPoint.position.x, eventPoint.position.y)
                         var l = bubbleText.hasLink ? bubbleText.linkAt(p.x, p.y) : ""
                         if (l && l !== "") root.openShare(String(l))
-                        else root.copyText(String(modelData.text || ""))
+                        else root.openMessageContext(String(modelData.text || ""))
                       }
                     }
 
                     // tapback pill overlapping the corner opposite the tail
-                    Rectangle {
-                      visible: (modelData.tapbacks || []).length > 0
-                      width: Math.ceil(tapbackText.implicitWidth) + Style.space(12)
-                      height: Math.ceil(tapbackText.implicitHeight) + Style.space(8)
-                      radius: height / 2
-                      color: bubbleRow.mine ? Qt.darker(root.mineFill, 2.2) : root.mineFill
-                      border.color: Qt.rgba(0, 0, 0, 0.5)
-                      border.width: 2
-                      anchors.top: parent.top
-                      anchors.topMargin: -Style.space(12)
-                      anchors.right: bubbleRow.mine ? undefined : parent.right
-                      anchors.rightMargin: bubbleRow.mine ? 0 : -Style.space(6)
-                      anchors.left: bubbleRow.mine ? parent.left : undefined
-                      anchors.leftMargin: bubbleRow.mine ? -Style.space(6) : 0
-                      Text {
-                        id: tapbackText
-                        anchors.centerIn: parent
-                        text: root.tapbackRow(modelData.tapbacks)
-                        textFormat: Text.PlainText
-                        font.pixelSize: Style.font.caption
-                      }
+                    TapbackReaction {
+                      mine: bubbleRow.mine
+                      reactions: modelData.link ? [] : (modelData.tapbacks || [])
                     }
                   }
 
@@ -2474,9 +2831,15 @@ FocusScope {
                            modelData.failed === true
                   spacing: 0
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
+                  GroupMessageAvatarSlot {
+                    reserve: bubbleRow.incomingGroup
+                    handle: String(modelData.handle || "")
+                    name: String(modelData.name || "")
+                    showAvatar: false
+                  }
                   Text {
-                    Layout.rightMargin: bubbleRow.mine ? Style.space(6) : 0
-                    Layout.leftMargin: bubbleRow.mine ? 0 : Style.space(6)
+                    Layout.rightMargin: bubbleRow.mine ? root.space(6) : 0
+                    Layout.leftMargin: bubbleRow.mine ? 0 : root.space(6)
                     text: [modelData.failed === true ? "⚠ Not Delivered" : "",
                            String(modelData.time || ""),
                            modelData.edited === true ? "Edited" : "",
@@ -2487,8 +2850,8 @@ FocusScope {
                     color: modelData.failed === true ? root.urgent : root.dim
                     font.bold: modelData.failed === true
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
-                    bottomPadding: Style.space(4)
+                    font.pixelSize: root.fontSize(Style.font.caption)
+                    bottomPadding: root.space(4)
                   }
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }
                 }
@@ -2500,14 +2863,14 @@ FocusScope {
                   spacing: 0
                   Item { Layout.fillWidth: true }
                   Text {
-                    Layout.rightMargin: Style.space(6)
+                    Layout.rightMargin: root.space(6)
                     text: String(modelData.receipt || "")
                     textFormat: Text.PlainText
                     color: root.dim
                     font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
+                    font.pixelSize: root.fontSize(Style.font.caption)
                     font.bold: true
-                    bottomPadding: Style.space(4)
+                    bottomPadding: root.space(4)
                   }
                 }
 
@@ -2522,7 +2885,7 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.fontSize(Style.font.bodySmall)
             }
           }
         }
@@ -2533,15 +2896,19 @@ FocusScope {
           foreground: root.foreground
         }
 
-        // queued attachment — one per message; ✕ removes it
+        // queued attachment — one per message; ✕ removes it. A previewable
+        // image shows itself; everything else shows its filename.
         RowLayout {
           Layout.fillWidth: true
           visible: root.inThread && root.draftPath !== ""
           spacing: 0
           Rectangle {
-            Layout.preferredWidth: Math.ceil(draftText.implicitWidth) + Style.space(18)
-            Layout.preferredHeight: Math.ceil(draftText.implicitHeight) + Style.space(12)
-            radius: Style.space(14)
+            // the filename pill: non-image drafts, and images until (or
+            // unless) the preview decodes
+            visible: !(root.draftIsImage && draftImage.status === Image.Ready)
+            Layout.preferredWidth: Math.ceil(draftText.implicitWidth) + root.space(18)
+            Layout.preferredHeight: Math.ceil(draftText.implicitHeight) + root.space(12)
+            radius: root.corner(root.space(14))
             color: root.mineFill
             opacity: 0.9
             Text {
@@ -2553,7 +2920,49 @@ FocusScope {
               textFormat: Text.PlainText
               color: root.mineText
               font.family: root.fontFamily
-              font.pixelSize: Style.font.caption
+              font.pixelSize: root.fontSize(Style.font.caption)
+            }
+            HoverHandler { cursorShape: Qt.PointingHandCursor }
+            TapHandler { onTapped: root.clearDraft() }
+          }
+          Rectangle {
+            visible: root.draftIsImage && draftImage.status === Image.Ready
+            Layout.preferredWidth: draftImage.width + root.space(8)
+            Layout.preferredHeight: draftImage.height + root.space(8)
+            radius: root.corner(root.space(10))
+            color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.10)
+            border.width: 1
+            border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.25)
+            clip: true
+            Image {
+              id: draftImage
+              readonly property real fit: status === Image.Ready && implicitWidth > 0 && implicitHeight > 0
+                ? Math.min(1, Math.min(root.space(240) / implicitWidth, root.space(130) / implicitHeight))
+                : 1
+              anchors.centerIn: parent
+              width: implicitWidth * fit
+              height: implicitHeight * fit
+              source: root.draftIsImage && root.draftPath !== "" ? "file://" + root.draftPath : ""
+              asynchronous: true
+              autoTransform: true
+              fillMode: Image.PreserveAspectFit
+              sourceSize.width: 512
+              sourceSize.height: 512
+            }
+            Rectangle {
+              anchors.top: parent.top
+              anchors.right: parent.right
+              anchors.margins: root.space(4)
+              width: root.space(18); height: width; radius: width / 2
+              color: Qt.rgba(0, 0, 0, 0.55)
+              Text {
+                anchors.centerIn: parent
+                text: "✕"
+                textFormat: Text.PlainText
+                color: "#ffffff"
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+              }
             }
             HoverHandler { cursorShape: Qt.PointingHandCursor }
             TapHandler { onTapped: root.clearDraft() }
@@ -2564,7 +2973,7 @@ FocusScope {
         RowLayout {
           Layout.fillWidth: true
           visible: root.inThread
-          spacing: Style.space(6)
+          spacing: root.space(6)
 
           TextField {
             id: composeField
@@ -2581,7 +2990,7 @@ FocusScope {
             foreground: root.foreground
             accent: root.mineFill
             font.family: root.fontFamily
-            font.pixelSize: Style.font.bodySmall
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
             onAccepted: root.send()
             Keys.onEscapePressed: root.back()
             // Ctrl+V goes through paste.ts: an image on the clipboard becomes
@@ -2598,14 +3007,14 @@ FocusScope {
           // send button — the blue arrow circle (lit when text OR a file is queued)
           Rectangle {
             readonly property bool armed: composeField.text.trim() !== "" || root.draftPath !== ""
-            width: Style.space(28); height: width; radius: width / 2
+            width: root.space(28); height: width; radius: width / 2
             color: armed ? root.mineFill : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.15)
             Text {
               anchors.centerIn: parent
               text: "↑"
               color: parent.armed ? "#ffffff" : root.dim
               font.family: root.fontFamily
-              font.pixelSize: Style.font.body
+              font.pixelSize: root.fontSize(Style.font.body)
               font.bold: true
             }
             TapHandler { onTapped: root.send() }
@@ -2619,17 +3028,309 @@ FocusScope {
           textFormat: Text.PlainText
           color: root.note === "sending…" ? root.dim : root.urgent
           font.family: root.fontFamily
-          font.pixelSize: Style.font.caption
+          font.pixelSize: root.fontSize(Style.font.caption)
           wrapMode: Text.WordWrap
         }
       }
     }
   }
 
+  component TapbackReaction: Rectangle {
+    id: tapbackPill
+    required property bool mine
+    required property var reactions
+    visible: reactions.length > 0
+    z: 10
+    readonly property real minimumSize: Math.max(
+      root.space(32), Math.ceil(tapbackText.implicitHeight) + root.space(12)
+    )
+    width: Math.max(minimumSize, Math.ceil(tapbackText.implicitWidth) + root.space(18))
+    height: minimumSize
+    radius: height / 2
+    // Composite once against the theme background so the pill and its tail
+    // remain opaque where they overlap a translucent bubble or link card.
+    color: root.incomingColorSetting === "theme"
+      ? root.opaqueOver(
+          Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.28),
+          Color.background
+        )
+      : root.opaqueOver(Qt.darker(root.theirsFill, 1.2), Color.background)
+    border.width: 0
+    anchors.top: parent.top
+    anchors.topMargin: -Math.round(height * 0.74)
+    x: mine
+      ? -Math.round(width * 0.35)
+      : parent.width - width + Math.round(width * 0.35)
+
+    Rectangle {
+      id: tapbackTailLarge
+      width: Math.round(tapbackPill.height * 0.28)
+      height: width
+      radius: width / 2
+      color: tapbackPill.color
+      x: tapbackPill.mine ? 0 : tapbackPill.width - width
+      y: Math.round(tapbackPill.height * 0.76)
+    }
+    Rectangle {
+      id: tapbackTailSmall
+      width: Math.max(3, Math.round(tapbackPill.height * 0.14))
+      height: width
+      radius: width / 2
+      color: tapbackPill.color
+      x: tapbackPill.mine
+        ? -Math.round(tapbackPill.height * 0.08)
+        : tapbackPill.width - width + Math.round(tapbackPill.height * 0.08)
+      y: Math.round(tapbackPill.height * 1.08)
+    }
+    Text {
+      id: tapbackText
+      z: 1
+      anchors.centerIn: parent
+      text: root.tapbackRow(tapbackPill.reactions)
+      textFormat: Text.PlainText
+      font.pixelSize: root.fontSize(Style.font.heading)
+    }
+  }
+
+  // Incoming group runs share one avatar lane. Every message stays aligned,
+  // while only the final visual row from a sender actually paints the photo.
+  component GroupMessageAvatarSlot: Item {
+    id: groupAvatarSlot
+    required property bool reserve
+    required property string handle
+    required property string name
+    required property bool showAvatar
+    Layout.preferredWidth: reserve ? root.groupMessageAvatarSlot : 0
+    Layout.preferredHeight: showAvatar ? root.groupMessageAvatarSize : 1
+
+    function ensureAvatar() {
+      if (showAvatar && handle !== "") root.requestAvatar(handle)
+    }
+    Component.onCompleted: ensureAvatar()
+    onShowAvatarChanged: ensureAvatar()
+    onHandleChanged: ensureAvatar()
+
+    Rectangle {
+      id: groupAvatarCircle
+      visible: groupAvatarSlot.showAvatar
+      anchors.left: parent.left
+      anchors.bottom: parent.bottom
+      width: root.groupMessageAvatarSize
+      height: width
+      radius: width / 2
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+
+      Image {
+        id: groupAvatarImage
+        anchors.fill: parent
+        visible: false
+        source: root.avatarFiles[groupAvatarSlot.handle] || ""
+        asynchronous: true
+        fillMode: Image.PreserveAspectCrop
+        sourceSize.width: 96
+        sourceSize.height: 96
+        onStatusChanged: if (status === Image.Error && groupAvatarSlot.handle !== "") {
+          var files = Object.assign({}, root.avatarFiles)
+          files[groupAvatarSlot.handle] = ""
+          root.avatarFiles = files
+        }
+      }
+      Item {
+        id: groupAvatarMask
+        anchors.fill: parent
+        visible: false
+        layer.enabled: true
+        Rectangle { anchors.fill: parent; radius: width / 2 }
+      }
+      MultiEffect {
+        anchors.fill: parent
+        source: groupAvatarImage
+        visible: groupAvatarImage.status === Image.Ready
+        maskEnabled: true
+        maskSource: groupAvatarMask
+      }
+      Text {
+        anchors.centerIn: parent
+        visible: groupAvatarImage.status !== Image.Ready
+        text: {
+          var n = String(groupAvatarSlot.name || groupAvatarSlot.handle || "")
+          if (/^[+0-9]/.test(n) || n === "") return "#"
+          var parts = n.trim().split(/\s+/)
+          return (parts[0][0] + (parts.length > 1 ? parts[parts.length - 1][0] : "")).toUpperCase()
+        }
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+    }
+  }
+
+  component PinnedConversation: Item {
+    id: pinTile
+    required property var thread
+    property bool selected: false
+    readonly property int pinAvatarSize: Math.max(
+      Math.round(Style.spaceReal(root.avatarSize) * 1.75), root.space(48))
+    // The tile owns its height: avatar + name + even padding, so the
+    // hover/selection outline hugs the centered content instead of leaving
+    // a fixed-size tail below the label.
+    implicitHeight: pinContent.implicitHeight + root.space(12)
+    readonly property string avatarHandle: root.isGroupId(String(thread.chat || ""))
+      ? String(thread.chat)
+      : String(thread.handle || thread.chat || "")
+    readonly property string displayName: String(thread.pin_name || thread.name || thread.chat || "")
+
+    Rectangle {
+      anchors.fill: parent
+      radius: root.corner(root.space(12))
+      color: pinHover.hovered || pinTile.selected
+        ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+        : "transparent"
+    }
+
+    Column {
+      id: pinContent
+      anchors.centerIn: parent
+      width: parent.width - root.space(8)
+      spacing: root.space(4)
+
+      Item {
+        width: parent.width
+        height: pinTile.pinAvatarSize
+
+        Rectangle {
+          id: pinAvatar
+          anchors.horizontalCenter: parent.horizontalCenter
+          width: pinTile.pinAvatarSize
+          height: width
+          radius: width / 2
+          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+          Component.onCompleted: root.requestAvatar(pinTile.avatarHandle)
+
+          Image {
+            id: pinAvatarImage
+            anchors.fill: parent
+            visible: false
+            source: root.avatarFiles[pinTile.avatarHandle] || ""
+            asynchronous: true
+            fillMode: Image.PreserveAspectCrop
+            sourceSize.width: 128
+            sourceSize.height: 128
+            onStatusChanged: if (status === Image.Error && pinTile.avatarHandle !== "") {
+              var files = Object.assign({}, root.avatarFiles)
+              files[pinTile.avatarHandle] = ""
+              root.avatarFiles = files
+            }
+          }
+          Item {
+            id: pinAvatarMask
+            anchors.fill: parent
+            visible: false
+            layer.enabled: true
+            Rectangle { anchors.fill: parent; radius: width / 2 }
+          }
+          MultiEffect {
+            anchors.fill: parent
+            source: pinAvatarImage
+            visible: pinAvatarImage.status === Image.Ready
+            maskEnabled: true
+            maskSource: pinAvatarMask
+          }
+          Text {
+            anchors.centerIn: parent
+            visible: pinAvatarImage.status !== Image.Ready
+            text: {
+              var name = pinTile.displayName
+              if (/^[+0-9]/.test(name) || name === "") return "#"
+              var parts = name.trim().split(/\s+/)
+              return (parts[0][0] + (parts.length > 1 ? parts[parts.length - 1][0] : "")).toUpperCase()
+            }
+            textFormat: Text.PlainText
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+
+          Rectangle {
+            visible: Number(pinTile.thread.unread || 0) > 0
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.rightMargin: -root.space(2)
+            anchors.topMargin: -root.space(2)
+            width: Math.max(root.space(18), unreadCount.implicitWidth + root.space(8))
+            height: root.space(18)
+            radius: height / 2
+            color: root.mineFill
+            border.width: 2
+            border.color: Color.background
+            Text {
+              id: unreadCount
+              anchors.centerIn: parent
+              text: Number(pinTile.thread.unread || 0) > 99 ? "99+" : String(pinTile.thread.unread || "")
+              textFormat: Text.PlainText
+              color: root.mineText
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+            }
+          }
+        }
+      }
+
+      Text {
+        width: parent.width
+        text: pinTile.displayName
+        textFormat: Text.PlainText
+        color: root.foreground
+        horizontalAlignment: Text.AlignHCenter
+        elide: Text.ElideRight
+        maximumLineCount: 1
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: Number(pinTile.thread.unread || 0) > 0
+      }
+    }
+
+    HoverHandler { id: pinHover; cursorShape: Qt.PointingHandCursor }
+    TapHandler { onTapped: root.openThread(pinTile.thread) }
+  }
+
+  Menu {
+    id: messageOnlyMenu
+    width: root.space(300)
+    MenuItem {
+      text: "Copy message"
+      onTriggered: root.copyText(root.contextMessageText)
+    }
+  }
+
+  BlipSettings {
+    id: settingsView
+    anchors.fill: parent
+    visible: root.settingsMode
+    preferences: root.preferences
+    hostWidget: root.hostWidget
+    foreground: root.foreground
+    urgent: root.urgent
+    accent: root.accent
+    outgoingFill: root.mineFill
+    outgoingText: root.mineText
+    incomingFill: root.theirsFill
+    incomingText: root.theirsText
+    fontFamily: root.fontFamily
+    fontScale: root.fontScale
+    density: root.density
+    cornerScale: root.cornerScale
+    onCloseRequested: root.closeSettings()
+  }
+
     // drag a file from a file manager onto the open conversation → draft chip
     DropArea {
       anchors.fill: parent
-      enabled: root.inThread
+      enabled: root.inThread && !root.settingsMode
       keys: ["text/uri-list"]
       onDropped: (drop) => {
         if (!drop.hasUrls || drop.urls.length === 0) return

--- a/BlipWindow.qml
+++ b/BlipWindow.qml
@@ -19,11 +19,13 @@ import qs.Commons
 FloatingWindow {
   id: win
   property var hostWidget: null
+  property var preferences: null
   // "Blip (3)" while unread exists — selectors match the "Blip" PREFIX.
   title: "Blip" + (hostWidget && hostWidget.unread > 0 ? " (" + hostWidget.unread + ")" : "")
-  // Same fill as Omarchy's other FloatingWindow (dev gallery). A 0.70
-  // alpha assumed Hyprland blur, which Omarchy 4.x ships off.
-  color: Color.background
+  // Opaque unless the user deliberately lowers the portable appearance
+  // preference. Omarchy 4.x does not guarantee window blur.
+  readonly property real backdropAlpha: preferences ? preferences.backgroundOpacity : 0.70
+  color: Qt.rgba(Color.background.r, Color.background.g, Color.background.b, backdropAlpha)
   implicitWidth: 1040
   implicitHeight: 720
   minimumSize: Qt.size(720, 480)
@@ -40,6 +42,7 @@ FloatingWindow {
   readonly property string activeLastTs: view.activeLastTs
   function openThread(t) { view.openThread(t) }
   function shareLink(url) { return view.shareLink(url) }
+  function openSettings(page) { view.openSettings(page) }
   function pushReload() { view.pushReload() }
   function navText(event) {
     if (event.key === Qt.Key_Slash) return "/"
@@ -117,8 +120,10 @@ FloatingWindow {
         anchors.fill: parent
         // Inset from the window edge: Hyprland rounds the corners, and text
         // flush to the border got clipped by the radius (Fred).
-        anchors.margins: Style.space(12)
+        anchors.margins: Math.max(1, Math.round(Style.spaceReal(12)
+          * (win.preferences ? win.preferences.density : 1.0)))
         hostWidget: win.hostWidget
+        preferences: win.preferences
         splitView: true
         surfaceOpen: win.visible
         readActive: win.focused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## Unreleased
+
+- The appearance page now uses the full window: the live preview fills the
+  available space (fit by both width and height, centered) and the controls
+  pin to the right edge at a fixed measure. The preview now depicts the app
+  window's default 1040×720 geometry instead of the live window — mirroring
+  the live window made 100% structurally impossible — and reaches a
+  pixel-true 100% (never upscaling past it) whenever the workspace has room.
+- A previewable pasted or dropped attachment (png/jpg/gif/webp/bmp/svg) shows
+  the image itself in the compose chip; non-previewable files like a vCard
+  keep the filename pill, which also remains the fallback while a preview
+  decodes or if it fails.
+- Open settings on the Appearance page. The live app preview is now a true
+  miniature: the whole mock window is laid out at real app dimensions (raw-px
+  sidebar, spaceReal avatars, the window's own gutters) and shrunk by one
+  uniform scale transform, replacing the old per-part approximations.
+- Center the avatar and name inside pinned-conversation tiles: the tile now
+  sizes itself to its content with even padding instead of a fixed tail that
+  left extra space under the label.
+- Make chronological sidebar rows contiguous: each row absorbs half the old
+  inter-row gap, so the hover highlight fills the whole area up to the
+  hairline separator instead of stopping short of it. Separators touching a
+  hovered or selected row hide so the highlight reads as one clean block.
+- Keep the settings page still while dragging appearance sliders: the page's
+  own chrome uses scale values frozen at open, and only the live preview
+  (plus the app behind it) tracks the moving density/font/corner values.
+- Move the popout's new-message and open-app-window buttons into the header,
+  upper right beside the gear, ordered by function: start a conversation,
+  promote to the app window, then settings.
+- Double the popout's width (and give it a little extra height) while the
+  appearance settings page is showing, so the live preview sits beside the
+  controls instead of stacking above them. New `panelsettings <page>` IPC
+  opens the settings pages inside the popout the way `settings`/`appearance`
+  do for the window. The two-column threshold dropped to space(700) with
+  smaller column minimums: the old 940 threshold sat too close to the wide
+  popout width (both shrink with density while the panel padding does not,
+  so low density flipped it back to stacked) and above what a narrow app
+  window can offer.
+- Preserve the natural aspect ratio of tall link-preview artwork, allow cards
+  to grow beyond the old shallow banner cap, and render tapback reactions on
+  unfurled cards. Conversation headers now use Messages' pinned group title,
+  short emoji-only messages use the large bubble-free Messages treatment, and
+  incoming group-message runs show the sender's avatar beside their last item.
+- Add subtle post-avatar separators between chronological sidebar discussions,
+  matching the visual grouping used by Messages on macOS.
+- Balance the vertical space above and below sidebar search before the
+  pinned grid.
+- Enlarge tapback reactions, add Messages-like background padding and two-dot
+  tails, raise them away from message text, and render their fill fully opaque
+  without the badge-style outline.
+- Match the Appearance preview bubbles to the live sender-corner treatment,
+  and add a portable 12/24-hour conversation-list time preference (AM/PM by
+  default).
+- Coalesce migrated named group-chat records when their title and exact
+  participant set agree. Pin state follows the one logical conversation, the
+  newest source remains the send target, and history/unread state spans every
+  retained source identifier.
+
+- Remove the sidebar's duplicate left inset in the app window so search,
+  pinned conversations, and the message list sit closer to the window edge
+  while retaining breathing room beside the conversation divider.
+- Match Messages' compact sidebar hierarchy by moving Settings into the Blip
+  header and removing redundant Messages/Pinned labels. Pinned direct and
+  group conversations now use short names from Contacts' unified-card view.
+- Suppress a message body when it contains only the URL already represented by
+  an unfurled link card, including when its preview metadata canonicalizes away
+  tracking parameters. Captions and other accompanying text remain visible.
+- Make message links inherit the bubble's readable text color, render grouped
+  bubble corners as one translucent shape without a darker overlap, and cap
+  inline media in logical UI units on wide windows. Retina PNG density is now
+  honored so 144-DPI screenshots render at their intended 2× logical scale.
+
 ## 2.3.2 — 2026-09-04
 
 - **A mute list, for the texts nobody opted into.** Political fundraising
@@ -360,6 +432,38 @@ findings, the clear ones fixed here, the rest on the roadmap.
 **Repo**
 - CI on every push and PR (bun test, Mac tools byte-compile, shellcheck),
   CONTRIBUTING, issue/PR templates, security policy, GitHub Releases.
+- Add explicitly gated Mac Contacts repair from Blip: exact-card preview,
+  second confirmation, supported Contacts.app removal, Mac-local undo receipt,
+  and post-change revalidation. The restricted SSH key remains unable to turn
+  contact writes on by itself.
+- Add an in-Blip active-card comparison with bounded contact details, a
+  de-duplicated combined view, missing-detail hints, exact-card editing handoff,
+  and guarded invocation of Contacts' native link/merge action. Preview and
+  execution are separate, the confirmed action is pinned end-to-end, and Blip
+  never links during discovery or testing.
+- Keep the Settings UI visually stable during five-second configuration checks: silent identity reads no longer toggle visible loading state, and unchanged identity/preference results no longer rebuild QML models or controls.
+
+**Added**
+- File-backed appearance preferences with an in-app QML editor: bubble colors,
+  app-window opacity, font scale, density, sidebar width, avatar size, and
+  corner roundness. `~/.config/blip/preferences.json` is portable, atomically
+  written, owner-only, bounded, and reloaded live after an external restore.
+- Messages.app pinned conversations, sourced read-only from the Mac's pinning
+  plist and rendered in its ordered circular-avatar grid above the regular
+  chronological list.
+- Explicit contact-name resolution for ambiguous phone/email handles. The QML
+  chooser writes a bounded, atomic `~/.config/blip/identities.json` override;
+  a source-fix action opens the validated persistent card in Contacts.app on
+  the Mac without writing Apple’s private AddressBook database.
+
+**Changed**
+- Contact-name repair is now a guided two-stage flow: selecting a candidate is
+  harmless, remembering the Contacts match is explicit, and optional Mac repair lists and
+  opens every exact source card separately. Generic one-click **Use** and
+  **Fix on Mac** controls were removed.
+- Settings now separates Contacts from Appearance with tabs. Contact repair is
+  a list-to-detail flow with Back/Escape navigation, bounded content width, and
+  collapsed Mac/source-card details instead of one enormous settings scroll.
 
 ## 2.0.0 — 2026-08-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,10 @@ what it is handed. Keep it that way.
 - **The Linux shims' ssh preflight must use `ssh -n`.** A bare
   `ssh <mac> true` connectivity probe EATS STDIN, which silently empties
   `imsg-send --file-stdin` payloads. Fixed 2026-08-31.
+- **Preferences cross a bounded helper.** QML never feeds
+  `~/.config/blip/preferences.json` into `FileView`. `preferences.ts` rejects
+  symlinks/FIFOs/wrong owners/oversized or invalid JSON and writes 0600 via a
+  pinned directory fd + atomic rename. Keep the schema portable and versioned.
 - **`bridge.conf` is data, never `source`d.** The shim parses four keys and
   validates them; keep it that way (audit #7). `automation=on` is what lets
   `qs ipc … goto/compose/bubbles` work — off, they return a refusal string.

--- a/Panel.qml
+++ b/Panel.qml
@@ -23,6 +23,7 @@ Panel {
 
   property var anchorItem: null
   property var hostWidget: null
+  property var preferences: null
   readonly property var barIdentity: hostWidget || root
 
   // ---- proxies: BarWidget and the IPC hooks talk to the panel, the view does the work
@@ -51,6 +52,7 @@ Panel {
   function searchFor(query) { if (!opened) open(); return view.searchFor(query) }
   function newChatFor(query) { if (!opened) open(); return view.newChatFor(query) }
   function shareLink(url) { if (!opened) open(); return view.shareLink(url) }
+  function openSettings(page) { if (!opened) open(); view.openSettings(page); return "panel settings shown" }
 
   // ------------------------------------------------------------ panel
   KeyboardPanel {
@@ -59,17 +61,21 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    focusTarget: view.inThread ? view.composeEditor : keyCatcher
+    focusTarget: view.settingsMode ? keyCatcher : (view.inThread ? view.composeEditor : keyCatcher)
     // 20% narrower than it was (Fred, 2.3.1). Messages' own sidebar is a
-    // narrow column; 440 read like a file browser.
-    contentWidth: panel.fittedContentWidth(Style.space(352))
+    // narrow column; 440 read like a file browser. Appearance settings go
+    // double-wide so the preview and controls sit side by side; every other
+    // mode keeps the compact dropdown width.
+    contentWidth: panel.fittedContentWidth(
+      view.settingsWide ? view.settingsWideWidth : Style.space(352))
     // The floor keeps the panel usable if a mode flip's relayout ever lags
     // again — search/new modes always have at least a field to show.
     contentHeight: panel.fittedContentHeight(
-      view.inThread ? Style.space(640)
+      view.settingsMode ? Style.space(view.settingsWide ? 760 : 640)
+        : view.inThread ? Style.space(640)
         : Math.max(view.contentHeightHint,
                    (view.newMode || view.searching) ? Style.space(280) : 0),
-      Style.space(640))
+      Style.space(view.settingsWide ? 760 : 640))
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -90,6 +96,7 @@ Panel {
         id: view
         anchors.fill: parent
         hostWidget: root.hostWidget
+        preferences: root.preferences
         surfaceOpen: root.opened
         foreground: root.bar ? root.bar.foreground : Color.foreground
         urgent: root.bar ? root.bar.urgent : Color.urgent

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <img alt="Omarchy" src="https://img.shields.io/badge/Omarchy-plugin-5fd7ff?style=flat-square">
   <img alt="QuickShell" src="https://img.shields.io/badge/QuickShell-QML-0a84ff?style=flat-square">
   <img alt="bun" src="https://img.shields.io/badge/bun-TypeScript-f9f1e1?style=flat-square">
-  <img alt="tests" src="https://img.shields.io/badge/tests-312%20passing-2ea043?style=flat-square">
+  <img alt="tests" src="https://img.shields.io/badge/tests-356%20passing-2ea043?style=flat-square">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-lightgrey?style=flat-square">
 </p>
 
@@ -133,7 +133,8 @@ Linux side. If the Mac is asleep, the widget dims and says so.
 - **link cards** — URL messages show the preview image, title, and host, like Messages. Apple only decorates some links; for the rest Blip fetches the page's own Open Graph card itself, so a bare URL still gets its picture. Click opens the link, **right-click opens the share sheet** (open · copy · QR for your phone · send to a device via LocalSend, Omarchy's share). `link_previews=off` in `bridge.conf` disables the fetching
 - **photos render inline** — images ≤5MB auto-fetch over SSH (HEIC converted on the Mac); click opens full-size. PDFs/videos are chips — click fetches and opens them
 - **send files** — Ctrl+V an image into the compose box, type `/attach <path>`, or drag-and-drop; a caption rides along
-- select text and Ctrl+C · right-click a bubble to copy it whole · right-click a **link** in a bubble for the share sheet
+- select text and Ctrl+C · right-click a bubble for **Copy message**;
+  right-click a **link** in a bubble for the share sheet
 - the share sheet **opens itself** for a link you send, and for one that arrives while Blip is open
 - compose box at the bottom, Enter sends — **DMs and groups**
 
@@ -390,6 +391,38 @@ send on their own service automatically.
 on the first screen polls and owns the app window, the others show the
 badge and forward clicks to it.
 
+## Settings and portable configuration
+
+Choose the gear in Blip's message header to edit appearance live. The editor
+writes a normal JSON file at `~/.config/blip/preferences.json`, so it can be
+copied between machines or tracked by dotfile tooling. A restored file is
+noticed within five seconds, or immediately with **Reload file**. Track the
+real file rather than a symlink: the preference boundary deliberately refuses
+symlinks and non-regular files.
+
+```json
+{
+  "schemaVersion": 1,
+  "outgoingBubbleColor": "theme",
+  "incomingBubbleColor": "theme",
+  "backgroundOpacity": 0.7,
+  "fontScale": 1,
+  "density": 1,
+  "sidebarWidth": 320,
+  "avatarSize": 30,
+  "cornerScale": 1,
+  "hideShortCodeConversations": true,
+  "use12HourConversationTimes": true
+}
+```
+
+Bubble colors accept `"theme"`, `#rrggbb`, or `#rrggbbaa`. The GUI exposes
+every field: app-window opacity, font scale, density, sidebar width, avatar
+size, corner roundness, short-code visibility, and 12/24-hour conversation-list
+times. Writes are atomic and owner-only; malformed,
+oversized, symlinked, or out-of-range files are rejected with an error in the
+settings view instead of being loaded into the long-lived shell.
+
 ## Keyboard
 
 | where | key | does |
@@ -410,6 +443,7 @@ IPC, for scripts and other plugins:
 
 ```sh
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip status
+qs -p /usr/share/omarchy/shell ipc call nixfred.blip settings
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip goto 15551234567   # bare digits
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip read               # mark all read
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip share https://example.com   # share sheet for a URL
@@ -419,7 +453,7 @@ Everything that sends or reads message content over IPC (`goto`, `compose`,
 `bubbles`, `threads`, `find`, `newchat`, `read`) is **off by default** — any
 local process could otherwise send as you. Turn it on with `automation=on`
 in `~/.config/blip/bridge.conf` (re-read live). `status`, `open`, `close`,
-`toggle`, `window`, `app` are always available.
+`toggle`, `window`, `app`, `settings` are always available.
 
 ## Design notes worth knowing
 
@@ -478,7 +512,7 @@ The 273,000-message history stays on the Mac where it lives.
 ## Development
 
 ```sh
-bun test                                     # 312 tests, ~110 ms
+bun test                                     # 356 tests, ~100 ms
 bun collector.ts --deep | jq '.unread, (.threads|length)'
 bun thread.ts +15551234567 40 | jq '.bubbles[-1]'
 scripts/demo/blip-shots                      # regenerate docs/img/*.png

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -29,6 +29,7 @@ import plistlib
 import re
 import sqlite3
 import struct
+import subprocess
 import sys
 from glob import glob
 
@@ -41,6 +42,7 @@ PINNING_PLIST_PATHS = (
     ),
 )
 APPLE_EPOCH = 978307200  # 2001-01-01 UTC
+CONTACT_HELPER = os.path.expanduser("~/.blip/bin/contact-delete")
 
 # ---------- Contacts name resolution (built-in, no external deps) ----------
 
@@ -248,6 +250,39 @@ def name_for(handle: str | None) -> str | None:
     if "@" in handle:
         return _NAME_INDEX.get(handle.strip().lower()) or None
     return _NAME_INDEX.get(_normalize_phone(handle)) or None
+
+
+def unified_names(handles: list[str]) -> dict[str, dict[str, str]]:
+    """Resolve a bounded set through the same unified-card view Messages uses."""
+    bounded = []
+    seen = set()
+    for value in handles[:128]:
+        if (isinstance(value, str) and 1 <= len(value) <= 320
+                and not re.search(r"[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]", value)
+                and value not in seen):
+            seen.add(value)
+            bounded.append(value)
+    if not bounded or not os.path.isfile(CONTACT_HELPER):
+        return {}
+    try:
+        result = subprocess.run(
+            [CONTACT_HELPER], input=json.dumps({"operation": "names", "handles": bounded}),
+            text=True, capture_output=True, timeout=10, check=False,
+        )
+        payload = json.loads(result.stdout) if result.returncode == 0 else {}
+        rows = payload.get("names") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            return {}
+        return {
+            row["handle"]: {
+                "name": str(row.get("name") or "")[:160],
+                "short": str(row.get("shortName") or row.get("name") or "")[:160],
+            }
+            for row in rows
+            if isinstance(row, dict) and row.get("handle") in seen and row.get("name")
+        }
+    except (OSError, subprocess.SubprocessError, ValueError, TypeError):
+        return {}
 
 
 def label(handle: str | None, is_from_me: int, with_names: bool) -> str:
@@ -852,7 +887,7 @@ def cmd_chats(con, args):
     rows = con.execute(
         f"""
         SELECT c.ROWID AS cid, c.chat_identifier, c.guid, c.group_id,
-               {orig_col} AS original_group_id, c.display_name, c.room_name,
+               {orig_col} AS original_group_id, c.display_name, c.room_name, c.style,
                c.service_name, MAX(m.date) AS last_date,
                COUNT(m.ROWID) AS n
         FROM chat c
@@ -869,20 +904,34 @@ def cmd_chats(con, args):
         # One entry per CONVERSATION: a group re-keyed by Messages leaves
         # several chat rows and used to list once per row.
         clusters = _group_cluster_map(con)
-        merged_counts: dict = {}
+        merged_counts: dict[str, int] = {}
+        pin_orders: dict[str, int] = {}
         for r in rows:
-            canon = clusters.get(r["chat_identifier"])
-            if canon:
-                merged_counts[canon] = merged_counts.get(canon, 0) + r["n"]
-        out = []
+            chat_id = r["chat_identifier"]
+            canon = clusters.get(chat_id, chat_id)
+            merged_counts[canon] = merged_counts.get(canon, 0) + r["n"]
+            order = pin_order_for(pin_ids, chat_id, r["guid"],
+                                  r["group_id"], r["original_group_id"])
+            if order is not None and (canon not in pin_orders or order < pin_orders[canon]):
+                pin_orders[canon] = order
+
+        selected = []
+        seen_ids = set()
         for r in rows:
-            canon = clusters.get(r["chat_identifier"])
-            if canon and canon != r["chat_identifier"]:
+            chat_id = r["chat_identifier"]
+            if chat_id in seen_ids:
+                continue
+            seen_ids.add(chat_id)
+            canon = clusters.get(chat_id)
+            if canon and canon != chat_id:
                 continue                 # an older row of a conversation listed under `canon`
-            pin_order = pin_order_for(pin_ids, r["chat_identifier"], r["guid"],
-                                      r["group_id"], r["original_group_id"])
+            selected.append(r)
+
+        latest = {}
+        for r in selected:
             last = con.execute(
-                f"""SELECT m.text, m.attributedBody, m.is_from_me, h.id AS handle
+                f"""SELECT m.ROWID AS mid, m.text, m.attributedBody, m.is_from_me,
+                            h.id AS handle
                     FROM chat_message_join cmj
                     JOIN {MESSAGE_SRC} m ON m.ROWID = cmj.message_id
                     LEFT JOIN handle h ON h.ROWID = m.handle_id
@@ -890,26 +939,89 @@ def cmd_chats(con, args):
                     ORDER BY m.date DESC LIMIT 1""",
                 (r["cid"],),
             ).fetchone()
+            if last:
+                latest[r["cid"]] = last
+
+        attachments = {}
+        for attachment in _chunked_in(
+            con,
+            """SELECT maj.message_id AS mid, a.transfer_name AS name, a.mime_type AS mime
+                 FROM message_attachment_join maj
+                 JOIN attachment a ON a.ROWID = maj.attachment_id
+                WHERE maj.message_id IN ({marks})
+                  AND COALESCE(a.transfer_name, '') NOT LIKE '%.pluginPayloadAttachment'
+                ORDER BY a.ROWID""",
+            [last["mid"] for last in latest.values()],
+        ):
+            attachments.setdefault(attachment["mid"], {
+                "name": attachment["name"] or "", "mime": attachment["mime"] or "",
+            })
+
+        participants = {}
+        for member in _chunked_in(
+            con,
+            """SELECT chj.chat_id AS cid, h.id AS handle
+                 FROM chat_handle_join chj JOIN handle h ON h.ROWID = chj.handle_id
+                WHERE chj.chat_id IN ({marks}) ORDER BY chj.chat_id, h.ROWID""",
+            [r["cid"] for r in selected if r["style"] == 43],
+        ):
+            if member["handle"]:
+                participants.setdefault(member["cid"], []).append(member["handle"])
+
+        wanted_names = []
+        for r in selected:
+            if r["chat_identifier"] not in pin_orders:
+                continue
+            if r["style"] == 43:
+                wanted_names.extend(participants.get(r["cid"], []))
+            else:
+                wanted_names.append(r["chat_identifier"])
+        contact_names = unified_names(wanted_names)
+
+        out = []
+        for r in selected:
+            chat_id = r["chat_identifier"]
+            last = latest.get(r["cid"])
+            raw_name = r["display_name"] or r["room_name"] or ""
+            explicit_name = raw_name if raw_name != chat_id else ""
+            pin_order = pin_orders.get(chat_id)
+            pin_name = ""
+            if pin_order is not None:
+                if r["style"] == 43:
+                    member_names = [
+                        contact_names.get(handle, {}).get("short") or name_for(handle) or handle
+                        for handle in participants.get(r["cid"], [])
+                    ]
+                    if len(member_names) == 2:
+                        generated_name = " & ".join(member_names)
+                    elif len(member_names) > 2:
+                        generated_name = ", ".join(member_names[:-1]) + " & " + member_names[-1]
+                    else:
+                        generated_name = member_names[0] if member_names else ""
+                    pin_name = explicit_name or generated_name
+                else:
+                    pin_name = contact_names.get(chat_id, {}).get("short") or ""
+
             out.append({
-                "id": r["chat_identifier"],
-                "name": r["display_name"] or r["room_name"],
+                "id": chat_id,
+                "name": explicit_name or None,
                 "service": r["service_name"],
-                "messages": r["n"],
+                "messages": merged_counts.get(chat_id, r["n"]),
                 "last": fmt_ts(r["last_date"]),
                 "last_text": message_text(last) if last else "",
                 "last_from_me": bool(last["is_from_me"]) if last else False,
                 "last_handle": (last["handle"] if last else None) or "",
                 "last_name": (None if args.no_names
                               else _dm_name(last["handle"] if last else None, r["chat_identifier"])),
+                "last_attachment": attachments.get(last["mid"]) if last else None,
                 "pinned": pin_order is not None,
                 "pin_order": pin_order,
+                "pin_name": pin_name or None,
                 # Other chat rows of this same conversation. A client must fold
                 # any thread carrying one of these onto this id.
                 "aliases": [c for c, k in clusters.items()
-                            if k == r["chat_identifier"] and c != r["chat_identifier"]],
+                            if k == chat_id and c != chat_id][:15],
             })
-            if canon:
-                out[-1]["messages"] = merged_counts.get(canon, r["n"])
         print(json.dumps(out, indent=2, ensure_ascii=False))
         return
     for r in rows:
@@ -962,6 +1074,13 @@ def cmd_groups(con, args):
         live.append(r)
     rows = live[: args.n]
     if args.json:
+        participant_lists = [
+            (r["participants"] or "").split(",") if r["participants"] else []
+            for r in rows
+        ]
+        contact_names = unified_names([
+            handle for members in participant_lists for handle in members
+        ]) if not args.no_names else {}
         print(
             json.dumps(
                 [
@@ -969,10 +1088,18 @@ def cmd_groups(con, args):
                         "chat": r["chat_identifier"],
                         "guid": r["guid"],
                         "name": r["display_name"] or "",
-                        "participants": (r["participants"] or "").split(",") if r["participants"] else [],
+                        "participants": participant_lists[index],
+                        "participant_names": {
+                            handle: (
+                                contact_names.get(handle, {}).get("name")
+                                or name_for(handle)
+                                or handle
+                            )
+                            for handle in participant_lists[index]
+                        } if not args.no_names else {},
                         "last": fmt_ts(r["last_date"]) if r["last_date"] else None,
                     }
-                    for r in rows
+                    for index, r in enumerate(rows)
                 ],
                 indent=2,
             )

--- a/bridge/mac/imsg_test.py
+++ b/bridge/mac/imsg_test.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Projection tests for the Messages conversation list."""
+
+import importlib.machinery
+import importlib.util
+import contextlib
+import io
+import json
+import os
+import sqlite3
+import unittest
+from types import SimpleNamespace
+
+
+def load_imsg():
+    path = os.path.join(os.path.dirname(__file__), "imsg")
+    loader = importlib.machinery.SourceFileLoader("blip_imsg", path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+imsg = load_imsg()
+
+
+class ChatProjectionTests(unittest.TestCase):
+    def test_chat_json_deduplicates_parallel_service_rows(self):
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        con.executescript("""
+            CREATE TABLE chat (
+              ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT, display_name TEXT,
+              room_name TEXT, service_name TEXT, group_id TEXT, original_group_id TEXT,
+              style INTEGER
+            );
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+              ROWID INTEGER PRIMARY KEY, date INTEGER, text TEXT,
+              attributedBody BLOB, is_from_me INTEGER, handle_id INTEGER,
+              item_type INTEGER DEFAULT 0
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+            CREATE TABLE attachment (
+              ROWID INTEGER PRIMARY KEY, transfer_name TEXT, mime_type TEXT
+            );
+            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+            CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+            INSERT INTO chat VALUES (1, '+15551234567', NULL, NULL, NULL, 'SMS', NULL, NULL, 45);
+            INSERT INTO chat VALUES (2, '+15551234567', NULL, NULL, NULL, 'iMessage', NULL, NULL, 45);
+            INSERT INTO handle VALUES (1, '+15551234567');
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (10, 100, 'old', NULL, 0, 1);
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (11, 200, 'new', NULL, 0, 1);
+            INSERT INTO chat_message_join VALUES (1, 10);
+            INSERT INTO chat_message_join VALUES (2, 11);
+        """)
+        original = imsg.pinned_chat_identifiers
+        imsg.pinned_chat_identifiers = lambda: [{"+15551234567"}]
+        try:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                imsg.cmd_chats(con, SimpleNamespace(n=300, json=True, no_names=True))
+            rows = json.loads(output.getvalue())
+        finally:
+            imsg.pinned_chat_identifiers = original
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["last_text"], "new")
+        self.assertEqual(rows[0]["pin_order"], 0)
+
+    def test_chat_json_labels_an_attachment_without_leaking_placeholder_text(self):
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        con.executescript("""
+            CREATE TABLE chat (
+              ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT, display_name TEXT,
+              room_name TEXT, service_name TEXT, group_id TEXT, original_group_id TEXT,
+              style INTEGER
+            );
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+              ROWID INTEGER PRIMARY KEY, date INTEGER, text TEXT,
+              attributedBody BLOB, is_from_me INTEGER, handle_id INTEGER,
+              item_type INTEGER DEFAULT 0
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+            CREATE TABLE attachment (
+              ROWID INTEGER PRIMARY KEY, transfer_name TEXT, mime_type TEXT
+            );
+            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+            CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+            INSERT INTO chat VALUES (1, 'chat999', NULL, NULL, 'chat999', 'iMessage', NULL, NULL, 43);
+            INSERT INTO handle VALUES (1, '+15551234567');
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (10, 100, '￼', NULL, 0, 1);
+            INSERT INTO chat_message_join VALUES (1, 10);
+            INSERT INTO attachment VALUES (20, 'photo.HEIC', 'image/heic');
+            INSERT INTO message_attachment_join VALUES (10, 20);
+        """)
+        original_pins = imsg.pinned_chat_identifiers
+        original_names = imsg.unified_names
+        imsg.pinned_chat_identifiers = lambda: []
+        imsg.unified_names = lambda _handles: {}
+        try:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                imsg.cmd_chats(con, SimpleNamespace(n=300, json=True, no_names=True))
+            rows = json.loads(output.getvalue())
+        finally:
+            imsg.pinned_chat_identifiers = original_pins
+            imsg.unified_names = original_names
+        self.assertIsNone(rows[0]["name"])
+        self.assertEqual(rows[0]["last_attachment"]["mime"], "image/heic")
+
+    def test_named_group_migrations_coalesce_only_with_the_same_participants(self):
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        con.executescript("""
+            CREATE TABLE chat (
+              ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT, display_name TEXT,
+              room_name TEXT, service_name TEXT, group_id TEXT, original_group_id TEXT,
+              style INTEGER
+            );
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE message (
+              ROWID INTEGER PRIMARY KEY, date INTEGER, text TEXT,
+              attributedBody BLOB, is_from_me INTEGER, handle_id INTEGER,
+              item_type INTEGER DEFAULT 0
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+            CREATE TABLE attachment (
+              ROWID INTEGER PRIMARY KEY, transfer_name TEXT, mime_type TEXT
+            );
+            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+            CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+            INSERT INTO chat VALUES (1, 'old-group', NULL, 'Project Team', NULL, 'iMessage', 'old', NULL, 43);
+            INSERT INTO chat VALUES (2, 'new-group', NULL, 'Project Team', NULL, 'iMessage', 'new', 'old', 43);
+            INSERT INTO chat VALUES (3, 'other-group', NULL, 'Project Team', NULL, 'iMessage', 'other', NULL, 43);
+            INSERT INTO handle VALUES (1, '+15550000001');
+            INSERT INTO handle VALUES (2, '+15550000002');
+            INSERT INTO handle VALUES (3, '+15550000003');
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (10, 100, 'old', NULL, 0, 1);
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (11, 200, 'new', NULL, 0, 1);
+            INSERT INTO message (ROWID, date, text, attributedBody, is_from_me, handle_id) VALUES (12, 150, 'different people', NULL, 0, 3);
+            INSERT INTO chat_message_join VALUES (1, 10);
+            INSERT INTO chat_message_join VALUES (2, 11);
+            INSERT INTO chat_message_join VALUES (3, 12);
+            INSERT INTO chat_handle_join VALUES (1, 1);
+            INSERT INTO chat_handle_join VALUES (1, 2);
+            INSERT INTO chat_handle_join VALUES (2, 1);
+            INSERT INTO chat_handle_join VALUES (2, 2);
+            INSERT INTO chat_handle_join VALUES (3, 1);
+            INSERT INTO chat_handle_join VALUES (3, 3);
+        """)
+        original_pins = imsg.pinned_chat_identifiers
+        original_names = imsg.unified_names
+        imsg.pinned_chat_identifiers = lambda: [{"old-group"}]
+        imsg.unified_names = lambda _handles: {}
+        try:
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                imsg.cmd_chats(con, SimpleNamespace(n=300, json=True, no_names=True))
+            rows = json.loads(output.getvalue())
+        finally:
+            imsg.pinned_chat_identifiers = original_pins
+            imsg.unified_names = original_names
+        self.assertEqual(len(rows), 2)
+        merged = next(row for row in rows if row["id"] == "new-group")
+        self.assertEqual(merged["aliases"], ["old-group"])
+        self.assertEqual(merged["messages"], 2)
+        self.assertEqual(merged["pin_order"], 0)
+        self.assertIn("other-group", [row["id"] for row in rows])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fetch.ts
+++ b/fetch.ts
@@ -20,9 +20,12 @@ import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import {
   closeSync,
+  constants,
+  fstatSync,
   fsyncSync,
   mkdirSync,
   openSync,
+  readSync,
   readdirSync,
   renameSync,
   lstatSync,
@@ -38,6 +41,8 @@ const HOME = process.env.HOME ?? homedir();
 export const CACHE_DIR = join(process.env.XDG_CACHE_HOME ?? join(HOME, ".cache"), "blip", "att");
 export const CACHE_CAP_BYTES = 500 * 1024 * 1024;
 export const FETCH_MAX_BYTES = 100 * 1024 * 1024;
+const IMAGE_HEADER_BYTES = 64 * 1024;
+
 /** Long edge for an auto-fetched inline preview. The bubble decodes at 800;
  *  1600 keeps it crisp on a HiDPI panel and still lands well under any cap. */
 export const PREVIEW_MAX_DIM = 1600;
@@ -94,6 +99,98 @@ export function lruEvictions(
     total -= e.bytes;
   }
   return out;
+}
+
+export interface ImageMetrics {
+  pixelWidth: number;
+  pixelHeight: number;
+  pixelRatio: number;
+}
+
+const EMPTY_IMAGE_METRICS: ImageMetrics = { pixelWidth: 0, pixelHeight: 0, pixelRatio: 1 };
+
+function densityRatio(xDpi: number, yDpi: number): number {
+  if (!Number.isFinite(xDpi) || !Number.isFinite(yDpi) || xDpi <= 0 || yDpi <= 0)
+    return 1;
+  if (Math.abs(xDpi - yDpi) / Math.max(xDpi, yDpi) > 0.05) return 1;
+  const ratio = (xDpi + yDpi) / 144;
+  const common = [1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4];
+  return common.find((value) => Math.abs(value - ratio) <= 0.06) ?? 1;
+}
+
+/** Bounded image metadata used only for display sizing; malformed data falls back to 1×. */
+export function imageMetrics(bytes: Buffer, mime: string): ImageMetrics {
+  if (!String(mime || "").startsWith("image/") || !bytes || bytes.length < 10)
+    return { ...EMPTY_IMAGE_METRICS };
+
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  if (bytes.length >= 24 && bytes.subarray(0, 8).equals(png)) {
+    const pixelWidth = bytes.readUInt32BE(16);
+    const pixelHeight = bytes.readUInt32BE(20);
+    let pixelRatio = 1;
+    for (let pos = 8; pos + 12 <= bytes.length;) {
+      const length = bytes.readUInt32BE(pos);
+      if (length > IMAGE_HEADER_BYTES || pos + 12 + length > bytes.length) break;
+      const type = bytes.toString("ascii", pos + 4, pos + 8);
+      if (type === "pHYs" && length === 9 && bytes[pos + 16] === 1) {
+        const xDpi = bytes.readUInt32BE(pos + 8) * 0.0254;
+        const yDpi = bytes.readUInt32BE(pos + 12) * 0.0254;
+        pixelRatio = densityRatio(xDpi, yDpi);
+        break;
+      }
+      if (type === "IDAT" || type === "IEND") break;
+      pos += 12 + length;
+    }
+    return { pixelWidth, pixelHeight, pixelRatio };
+  }
+
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) {
+    let pixelWidth = 0;
+    let pixelHeight = 0;
+    let pixelRatio = 1;
+    const sof = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
+    for (let pos = 2; pos + 4 <= bytes.length;) {
+      if (bytes[pos] !== 0xff) { pos++; continue; }
+      while (pos < bytes.length && bytes[pos] === 0xff) pos++;
+      if (pos >= bytes.length) break;
+      const marker = bytes[pos++];
+      if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+      if (marker === 0xd9 || marker === 0xda || pos + 2 > bytes.length) break;
+      const length = bytes.readUInt16BE(pos);
+      if (length < 2 || pos + length > bytes.length) break;
+      const data = pos + 2;
+      if (marker === 0xe0 && length >= 14 && bytes.toString("ascii", data, data + 5) === "JFIF\0") {
+        const units = bytes[data + 7];
+        const x = bytes.readUInt16BE(data + 8);
+        const y = bytes.readUInt16BE(data + 10);
+        if (units === 1) pixelRatio = densityRatio(x, y);
+        else if (units === 2) pixelRatio = densityRatio(x * 2.54, y * 2.54);
+      }
+      if (sof.has(marker) && length >= 7) {
+        pixelHeight = bytes.readUInt16BE(data + 1);
+        pixelWidth = bytes.readUInt16BE(data + 3);
+      }
+      pos += length;
+    }
+    return { pixelWidth, pixelHeight, pixelRatio };
+  }
+  return { ...EMPTY_IMAGE_METRICS };
+}
+
+function cachedImageMetrics(path: string, mime: string): ImageMetrics {
+  let fd = -1;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    if (!st.isFile() || st.uid !== process.getuid() || st.size <= 0) return { ...EMPTY_IMAGE_METRICS };
+    const header = Buffer.alloc(Math.min(st.size, IMAGE_HEADER_BYTES));
+    const count = readSync(fd, header, 0, header.length, 0);
+    return imageMetrics(header.subarray(0, count), mime);
+  } catch {
+    return { ...EMPTY_IMAGE_METRICS };
+  } finally {
+    if (fd >= 0) closeSync(fd);
+  }
 }
 
 function evict(keep: string): void {
@@ -213,6 +310,9 @@ export interface FetchResult {
   path: string;
   url: string;
   error: string;
+  pixelWidth: number;
+  pixelHeight: number;
+  pixelRatio: number;
 }
 
 export function fetchAttachment(
@@ -223,7 +323,7 @@ export function fetchAttachment(
   maxBytes = FETCH_MAX_BYTES,
 ): FetchResult {
   const fail = (error: string, online = true): FetchResult =>
-    ({ ok: false, online, path: "", url: "", error });
+    ({ ok: false, online, path: "", url: "", error, ...EMPTY_IMAGE_METRICS });
 
   if (!/^[0-9]{1,18}$/.test(id)) return fail("bad attachment id");
   mkdirSync(CACHE_DIR, { recursive: true, mode: 0o700 });
@@ -236,7 +336,10 @@ export function fetchAttachment(
     if (st.isFile() && st.size > 0) {
       const now = new Date();
       utimesSync(file, now, now); // mtime is the LRU clock
-      return { ok: true, online: true, path: file, url: pathToFileURL(file).href, error: "" };
+      return {
+        ok: true, online: true, path: file, url: pathToFileURL(file).href, error: "",
+        ...cachedImageMetrics(file, mime),
+      };
     }
   } catch { /* not cached */ }
 
@@ -280,7 +383,10 @@ export function fetchAttachment(
   }
   renameSync(tmp, file);
   evict(cacheFileName(id, name, mime, preview));
-  return { ok: true, online: true, path: file, url: pathToFileURL(file).href, error: "" };
+  return {
+    ok: true, online: true, path: file, url: pathToFileURL(file).href, error: "",
+    ...imageMetrics(bytes.subarray(0, IMAGE_HEADER_BYTES), mime),
+  };
 }
 
 if (import.meta.main) {

--- a/paste.ts
+++ b/paste.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 /**
  * Blip clipboard paste helper — snapshots the Wayland clipboard ONCE and
- * reports what it held: an image (staged as a draft file) or text.
+ * reports what it held: a file, an image (staged as a draft file), or text.
  *
- *   bun paste.ts   →  {kind:"image", path, url} | {kind:"text", text} | {kind:"none"}
+ *   bun paste.ts   →  {kind:"file", path, url, name} | {kind:"image", path, url}
+ *                    | {kind:"text", text} | {kind:"none"}
  *
  * QML intercepts Ctrl+V and calls this instead of letting TextEdit paste,
  * because the decision (attach vs insert) needs the mime types, and probing
@@ -13,9 +14,9 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { lstatSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const RUNTIME = process.env.XDG_RUNTIME_DIR ?? `/run/user/${process.getuid?.() ?? 1000}`;
 export const DRAFT_DIR = join(RUNTIME, "blip");
@@ -29,6 +30,27 @@ export function pickImageType(types: string[]): string {
 
 export function extFor(mime: string): string {
   return { "image/png": "png", "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif" }[mime] ?? "img";
+}
+
+/** Preferred local-file clipboard format; GNOME carries copy/cut semantics. */
+export function pickFileType(types: string[]): string {
+  if (types.includes("x-special/gnome-copied-files")) return "x-special/gnome-copied-files";
+  if (types.includes("text/uri-list")) return "text/uri-list";
+  return "";
+}
+
+/** Extract the first safe local file from a Wayland file-copy payload. */
+export function localFileFromPayload(mime: string, payload: string): string {
+  const lines = payload.replace(/\r/g, "").split("\n").map((line) => line.trim()).filter(Boolean);
+  if (mime === "x-special/gnome-copied-files" && /^(copy|cut)$/i.test(lines[0] ?? "")) lines.shift();
+  const uri = lines.find((line) => !line.startsWith("#")) ?? "";
+  if (!uri.startsWith("file://")) return "";
+  try {
+    const path = fileURLToPath(uri);
+    return lstatSync(path).isFile() ? path : "";
+  } catch {
+    return "";
+  }
 }
 
 function gcDrafts(): void {
@@ -47,6 +69,18 @@ export function snapshotClipboard(runner = spawnSync): Record<string, string> {
   const types = runner("wl-paste", ["--list-types"], { encoding: "utf8", timeout: 4000 });
   if (types.status !== 0) return { kind: "none" };
   const offered = (types.stdout as string).trim().split("\n").filter(Boolean);
+
+  // File objects must win over their optional text representation. This is
+  // what makes Copy vCard → paste into another Blip conversation attach the
+  // .vcf instead of inserting its URI or source text into the composer.
+  const fileMime = pickFileType(offered);
+  if (fileMime !== "") {
+    const dump = runner("wl-paste", ["--no-newline", "-t", fileMime], { encoding: "utf8", timeout: 4000 });
+    if (dump.status === 0) {
+      const path = localFileFromPayload(fileMime, dump.stdout as string);
+      if (path !== "") return { kind: "file", path, url: pathToFileURL(path).href, name: basename(path) };
+    }
+  }
 
   const imageMime = pickImageType(offered);
   if (imageMime !== "") {

--- a/preferences.test.ts
+++ b/preferences.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_PREFERENCES,
+  MAX_PREFERENCES_BYTES,
+  normalizePreferences,
+  parsePreferences,
+  readBoundedPreferenceFile,
+  readPreferences,
+  writePreferences,
+} from "./preferences";
+
+const roots: string[] = [];
+function fixture(): { root: string; path: string } {
+  const root = mkdtempSync(join(tmpdir(), "blip-preferences-"));
+  roots.push(root);
+  return { root, path: join(root, "blip", "preferences.json") };
+}
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("preference schema", () => {
+  test("defaults normalize without changing appearance", () => {
+    expect(normalizePreferences(DEFAULT_PREFERENCES)).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  test("normalizes colors, integers, and bounded decimals", () => {
+    expect(normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      outgoingBubbleColor: "#AABBCC",
+      incomingBubbleColor: "#11223380",
+      backgroundOpacity: 0.733,
+      sidebarWidth: 333.8,
+    })).toEqual({
+      ...DEFAULT_PREFERENCES,
+      outgoingBubbleColor: "#aabbcc",
+      incomingBubbleColor: "#11223380",
+      backgroundOpacity: 0.73,
+      sidebarWidth: 334,
+    });
+  });
+
+  test("hides short-code conversations by default and validates the toggle", () => {
+    const legacy = { ...DEFAULT_PREFERENCES } as Record<string, unknown>;
+    delete legacy.hideShortCodeConversations;
+    expect(normalizePreferences(legacy).hideShortCodeConversations).toBe(true);
+    expect(normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      hideShortCodeConversations: false,
+    }).hideShortCodeConversations).toBe(false);
+    expect(() => normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      hideShortCodeConversations: "yes",
+    })).toThrow("boolean");
+  });
+
+  test("defaults legacy files to AM/PM conversation times and validates the choice", () => {
+    const legacy = { ...DEFAULT_PREFERENCES } as Record<string, unknown>;
+    delete legacy.use12HourConversationTimes;
+    expect(normalizePreferences(legacy).use12HourConversationTimes).toBe(true);
+    expect(normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      use12HourConversationTimes: false,
+    }).use12HourConversationTimes).toBe(false);
+    expect(() => normalizePreferences({
+      ...DEFAULT_PREFERENCES,
+      use12HourConversationTimes: "sometimes",
+    })).toThrow("boolean");
+  });
+
+  test("rejects every wrong top-level JSON type", () => {
+    for (const value of [null, [], "x", 1, true])
+      expect(() => normalizePreferences(value)).toThrow("JSON object");
+  });
+
+  test("rejects wrong versions, malformed colors, types, and ranges", () => {
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, schemaVersion: 2 })).toThrow("schemaVersion");
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, outgoingBubbleColor: "red" })).toThrow("outgoingBubbleColor");
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, density: "1" })).toThrow("finite number");
+    expect(() => normalizePreferences({ ...DEFAULT_PREFERENCES, avatarSize: 1000 })).toThrow("between");
+  });
+
+  test("malformed JSON is reported without echoing its content", () => {
+    expect(() => parsePreferences('{"secret":"do not echo"')).toThrow("not valid JSON");
+  });
+});
+
+describe("bounded preference file", () => {
+  test("a missing file yields defaults", () => {
+    const { path } = fixture();
+    expect(readPreferences(path)).toEqual({
+      exists: false,
+      preferences: DEFAULT_PREFERENCES,
+    });
+  });
+
+  test("round-trips atomically with private directory and file modes", () => {
+    const { root, path } = fixture();
+    const custom = { ...DEFAULT_PREFERENCES, fontScale: 1.2, density: 0.85 };
+    writePreferences(path, custom);
+    expect(readPreferences(path)).toEqual({ exists: true, preferences: custom });
+    expect(lstatSync(join(root, "blip")).mode & 0o777).toBe(0o700);
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    expect(readFileSync(path, "utf8")).toContain('"fontScale": 1.2');
+  });
+
+  test("accepts exactly the byte cap and rejects one byte over before parsing", () => {
+    const { root, path } = fixture();
+    const dir = join(root, "blip");
+    writePreferences(path, DEFAULT_PREFERENCES);
+    writeFileSync(path, Buffer.alloc(MAX_PREFERENCES_BYTES, 0x20));
+    expect(readBoundedPreferenceFile(path)?.length).toBe(MAX_PREFERENCES_BYTES);
+    writeFileSync(path, Buffer.alloc(MAX_PREFERENCES_BYTES + 1, 0x20));
+    expect(() => readBoundedPreferenceFile(path)).toThrow("too large");
+    expect(lstatSync(dir).isDirectory()).toBe(true);
+  });
+
+  test("rejects a symlink instead of following it", () => {
+    const { root, path } = fixture();
+    const target = join(root, "target.json");
+    writePreferences(target, DEFAULT_PREFERENCES);
+    const dir = join(root, "blip");
+    writePreferences(join(dir, "seed.json"), DEFAULT_PREFERENCES);
+    symlinkSync(target, path);
+    expect(() => readBoundedPreferenceFile(path)).toThrow();
+    expect(() => writePreferences(path, DEFAULT_PREFERENCES)).toThrow("regular file");
+  });
+
+  test("rejects a nonblocking FIFO", () => {
+    const { root, path } = fixture();
+    const dir = join(root, "blip");
+    writePreferences(join(dir, "seed.json"), DEFAULT_PREFERENCES);
+    expect(Bun.spawnSync(["mkfifo", path]).exitCode).toBe(0);
+    expect(() => readBoundedPreferenceFile(path)).toThrow("regular file");
+  });
+
+  test("tightens a permissive preferences directory", () => {
+    const { root, path } = fixture();
+    const dir = join(root, "blip");
+    writePreferences(path, DEFAULT_PREFERENCES);
+    chmodSync(dir, 0o755);
+    writePreferences(path, DEFAULT_PREFERENCES);
+    expect(lstatSync(dir).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe("CLI streaming boundary", () => {
+  test("exits before an oversized producer closes stdin", async () => {
+    const { path } = fixture();
+    const child = Bun.spawn(["bun", join(import.meta.dir, "preferences.ts"), "write"], {
+      env: { ...process.env, BLIP_PREFERENCES_PATH: path },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    child.stdin.write(Buffer.alloc(MAX_PREFERENCES_BYTES + 1, 0x20));
+    child.stdin.flush();
+    const result = await Promise.race([
+      child.exited.then((code) => ({ code })),
+      Bun.sleep(1500).then(() => ({ code: -999 })),
+    ]);
+    expect(result.code).not.toBe(-999);
+    expect(result.code).not.toBe(0);
+    try { child.stdin.end(); } catch { /* child already closed the pipe */ }
+  });
+});

--- a/preferences.ts
+++ b/preferences.ts
@@ -1,0 +1,344 @@
+/**
+ * Blip appearance preferences.
+ *
+ * QML never reads the user-writable file directly. This helper owns a small,
+ * bounded JSON contract and emits only normalized values. The same helper
+ * writes atomically with private permissions, so preferences.json is safe to
+ * copy into a dotfiles repository and restore later.
+ *
+ *   bun preferences.ts read
+ *   printf '%s' '{...}' | bun preferences.ts write
+ *   bun preferences.ts reset
+ */
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { basename, dirname, isAbsolute, join } from "node:path";
+
+export const MAX_PREFERENCES_BYTES = 16 * 1024;
+export const MAX_HELPER_OUTPUT_BYTES = 4 * 1024;
+
+export type BubbleColor = "theme" | `#${string}`;
+
+export interface BlipPreferences {
+  schemaVersion: 1;
+  outgoingBubbleColor: BubbleColor;
+  incomingBubbleColor: BubbleColor;
+  backgroundOpacity: number;
+  fontScale: number;
+  density: number;
+  sidebarWidth: number;
+  avatarSize: number;
+  cornerScale: number;
+  hideShortCodeConversations: boolean;
+  use12HourConversationTimes: boolean;
+}
+
+export const DEFAULT_PREFERENCES: Readonly<BlipPreferences> = Object.freeze({
+  schemaVersion: 1,
+  outgoingBubbleColor: "theme",
+  incomingBubbleColor: "theme",
+  backgroundOpacity: 0.7,
+  fontScale: 1,
+  density: 1,
+  sidebarWidth: 320,
+  avatarSize: 30,
+  cornerScale: 1,
+  hideShortCodeConversations: true,
+  use12HourConversationTimes: true,
+});
+
+const NUMBER_RULES = {
+  backgroundOpacity: { min: 0.2, max: 1, digits: 2 },
+  fontScale: { min: 0.75, max: 1.5, digits: 2 },
+  density: { min: 0.7, max: 1.4, digits: 2 },
+  sidebarWidth: { min: 240, max: 520, digits: 0 },
+  avatarSize: { min: 24, max: 64, digits: 0 },
+  cornerScale: { min: 0, max: 2, digits: 2 },
+} as const;
+
+function own(value: Record<string, unknown>, key: string): unknown {
+  return Object.prototype.hasOwnProperty.call(value, key) ? value[key] : undefined;
+}
+
+function normalizedColor(value: unknown, key: string): BubbleColor {
+  if (typeof value !== "string") throw new Error(`${key} must be "theme" or a hex color`);
+  const color = value.trim().toLowerCase();
+  if (color === "theme") return color;
+  if (!/^#[0-9a-f]{6}([0-9a-f]{2})?$/.test(color))
+    throw new Error(`${key} must be "theme", #rrggbb, or #rrggbbaa`);
+  return color as BubbleColor;
+}
+
+function normalizedNumber(
+  value: unknown,
+  key: keyof typeof NUMBER_RULES,
+): number {
+  const rule = NUMBER_RULES[key];
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error(`${key} must be a finite number`);
+  if (value < rule.min || value > rule.max)
+    throw new Error(`${key} must be between ${rule.min} and ${rule.max}`);
+  if (rule.digits === 0) return Math.round(value);
+  const factor = 10 ** rule.digits;
+  return Math.round(value * factor) / factor;
+}
+
+function normalizedBoolean(value: unknown, key: string, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") throw new Error(`${key} must be a boolean`);
+  return value;
+}
+
+/** Strict for known fields, tolerant of unknown future fields. */
+export function normalizePreferences(value: unknown): BlipPreferences {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("preferences must be a JSON object");
+  const input = value as Record<string, unknown>;
+  if (own(input, "schemaVersion") !== 1)
+    throw new Error("schemaVersion must be 1");
+
+  return {
+    schemaVersion: 1,
+    outgoingBubbleColor: normalizedColor(own(input, "outgoingBubbleColor"), "outgoingBubbleColor"),
+    incomingBubbleColor: normalizedColor(own(input, "incomingBubbleColor"), "incomingBubbleColor"),
+    backgroundOpacity: normalizedNumber(own(input, "backgroundOpacity"), "backgroundOpacity"),
+    fontScale: normalizedNumber(own(input, "fontScale"), "fontScale"),
+    density: normalizedNumber(own(input, "density"), "density"),
+    sidebarWidth: normalizedNumber(own(input, "sidebarWidth"), "sidebarWidth"),
+    avatarSize: normalizedNumber(own(input, "avatarSize"), "avatarSize"),
+    cornerScale: normalizedNumber(own(input, "cornerScale"), "cornerScale"),
+    hideShortCodeConversations: normalizedBoolean(
+      own(input, "hideShortCodeConversations"),
+      "hideShortCodeConversations",
+      true,
+    ),
+    use12HourConversationTimes: normalizedBoolean(
+      own(input, "use12HourConversationTimes"),
+      "use12HourConversationTimes",
+      true,
+    ),
+  };
+}
+
+export function parsePreferences(text: string): BlipPreferences {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("preferences.json is not valid JSON");
+  }
+  return normalizePreferences(parsed);
+}
+
+function currentUid(): number {
+  const uid = typeof process.getuid === "function" ? process.getuid() : -1;
+  if (uid < 0) throw new Error("cannot determine the current user");
+  return uid;
+}
+
+function openPinnedDirectory(path: string, create: boolean): number {
+  if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+  );
+  const stat = fstatSync(fd);
+  if (!stat.isDirectory()) {
+    closeSync(fd);
+    throw new Error("preferences directory is not a directory");
+  }
+  if (stat.uid !== currentUid()) {
+    closeSync(fd);
+    throw new Error("preferences directory is not owned by the current user");
+  }
+  if ((stat.mode & 0o077) !== 0) fchmodSync(fd, 0o700);
+  return fd;
+}
+
+function pinnedPath(directoryFd: number, name: string): string {
+  return `/proc/self/fd/${directoryFd}/${name}`;
+}
+
+/** Read exactly one pinned, regular, owner-controlled file with a hard cap. */
+export function readBoundedPreferenceFile(path: string): string | null {
+  const directoryFd = openPinnedDirectory(dirname(path), false);
+  let fileFd = -1;
+  try {
+    try {
+      fileFd = openSync(
+        pinnedPath(directoryFd, basename(path)),
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+    } catch (error: any) {
+      if (error?.code === "ENOENT") return null;
+      throw error;
+    }
+    const stat = fstatSync(fileFd);
+    if (!stat.isFile()) throw new Error("preferences.json must be a regular file");
+    if (stat.uid !== currentUid()) throw new Error("preferences.json is not owned by the current user");
+    if (stat.size > MAX_PREFERENCES_BYTES) throw new Error("preferences.json is too large");
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.alloc(Math.min(4096, MAX_PREFERENCES_BYTES + 1 - total));
+      const count = readSync(fileFd, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > MAX_PREFERENCES_BYTES) throw new Error("preferences.json is too large");
+      chunks.push(chunk.subarray(0, count));
+    }
+    return Buffer.concat(chunks, total).toString("utf8");
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    closeSync(directoryFd);
+  }
+}
+
+export function readPreferences(path: string): { exists: boolean; preferences: BlipPreferences } {
+  let text: string | null;
+  try {
+    text = readBoundedPreferenceFile(path);
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return { exists: false, preferences: { ...DEFAULT_PREFERENCES } };
+    throw error;
+  }
+  if (text === null) return { exists: false, preferences: { ...DEFAULT_PREFERENCES } };
+  return { exists: true, preferences: parsePreferences(text) };
+}
+
+function verifyReplaceableTarget(directoryFd: number, name: string): void {
+  try {
+    const stat = lstatSync(pinnedPath(directoryFd, name));
+    if (!stat.isFile()) throw new Error("preferences.json must be a regular file");
+    if (stat.uid !== currentUid()) throw new Error("preferences.json is not owned by the current user");
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+/** Atomic, owner-only write inside a pinned config directory. */
+export function writePreferences(path: string, value: unknown): BlipPreferences {
+  if (!isAbsolute(path)) throw new Error("preferences path must be absolute");
+  const preferences = normalizePreferences(value);
+  const serialized = `${JSON.stringify(preferences, null, 2)}\n`;
+  if (Buffer.byteLength(serialized) > MAX_PREFERENCES_BYTES)
+    throw new Error("normalized preferences exceed the size limit");
+
+  const directoryFd = openPinnedDirectory(dirname(path), true);
+  const name = basename(path);
+  const tempName = `.${name}.tmp.${process.pid}.${randomBytes(6).toString("hex")}`;
+  const tempPath = pinnedPath(directoryFd, tempName);
+  let tempFd = -1;
+  let renamed = false;
+  try {
+    verifyReplaceableTarget(directoryFd, name);
+    tempFd = openSync(
+      tempPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    const bytes = Buffer.from(serialized, "utf8");
+    let offset = 0;
+    while (offset < bytes.length) offset += writeSync(tempFd, bytes, offset, bytes.length - offset);
+    fchmodSync(tempFd, 0o600);
+    fsyncSync(tempFd);
+    closeSync(tempFd);
+    tempFd = -1;
+    renameSync(tempPath, pinnedPath(directoryFd, name));
+    renamed = true;
+    chmodSync(pinnedPath(directoryFd, name), 0o600);
+    fsyncSync(directoryFd);
+    return preferences;
+  } finally {
+    if (tempFd >= 0) closeSync(tempFd);
+    if (!renamed) {
+      try { unlinkSync(tempPath); } catch { /* no temporary file */ }
+    }
+    closeSync(directoryFd);
+  }
+}
+
+export async function readStdinBounded(
+  input: AsyncIterable<Uint8Array | string> = process.stdin as any,
+  maximum = MAX_PREFERENCES_BYTES,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const raw of input) {
+    const chunk = typeof raw === "string" ? Buffer.from(raw) : Buffer.from(raw);
+    total += chunk.length;
+    if (total > maximum) throw new Error("preference input is too large");
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function safeError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : "preference operation failed";
+  return raw
+    .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180) || "preference operation failed";
+}
+
+function emit(value: unknown): void {
+  const output = JSON.stringify(value);
+  if (Buffer.byteLength(output) > MAX_HELPER_OUTPUT_BYTES)
+    throw new Error("preference helper output exceeded its contract");
+  process.stdout.write(`${output}\n`);
+}
+
+export function preferencesPath(): string {
+  const overridden = process.env.BLIP_PREFERENCES_PATH;
+  if (overridden) {
+    if (!isAbsolute(overridden)) throw new Error("BLIP_PREFERENCES_PATH must be absolute");
+    return overridden;
+  }
+  const home = process.env.HOME;
+  if (!home || !isAbsolute(home)) throw new Error("HOME must be an absolute path");
+  return join(home, ".config", "blip", "preferences.json");
+}
+
+async function main(): Promise<void> {
+  const operation = process.argv[2] || "read";
+  const path = preferencesPath();
+  try {
+    if (operation === "read") {
+      emit({ ok: true, ...readPreferences(path) });
+      return;
+    }
+    if (operation === "write") {
+      const text = await readStdinBounded();
+      const preferences = writePreferences(path, parsePreferences(text));
+      emit({ ok: true, exists: true, preferences });
+      return;
+    }
+    if (operation === "reset") {
+      const preferences = writePreferences(path, DEFAULT_PREFERENCES);
+      emit({ ok: true, exists: true, preferences });
+      return;
+    }
+    throw new Error("operation must be read, write, or reset");
+  } catch (error) {
+    emit({ ok: false, error: safeError(error) });
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) await main();

--- a/thread.test.ts
+++ b/thread.test.ts
@@ -169,6 +169,7 @@ describe("decorate", () => {
     expect(b[0]!.groupStart).toBe(true);
     expect(b[0]!.groupEnd).toBe(true);
     expect(b[0]!.time).toBe("12:00 PM");
+    expect(b[0]!.handle).toBe("+15551234567");
   });
 
   test("the patterns reach the divider, the timestamp and the read receipt", () => {
@@ -436,10 +437,40 @@ describe("selectThread", () => {
     expect(seen).toContain("--chat");
     expect(seen[seen.indexOf("--chat") + 1]).toBe(guid);
   });
+
+  test("a coalesced group loads and selects every exact historical alias", () => {
+    const oldGuid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const raw = [
+      msg({ chat: oldGuid, ts: "2026-08-29 12:00:00", text: "old history" }),
+      msg({ chat: guid, ts: "2026-08-30 12:00:00", text: "new history" }),
+    ];
+    expect(selectThread(raw, guid, true, 80, [], [oldGuid]).map((m) => m.text))
+      .toEqual(["old history", "new history"]);
+    let seen: string[] = [];
+    const runner = ((_: string, args: string[]) => {
+      seen = args;
+      return { status: 0, stdout: JSON.stringify(raw), stderr: "" };
+    }) as never;
+    const out = loadThread(guid, 80, "2026-08-30", DEFAULT_FORMATS, runner, [oldGuid]);
+    expect(seen).not.toContain("--also-chat");
+    expect(seen[seen.indexOf("--chat") + 1]).toBe(guid);
+    expect(out.bubbles.map((bubble) => bubble.text)).toEqual(["old history", "new history"]);
+  });
 });
 
 describe("linkify", () => {
-  const { linkify } = require("./thread") as typeof import("./thread");
+  const { linkify, standaloneUrl, standaloneEmoji } = require("./thread") as typeof import("./thread");
+
+  test("recognizes only short emoji-only messages as expressive", () => {
+    expect(standaloneEmoji("🤗")).toBe(true);
+    expect(standaloneEmoji("❤️ 👍🏽")).toBe(true);
+    expect(standaloneEmoji("👨‍👩‍👧‍👦")).toBe(true);
+    expect(standaloneEmoji("🇺🇸")).toBe(true);
+    expect(standaloneEmoji("1️⃣")).toBe(true);
+    expect(standaloneEmoji("hello 🤗")).toBe(false);
+    expect(standaloneEmoji("🤗🤗🤗🤗")).toBe(false);
+    expect(standaloneEmoji(" ")).toBe(false);
+  });
 
   test("no URL → empty string (PlainText fast path)", () => {
     expect(linkify("just words")).toBe("");
@@ -472,6 +503,11 @@ describe("linkify", () => {
 
   test("newlines become <br> in the rich path", () => {
     expect(linkify("https://a.io\nline2")).toBe('<a href="https://a.io">https://a.io</a><br>line2');
+  });
+
+  test("a standalone shared URL is recognized even when metadata canonicalizes it", () => {
+    expect(standaloneUrl("https://example.com/reel/one?tracking=abc")).toBe(true);
+    expect(standaloneUrl("look https://example.com/reel/one")).toBe(false);
   });
 });
 
@@ -508,6 +544,21 @@ describe("rich decoration", () => {
       today,
     );
     expect(out[0]!.attachments.map((a) => a.name)).toEqual(["real.pdf"]);
+  });
+
+  test("an unfurled card suppresses a URL-only body but keeps a real caption", () => {
+    const link = {
+      url: "https://example.com/reel/one",
+      title: "One reel",
+      summary: "",
+      image_id: "10",
+    };
+    const out = decorate([
+      msg({ text: "https://example.com/reel/one?tracking=abc", link }),
+      msg({ ts: "2026-08-30 12:01:00", text: "Look at this https://example.com/reel/one", link }),
+    ], today);
+    expect(out[0]!.linkOnly).toBe(true);
+    expect(out[1]!.linkOnly).toBe(false);
   });
 
   test("attachment placeholder char is stripped, chips pass through", () => {
@@ -548,6 +599,13 @@ describe("rich decoration", () => {
     expect(out[0]!.replyText).toBe("");
     expect(out[0]!.edited).toBe(false);
     expect(out[0]!.retracted).toBe(false);
+    expect(out[0]!.linkOnly).toBe(false);
+    expect(out[0]!.emojiOnly).toBe(false);
+  });
+
+  test("decorates an emoji-only message for expressive rendering", () => {
+    const out = decorate([msg({ text: "🤗" })], today);
+    expect(out[0]!.emojiOnly).toBe(true);
   });
 });
 

--- a/thread.ts
+++ b/thread.ts
@@ -54,8 +54,12 @@ export const GROUP_GAP_MINUTES = 15;
 export interface Bubble {
   ts: string;
   from_me: boolean;
+  /** Sender handle retained for contact actions; never rendered directly when a name exists. */
+  handle: string;
   name: string;
   text: string;
+  /** One to three emoji and no prose/media — rendered at Messages' expressive size. */
+  emojiOnly: boolean;
   /** Non-empty on the first message of a new calendar day: "Today", "Aug 28". */
   day: string;
   /** First bubble of a run by one sender — gets the rounded outer corner. */
@@ -76,6 +80,8 @@ export interface Bubble {
   edited: boolean;
   /** Rich-link preview card, null when the message has none. */
   link: LinkCard | null;
+  /** The body is only the shared URL already represented by `link`. */
+  linkOnly: boolean;
   /** An unsent message renders as a tombstone, not a bubble. */
   retracted: boolean;
   /** Screen/bubble effect short name ("confetti"), "" when none. */
@@ -201,6 +207,28 @@ export function minutesBetween(a: string, b: string): number {
   return Math.abs(pb - pa) / 60000;
 }
 
+/** Metadata often canonicalizes a shared URL by dropping tracking parameters. */
+export function standaloneUrl(text: string): boolean {
+  return /^(?:https?:\/\/|www\.)[^\s<>"']+$/i.test(String(text ?? "").trim());
+}
+
+// A single user-perceived emoji can span several code points (skin tone,
+// variation selector, family ZWJ sequence, flag, or keycap). Segment by
+// grapheme first so those still count as one expressive glyph.
+const EMOJI_GRAPHEME = /^(?:\p{Regional_Indicator}{2}|[#*0-9]\uFE0F?\u20E3|\p{Extended_Pictographic}(?:\uFE0E|\uFE0F)?(?:\p{Emoji_Modifier})?(?:\u200D\p{Extended_Pictographic}(?:\uFE0E|\uFE0F)?(?:\p{Emoji_Modifier})?)*)$/u;
+
+/** Messages-style expressive text: one to three emoji, with no prose. */
+export function standaloneEmoji(text: string): boolean {
+  const compact = String(text ?? "").trim().replace(/\s+/gu, "");
+  if (!compact) return false;
+  const graphemes = Array.from(
+    new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(compact),
+    (part) => part.segment,
+  );
+  return graphemes.length >= 1 && graphemes.length <= 3 &&
+    graphemes.every((part) => EMOJI_GRAPHEME.test(part));
+}
+
 // ---------------------------------------------------------------- decoration
 
 /**
@@ -241,14 +269,21 @@ export function decorate(msgs: ImsgMessage[], today: string, formats = DEFAULT_F
       next.ts.slice(0, 10) !== m.ts.slice(0, 10) ||
       !sameSender(m, next) ||
       minutesBetween(m.ts, next.ts) > GROUP_GAP_MINUTES;
+    const cleanText = (m.text ?? "").replace(/￼/g, "").trim();
+    const link = normalizeLink(m.link);
+    const attachments = (m.attachments ?? []).filter(
+      (a) => !String(a.name || "").endsWith(".pluginPayloadAttachment"),
+    );
 
     out.push({
       ts: m.ts,
       from_me: m.from_me,
+      handle: m.handle ?? "",
       name: m.name ?? m.handle ?? "",
       // U+FFFC is the object-replacement placeholder Messages leaves where an
       // attachment sat; the chip row carries that information instead.
-      text: (m.text ?? "").replace(/￼/g, "").trim(),
+      text: cleanText,
+      emojiOnly: link === null && attachments.length === 0 && standaloneEmoji(cleanText),
       day: newDay ? dayLabel(m.ts, today, formats) : "",
       groupStart,
       groupEnd,
@@ -256,17 +291,16 @@ export function decorate(msgs: ImsgMessage[], today: string, formats = DEFAULT_F
       receipt: i === receiptIdx ? receiptLabel(m.read_at!, today, formats) : "",
       tapbacks: m.tapbacks ?? [],
       // Belt to imsg 1.5.1's suspenders: link-preview payloads are not files.
-      attachments: (m.attachments ?? []).filter(
-        (a) => !String(a.name || "").endsWith(".pluginPayloadAttachment"),
-      ),
+      attachments,
       replyText: m.reply_to?.text ?? "",
       replyMine: m.reply_to?.from_me ?? false,
       edited: m.edited === true,
-      link: normalizeLink(m.link),
+      link,
+      linkOnly: link !== null && standaloneUrl(cleanText),
       retracted: m.retracted === true,
       effect: m.effect ?? "",
       audio: m.audio === true,
-      html: linkify((m.text ?? "").replace(/￼/g, "").trim()),
+      html: linkify(cleanText),
       failed: m.from_me && typeof m.error === "number" && m.error !== 0,
     });
   }
@@ -344,13 +378,16 @@ export function selectThread(
   group: boolean,
   limit: number,
   selfChats: string[] = [],
+  aliases: string[] = [],
 ): ImsgMessage[] {
   // Exact-filter DMs too: `imsg thread` matches the handle by SUBSTRING, so
   // +15551234567 can pull rows from +995551234567 into the wrong conversation
   // (Codex finding #3).
+  const accepted = new Set([chat, ...aliases]);
   // A DM is scoped by CHAT, not by sender: the same handle's messages in a
   // group carry the group's chat id and must stay out of the 1:1 thread.
-  let msgs = raw.filter((m) => chatKey(m) === chat || (!group && m.handle === chat && !isGroupChat(chatKey(m))));
+  let msgs = raw.filter((m) => accepted.has(chatKey(m)) ||
+    (!group && m.handle === chat && !isGroupChat(chatKey(m))));
   msgs = [...msgs].sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
   msgs = dedupeSelfEcho(msgs, selfChats);
   return msgs.length > limit ? msgs.slice(msgs.length - limit) : msgs;
@@ -364,6 +401,7 @@ export function loadThread(
   today: string,
   formats = DEFAULT_FORMATS,
   runner = spawnSync,
+  aliases: string[] = [],
 ): ThreadOutput {
   // Groups load by EXACT chat id (imsg ≥1.8.0 `thread --chat`). The old
   // recent-window scan cost ~20× the rows and missed anything older than
@@ -373,6 +411,10 @@ export function loadThread(
   // window (war room #14). A DM's chat_identifier IS the handle.
   const group = isGroupChat(chat);
   const args = ["--json", "--rich", "thread", "--chat", chat, String(limit)];
+  const safeAliases = [...new Set(aliases)]
+    .filter((alias) => alias !== chat && alias.length > 0 && alias.length <= 512 &&
+      !/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/.test(alias))
+    .slice(0, 15);
   const res = runner(`${HOME}/bin/imsg`, args, {
     encoding: "utf8",
     timeout: 15000, maxBuffer: 64 * 1024 * 1024,
@@ -388,7 +430,7 @@ export function loadThread(
   try {
     const parsed = JSON.parse(res.stdout as string);
     if (!Array.isArray(parsed)) throw new Error("not an array");
-    const msgs = selectThread(parsed as ImsgMessage[], chat, group, limit, loadState().selfChats);
+    const msgs = selectThread(parsed as ImsgMessage[], chat, group, limit, loadState().selfChats, safeAliases);
     return { ok: true, online: true, error: "", bubbles: decorate(msgs, today, formats) };
   } catch (e) {
     return { ok: false, online: true, error: `bad JSON from imsg: ${e}`, bubbles: [] };
@@ -410,9 +452,16 @@ export function cliChatArg(raw: string): string {
 if (import.meta.main) {
   const chat = cliChatArg(process.argv[2] ?? "");
   const limit = Number(process.argv[3] ?? 80) || 80;
+  const aliases: string[] = [];
+  for (let i = 4; i < process.argv.length; i++) {
+    const arg = process.argv[i] ?? "";
+    if (arg.startsWith("--")) { i++; continue; }
+    aliases.push(arg);
+  }
   const today = localToday();
   try {
-    console.log(JSON.stringify(loadThread(chat, limit, today, formatsFromArgv(process.argv))));
+    console.log(JSON.stringify(loadThread(
+      chat, limit, today, formatsFromArgv(process.argv), spawnSync, aliases)));
   } catch (e) {
     console.log(JSON.stringify({ ok: false, online: false, error: String(e), bubbles: [] }));
   }

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { CACHE_DIR, bakeOrientation, cacheFileName, exifOrientation, fetchAttachment, isImageMime, jpegtranArgs, lruEvictions, sanitizeName, wantsJpeg } from "./fetch";
-import { extFor, pickImageType } from "./paste";
+import { CACHE_DIR, bakeOrientation, cacheFileName, exifOrientation, fetchAttachment, imageMetrics, isImageMime, jpegtranArgs, lruEvictions, sanitizeName, wantsJpeg } from "./fetch";
+import { extFor, localFileFromPayload, pickFileType, pickImageType, snapshotClipboard } from "./paste";
 import { resolveTarget, sendFile } from "./send-file";
 import { linkHost, linkify, normalizeLink, selectThread } from "./thread";
 import {
@@ -17,7 +17,7 @@ import {
 import { AVATAR_DIR, AVATAR_NONE_TTL_MS, AVATAR_TTL_MS, avatarArgs, avatarKey, fetchAvatar } from "./avatar";
 import { readFileSync, writeFileSync, unlinkSync, utimesSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 // A real 16×8 baseline JPEG (ImageMagick, -strip): no APP1 at all.
 const TINY_JPEG = Buffer.from(
@@ -66,6 +66,28 @@ describe("fetch cache", () => {
     expect(orig).toBe("42-orig-IMG_1.png");
     expect(conv).toBe("42-jpg-IMG_1.jpg");   // extension follows the delivered format
     expect(orig).not.toBe(conv);
+  });
+
+  test("retina PNG density becomes a logical-pixel ratio", () => {
+    const png = Buffer.alloc(54);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0);
+    png.writeUInt32BE(13, 8); Buffer.from("IHDR").copy(png, 12);
+    png.writeUInt32BE(1206, 16); png.writeUInt32BE(1728, 20);
+    png.writeUInt32BE(9, 33); Buffer.from("pHYs").copy(png, 37);
+    png.writeUInt32BE(5669, 41); png.writeUInt32BE(5669, 45); png[49] = 1;
+    expect(imageMetrics(png, "image/png")).toEqual({
+      pixelWidth: 1206, pixelHeight: 1728, pixelRatio: 2,
+    });
+  });
+
+  test("ordinary PNG density stays at one logical pixel per source pixel", () => {
+    const png = Buffer.alloc(24);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png, 0);
+    png.writeUInt32BE(13, 8); Buffer.from("IHDR").copy(png, 12);
+    png.writeUInt32BE(800, 16); png.writeUInt32BE(600, 20);
+    expect(imageMetrics(png, "image/png")).toEqual({
+      pixelWidth: 800, pixelHeight: 600, pixelRatio: 1,
+    });
   });
 
   test("sanitizeName strips traversal and hidden-file tricks", () => {
@@ -186,6 +208,45 @@ describe("EXIF orientation is baked into cached JPEGs", () => {
     expect(sofSize(withExif(TINY_JPEG, 6))).toEqual([16, 8]);
     expect(sofSize(out)).toEqual([8, 16]);
     expect(exifOrientation(out)).toBe(1);                    // tag gone: no double rotation in Qt
+  });
+});
+
+describe("clipboard file paste", () => {
+  test("prefers a GNOME file object over URI-list and text", () => {
+    expect(pickFileType(["text/plain", "text/uri-list", "x-special/gnome-copied-files"]))
+      .toBe("x-special/gnome-copied-files");
+  });
+
+  test("extracts an existing local file from both supported payloads", () => {
+    const tmp = `${process.env.HOME}/.cache/blip-paste-${process.pid}.vcf`;
+    writeFileSync(tmp, "BEGIN:VCARD\nEND:VCARD\n");
+    const uri = new URL(`file://${tmp}`).href;
+    try {
+      expect(localFileFromPayload("x-special/gnome-copied-files", `copy\n${uri}\n`)).toBe(tmp);
+      expect(localFileFromPayload("text/uri-list", `# contact\r\n${uri}\r\n`)).toBe(tmp);
+    } finally { unlinkSync(tmp); }
+  });
+
+  test("rejects remote URIs and missing local files", () => {
+    expect(localFileFromPayload("text/uri-list", "https://example.com/person.vcf\n")).toBe("");
+    expect(localFileFromPayload("text/uri-list", "file:///definitely/missing/person.vcf\n")).toBe("");
+  });
+
+  test("snapshot returns a file attachment before attempting text", () => {
+    const tmp = `${process.env.HOME}/.cache/blip-snapshot-${process.pid}.vcf`;
+    writeFileSync(tmp, "BEGIN:VCARD\nEND:VCARD\n");
+    const calls: string[][] = [];
+    const runner = ((_cmd: string, args: string[]) => {
+      calls.push(args);
+      if (args.includes("--list-types")) {
+        return { status: 0, stdout: "text/plain\nx-special/gnome-copied-files\n" };
+      }
+      return { status: 0, stdout: `copy\n${new URL(`file://${tmp}`).href}\n` };
+    }) as never;
+    try {
+      expect(snapshotClipboard(runner)).toMatchObject({ kind: "file", path: tmp, name: basename(tmp) });
+      expect(calls.some((args) => args.includes("text"))).toBe(false);
+    } finally { unlinkSync(tmp); }
   });
 });
 

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -4,6 +4,16 @@ import { CACHE_DIR, bakeOrientation, cacheFileName, exifOrientation, fetchAttach
 import { extFor, pickImageType } from "./paste";
 import { resolveTarget, sendFile } from "./send-file";
 import { linkHost, linkify, normalizeLink, selectThread } from "./thread";
+import {
+  decodeEntities,
+  hostOf,
+  isPrivateAddress,
+  parseCard,
+  previewsEnabled,
+  previewKey,
+  safeUrl,
+  sniffImage,
+} from "./linkpreview";
 import { AVATAR_DIR, AVATAR_NONE_TTL_MS, AVATAR_TTL_MS, avatarArgs, avatarKey, fetchAvatar } from "./avatar";
 import { readFileSync, writeFileSync, unlinkSync, utimesSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -596,10 +606,6 @@ describe("country code + service (2.2.0)", () => {
 });
 
 describe("link previews for URLs Messages never decorated", () => {
-  const {
-    decodeEntities, hostOf, isPrivateAddress, parseCard, previewsEnabled, previewKey, safeUrl, sniffImage,
-  } = require("./linkpreview") as typeof import("./linkpreview");
-
   test("Open Graph wins, then Twitter, then the plain document", () => {
     const html = `<html><head>
       <title>fallback title</title>

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -4,6 +4,9 @@ import { readFileSync } from "node:fs";
 // The renderer moved from Panel.qml into BlipView.qml in 1.8.0 (shared with the app window).
 const panel = readFileSync(new URL("./BlipView.qml", import.meta.url), "utf8");
 const widget = readFileSync(new URL("./BarWidget.qml", import.meta.url), "utf8");
+const settings = readFileSync(new URL("./BlipSettings.qml", import.meta.url), "utf8");
+const preferences = readFileSync(new URL("./BlipPreferences.qml", import.meta.url), "utf8");
+const popout = readFileSync(new URL("./Panel.qml", import.meta.url), "utf8");
 const window = readFileSync(new URL("./BlipWindow.qml", import.meta.url), "utf8");
 
 function handleTextKeySource() {
@@ -68,7 +71,9 @@ describe("QML safety invariants", () => {
 
   test("group rows and tiles show the GROUP's photo, never the last speaker's", () => {
     const bind = 'root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")';
-    expect(panel.split(bind).length - 1).toBe(2);   // list row + pinned tile
+    expect(panel).toContain(bind);   // chronological row
+    expect(panel).toContain('root.isGroupId(String(thread.chat || ""))');   // pinned tile
+    expect(panel).toContain('? String(thread.chat)');
     expect(panel).not.toContain('if (!root.isGroupId(String(modelData.chat || ""))) root.requestAvatar(avatarHandle)');
     expect(panel).not.toContain('if (handle === "" || isGroupId(handle)) return');
   });
@@ -91,13 +96,196 @@ describe("QML safety invariants", () => {
     expect(widget).not.toContain('/^[0-9]+$/.test(want)');
   });
 
+  test("message links and grouped bubble corners follow the bubble palette", () => {
+    expect(panel).toContain("function richMessageHtml(html, linkColor)");
+    expect(panel).toContain('text-decoration: underline;');
+    expect(panel).toContain("fillColor: bubble.color");
+    expect(panel).toContain("modelData.groupEnd === true && !bubbleRow.mine");
+    expect(panel).toContain("modelData.linkOnly !== true");
+    expect(panel).toContain("id: tapbackPill");
+    expect(panel).toContain("font.pixelSize: root.fontSize(Style.font.heading)");
+    expect(panel).toContain("border.width: 0");
+    expect(panel).toContain("function opaqueOver(fill, background)");
+    expect(panel).toContain("id: tapbackTailLarge");
+    expect(panel).toContain("id: tapbackTailSmall");
+    expect(panel).toContain("component TapbackReaction: Rectangle");
+    expect(panel).toContain("reactions: modelData.link ? [] : (modelData.tapbacks || [])");
+    expect(panel).not.toContain("color: bubble.color\n                      anchors.bottom");
+  });
+
+  test("standalone emoji use expressive Messages-style sizing without a bubble", () => {
+    expect(panel).toContain("readonly property bool expressiveEmoji: modelData.emojiOnly === true");
+    expect(panel).toContain("visible: !bubble.expressiveEmoji");
+    expect(panel).toContain("root.fontSize(Style.font.bodySmall) * 4.1");
+  });
+
+  test("group messages reserve one avatar lane and paint only at run end", () => {
+    expect(panel).toContain("component GroupMessageAvatarSlot: Item");
+    expect(panel).toContain("readonly property bool runEndsHere: incomingGroup && modelData.groupEnd === true");
+    expect(panel).toContain("showAvatar: bubbleRow.runEndsHere && !bubbleRow.hasTextBubble");
+    expect(panel).toContain("root.requestAvatar(handle)");
+  });
+
+  test("inline media has a logical-width cap on wide and high-DPI windows", () => {
+    expect(panel).toContain("Math.round(content.width * 0.6), root.space(380)");
+    expect(panel).toContain("Number(chipRow.imageMetrics.pixelWidth) / pixelRatio");
+    expect(panel).toContain("metrics[id] = { pixelRatio: ratio, pixelWidth: pixelWidth, pixelHeight: pixelHeight }");
+  });
+
+  test("link previews keep portrait artwork and pinned group titles", () => {
+    expect(panel).toContain("Math.min(root.space(480)");
+    expect(panel).toContain("fillMode: Image.PreserveAspectFit");
+    expect(panel).toContain("root.active.pin_name || root.active.name || root.active.chat");
+  });
+
+  test("the app sidebar does not duplicate the window's outer left inset", () => {
+    expect(panel).toContain("anchors.leftMargin: root.splitView ? root.space(6) : 0");
+    expect(panel).toContain("retain the larger right gutter beside the pane divider");
+  });
+
+  test("the sidebar header is compact and pinned labels use Messages names", () => {
+    expect(panel).toContain('tooltipText: "Settings"');
+    expect(panel).toContain("readonly property real splitHeaderHeight");
+    expect(panel).toContain("Layout.topMargin: root.splitView ? root.space(6) : 0");
+    expect(panel).toContain("spacing: root.splitView\n              ? root.space(10)");
+    expect(panel).toContain('root.unread > 0 ? root.unread + " UNREAD" : "ALL CAUGHT UP"');
+    expect(panel).toContain("Layout.preferredHeight: root.splitView\n            ? root.splitHeaderHeight");
+    expect(panel).toContain("id: splitConversationHero");
+    expect(panel).toContain("id: conversationHeaderSpacer");
+    expect(panel).toContain("Math.max(root.space(160), conversationPane.width * 0.50)");
+    expect(panel).toContain('text: !root.inThread\n                ? ""');
+    expect(panel).toContain("Layout.alignment: Qt.AlignVCenter");
+    expect(panel).not.toContain('visible: root.splitView && !root.newMode\n            Layout.alignment: Qt.AlignTop');
+    expect(panel).toContain("thread.pin_name || thread.name || thread.chat");
+    expect(panel.match(/id: pinnedGrid/g)).toHaveLength(1);
+    expect(panel).not.toContain('text: "PINNED"');
+    expect(panel).not.toContain('? "SEARCH" : "MESSAGES"');
+  });
+
+  test("bubble right-clicks copy the message only", () => {
+    expect(panel).toContain('text: "Copy message"');
+    expect(panel).toContain("id: messageOnlyMenu");
+    expect(panel).toContain("function openMessageContext(messageText)");
+    expect(panel).toContain("root.openMessageContext(String(modelData.text || \"\"))");
+  });
+
+  test("chronological sidebar discussions use post-avatar separators", () => {
+    expect(panel).toContain("Messages separates chronological conversations");
+    expect(panel).toContain("avatarCircle.width + root.space(8)");
+    expect(panel).toContain("index < root.regularThreads.length - 1");
+  });
+
+  test("appearance previews the app to scale with real bubble corners and portable list times", () => {
+    expect(settings).toContain("component AppearancePreview: Rectangle");
+    expect(settings).toContain('text: "LIVE APP PREVIEW"');
+    expect(settings).toContain("configuredSidebar");
+    expect(settings).toContain("configuredAvatar");
+    // one uniform scale transform over REAL app dimensions — the raw-px
+    // sidebar and spaceReal avatar formulas, never per-part fudge factors
+    expect(settings).toContain("scale: appearancePreview.previewScale");
+    expect(settings).toContain("Layout.preferredWidth: appearancePreview.configuredSidebar");
+    expect(settings).toContain("Math.round(Style.spaceReal(configuredAvatar) * 1.75), root.liveSpace(48))");
+    // fixed 1040×720 reference geometry, capped at an honest 100%
+    expect(settings).toContain("readonly property real appWidth: 1040");
+    expect(settings).toContain("Math.max(0.05, Math.min(1,");
+    expect(settings).not.toContain("previewSidebar");
+    expect(settings).not.toContain("* 0.76");
+    expect(settings).toContain("component PreviewBubble: Item");
+    expect(settings).toContain("previewBubble.mine ? previewBubble.height");
+    expect(settings).toContain('label: "12-hour (AM/PM)"');
+    expect(settings).toContain('setBoolean("use12HourConversationTimes", true)');
+    expect(widget).toContain("preferences.use12HourConversationTimes");
+  });
+
+  test("settings opens on the appearance page", () => {
+    expect(settings).toContain('property string page: "appearance"');
+    expect(settings).toContain('label: "Appearance"');
+    expect(panel).toContain('settingsView.showPage("appearance")');
+  });
+
+  test("appearance sliders re-lay-out only the preview, never the settings chrome", () => {
+    // chrome uses scales frozen at open; the scaled miniature tracks live values
+    expect(settings).toContain("function freezeChrome()");
+    expect(settings).toContain("onVisibleChanged: if (visible) freezeChrome()");
+    expect(settings).toContain("Math.round(value * chromeFontScale)");
+    expect(settings).toContain("Style.spaceReal(value) * chromeDensity");
+    expect(settings).toContain("function liveSpace(value)");
+  });
+
+  test("the settings hint cannot stretch the narrow popout", () => {
+    expect(settings).toContain("horizontalAlignment: Text.AlignRight");
+    const hint = settings.indexOf('text: "Changes preview and apply live"');
+    expect(hint).toBeGreaterThan(0);
+    const block = settings.slice(hint - 400, hint);
+    expect(block).toContain("Layout.fillWidth: true");
+    expect(block).toContain("elide: Text.ElideRight");
+  });
+
+  test("chronological rows are contiguous so hover fills up to the separator", () => {
+    expect(panel).toContain("root.space(root.splitView ? 30 : 18)");
+    expect(panel).not.toContain("root.space(root.splitView ? 20 : 12)");
+    expect(panel).toContain("// Chronological rows are CONTIGUOUS");
+    // separators touching a highlighted row hide so the hover reads as one block
+    expect(panel).toContain("!chronoRows.rowActive(index) && !chronoRows.rowActive(index + 1)");
+    expect(panel).toContain("if (hovered) chronoRows.hoveredRow = index");
+  });
+
+  test("popout header hosts new/window/settings actions and widens for settings", () => {
+    expect(panel).toContain("id: headerActions");
+    // ordered by function: content action, surface action, configuration
+    const plus = panel.indexOf('tooltipText: "New message (n)"');
+    const promote = panel.indexOf('tooltipText: "Open the app window (SUPER+M)"');
+    const gear = panel.indexOf('tooltipText: "Settings"');
+    expect(plus).toBeGreaterThan(-1);
+    expect(promote).toBeGreaterThan(plus);
+    expect(gear).toBeGreaterThan(promote);
+    // settings double the dropdown: appearance fits preview + controls side by
+    // side, and the contacts review/compare workflows get room to function
+    expect(panel).toContain("readonly property bool settingsWide: settingsMode");
+    expect(settings).toContain("readonly property real wideWidth");
+    // two-column threshold sits well below the wide width: space() shrinks with
+    // density while the panel padding does not, and a near-equal pair stacked
+    expect(settings).toContain("width >= root.space(700) ? 2 : 1");
+    expect(popout).toContain("view.settingsWide ? view.settingsWideWidth : Style.space(352)");
+    expect(widget).toContain("function panelsettings(page: string): string");
+  });
+
+  test("previewable compose drafts show the image, other files show the name", () => {
+    expect(panel).toContain("readonly property bool draftIsImage");
+    // the pill stays for non-images and while the preview decodes; a decoded
+    // image replaces it (and a broken file falls back to the pill)
+    expect(panel).toContain("visible: !(root.draftIsImage && draftImage.status === Image.Ready)");
+    expect(panel).toContain("visible: root.draftIsImage && draftImage.status === Image.Ready");
+    const draftImage = panel.slice(panel.indexOf("id: draftImage"), panel.indexOf("id: draftImage") + 900);
+    expect(draftImage).toContain("autoTransform: true");
+    expect(draftImage).toContain("fillMode: Image.PreserveAspectFit");
+  });
+
+  test("pinned tiles center the avatar and name inside their outline", () => {
+    expect(panel).toContain("implicitHeight: pinContent.implicitHeight + root.space(12)");
+    expect(panel).toContain("id: pinContent");
+    expect(panel).not.toContain("pinAvatarSize + root.space(38)");
+  });
+
+  test("coalesced chat aliases load one history and clear one logical unread state", () => {
+    expect(panel).toContain("property var threadRunningAliases: []");
+    expect(panel).toContain('.concat(threadRunningAliases)');
+    expect(panel).toContain("threadContainsChat(threads[i], hit.chat)");
+    expect(widget).toContain('args.push("--read-alias", req.readAliases[i])');
+    expect(widget).toContain("root.activeReadAliases()");
+  });
+
   test("read marks are queued and only applied after a successful load", () => {
     expect(widget).toContain("property var refreshQueue: []");
     expect(widget).not.toContain("property var queued: null");
     const success = panel.indexOf("if (d.ok === true)");
-    const mark = panel.indexOf("markThreadRead(root.threadRunningChat)");
+    const mark = panel.indexOf("markThreadRead(root.threadRunningChat,");
     expect(success).toBeGreaterThan(-1);
     expect(mark).toBeGreaterThan(success);
+  });
+
+  test("silent preference refreshes keep stable state", () => {
+    expect(preferences).toContain("if (loaded && serialized === lastSerialized) return true");
   });
 
   test("app window routes n, slash, digits, and Esc through catch helpers", () => {
@@ -115,8 +303,8 @@ describe("QML safety invariants", () => {
     expect(fn.indexOf('text === "/"')).toBeLessThan(fn.indexOf("inThread"));
     expect(fn.indexOf('text === "n"')).toBeLessThan(fn.indexOf("inThread"));
     expect(fn.indexOf('text >= "1"')).toBeLessThan(fn.indexOf("inThread"));
-    expect(fn).toContain("if (i < 0 || i >= threads.length) return false");
-    expect(fn).toContain("openThread(threads[i])");
+    expect(fn).toContain("if (i < 0 || i >= navigationThreads.length) return false");
+    expect(fn).toContain("openThread(navigationThreads[i])");
   });
 
   test("1-9 still jumps, with no digit drawn anywhere (Fred, 2.3.1)", () => {


### PR DESCRIPTION
This adds a settings surface to Blip and then uses it: a portable preferences file with a live appearance editor, plus a pile of rendering fixes I've been accumulating while using the app daily.

The preferences live in a plain JSON file at `~/.config/blip/preferences.json` so they can ride along in dotfiles. `preferences.ts` owns the schema and all the I/O — it refuses symlinks, wrong owners, and malformed or oversized files, and writes atomically at 0600 — so QML never touches the writable file directly. The editor covers bubble colors, window opacity, font scale, density, sidebar width, avatar size, corner roundness, and a 12/24-hour time preference that feeds the timeFormat plumbing you added in 2.3.0. The fun part is the preview: it's a true miniature of the app laid out at real dimensions and shrunk with one scale transform, and the page chrome freezes while you drag a slider so only the preview moves. The popout widens while settings are showing so the preview can sit beside the controls.

The rendering side fixes things you mostly notice on a HiDPI screen: Retina screenshots were drawing at 2x their intended size (fetch.ts now reads the image header and honors pixel density), inline media caps in logical units, message links take the bubble's text color instead of theme blue, and grouped bubble corners draw as one shape instead of overlapping darker. Conversations also pick up some Messages details — tall link artwork keeps its aspect ratio, tapbacks land on unfurled cards too, one-to-three-emoji messages render big and bubble-free, incoming group runs show the sender's avatar, and a message that's just the URL of its own link card gets suppressed. Sidebar: hover now fills the full row, separators hide under the hovered row, pinned tiles center properly, and the 1-9 jump digits from 2.3.0 moved into the chronological rows so there's a single pinned grid. Renamed/migrated group chats coalesce into one conversation when the title and participant set agree.

326 tests pass, and `python3 bridge/mac/imsg_test.py` covers the chat projection against a fixture chat.db.

This is independent of #20 — either can land alone. They both touch BlipView and BlipSettings, so whichever goes in second will need a rebase; happy to do that immediately once one lands.
