### PR TITLE
Gated contact writes: edit, merge, clean up, delete, and undo

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -210,6 +210,10 @@ BarWidget {
       'for i in 1 2 3 4 5 6 7 8; do a=$(hyprctl clients -j | jq -r \'.[] | select(.title | startswith("Blip")) | .address\' | head -1); [ -n "$a" ] && break; sleep 0.15; done; ' +
       '[ -n "$a" ] && hyprctl dispatch "hl.dsp.focus({ window = \\"address:$a\\" })" >/dev/null'])
   }
+  function manageContact(handle) {
+    showApp()
+    return windowLoader.item !== null && windowLoader.item.manageContact(handle)
+  }
   /** Either surface open → keep the deep (complete) thread list. */
   function anySurfaceOpen() {
     return (panelLoader.item && panelLoader.item.opened === true)

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1755,7 +1755,7 @@ FocusScope {
   // press past the last row landing at the top reads as a jump, not a loop
   // (Omarchy's Dropdown clamps the same way).
   function moveCursor(dy) {
-    if (contactReview.opened || !listShowing || threads.length === 0 || dy === 0) return
+    if (contactsOpen || !listShowing || threads.length === 0 || dy === 0) return
     // Up from the first row hands focus to the search field above the list,
     // and Down in an empty field hands it back (Omarchy's SearchableDropdown).
     if (dy < 0 && cursor <= 0) { startSearch(); return }
@@ -3421,6 +3421,13 @@ FocusScope {
     }
   }
 
+  // Contact work owns the full detached surface. Refuse replacing an open
+  // workspace so another menubar click cannot discard an editor or preview.
+  function openContactManagement(handle) {
+    if (!root.splitView) return false
+    return contactWorkspace.review(handle)
+  }
+
   property var contactContext: null
   Menu {
     id: contactMenu
@@ -3440,7 +3447,12 @@ FocusScope {
     fontFamily: root.fontFamily
     fontSize: root.fontBodySmall
     onClosed: root.focusDefault()
-    onManageRequested: function(handle) { contactWorkspace.review(handle) }
+    detached: root.splitView
+    onManageRequested: function(handle) {
+      if (root.splitView) root.openContactManagement(handle)
+      else if (!root.hostWidget || !root.hostWidget.manageContact(handle))
+        contactReview.notice = "Finish the contact already open in the Blip window first."
+    }
   }
   ContactWorkspace {
     id: contactWorkspace

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -84,7 +84,7 @@ FocusScope {
   readonly property color dim: Qt.darker(foreground, 1.45)
   /** An editor owns the keyboard — the host's key catcher must stand down. */
   readonly property bool editorActive:
-    contactReview.opened || composeField.activeFocus || searchField.activeFocus || newField.activeFocus || bubbleFocused
+    contactWorkspace.opened || contactReview.opened || composeField.activeFocus || searchField.activeFocus || newField.activeFocus || bubbleFocused
   readonly property alias composeEditor: composeField
   readonly property real contentHeightHint: listContent.implicitHeight
   /** The view wants keyboard navigation focus back (list mode). */
@@ -364,8 +364,8 @@ FocusScope {
     return (parts[0][0] + (parts.length > 1 ? parts[parts.length - 1][0] : "")).toUpperCase()
   }
 
-  readonly property bool contactsOpen: contactReview.opened
-  readonly property bool inThread: active !== null && !contactReview.opened
+  readonly property bool contactsOpen: contactReview.opened || contactWorkspace.opened
+  readonly property bool inThread: active !== null && !contactReview.opened && !contactWorkspace.opened
   // last_ts of the open conversation as of its last load — the push watcher
   // refreshes the thread list, and when OUR thread advances, the bubbles
   // reload themselves. The guard makes unchanged refreshes free.
@@ -438,6 +438,7 @@ FocusScope {
     closeShare()
     peekTimer.stop()
     peeking = false
+
     active = null
     bubbles = []
     note = ""
@@ -454,6 +455,7 @@ FocusScope {
   /** Back to the list view, scrolled to top — the host calls this on open. */
   function resetToList() {
     clearThread()
+    contactWorkspace.opened = false
     contactReview.opened = false
     cursor = -1
     composeField.text = ""
@@ -1798,7 +1800,7 @@ FocusScope {
     return false
   }
   function catchNavText(text) {
-    if (contactReview.opened) return false
+    if (contactReview.opened || contactWorkspace.opened) return false
     var jump = text === "/" || text === "n" || text === "N"
       || (text >= "1" && text <= "9")
     if (!jump) return false
@@ -1828,6 +1830,7 @@ FocusScope {
   /** Esc semantics for a host without a PanelKeyCatcher (the window): true if
    *  something was unwound, false if the host should close. */
   function unwind() {
+    if (contactWorkspace.opened) { contactWorkspace.close(); return true }
     if (contactReview.opened) { contactReview.back(); return true }
     if (shareUrl !== "") { closeShare(); return true }
     if (catchEscape()) return true
@@ -1835,7 +1838,8 @@ FocusScope {
     return false
   }
   function focusDefault() {
-    if (contactReview.opened) contactReview.forceActiveFocus()
+    if (contactWorkspace.opened) contactWorkspace.forceActiveFocus()
+    else if (contactReview.opened) contactReview.forceActiveFocus()
     else if (inThread) composeField.forceActiveFocus()
     else navigationFocusRequested()
   }
@@ -1848,7 +1852,7 @@ FocusScope {
 
   RowLayout {
     anchors.fill: parent
-    visible: !contactReview.opened
+    visible: !contactReview.opened && !contactWorkspace.opened
     spacing: 0
 
     // ------------------------------------------------------- thread pane
@@ -3435,6 +3439,17 @@ FocusScope {
     fontFamily: root.fontFamily
     fontSize: root.fontBodySmall
     onClosed: root.focusDefault()
+    onManageRequested: function(handle) { contactWorkspace.review(handle) }
+  }
+  ContactWorkspace {
+    id: contactWorkspace
+    objectName: "blipContactWorkspace"
+    anchors.fill: parent
+    foreground: root.foreground; urgent: root.urgent; accent: root.accent
+    fontFamily: root.fontFamily
+    fontScale: root.fontBodySmall / Style.font.bodySmall
+    onClosed: root.focusDefault()
+    onContactsMutated: if (root.hostWidget) root.hostWidget.refresh(true, false)
   }
 
     // drag a file from a file manager onto the open conversation → draft chip

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -3432,6 +3432,7 @@ FocusScope {
   ContactReview {
     id: contactReview
     objectName: "blipContactReview"
+    visible: opened && !contactWorkspace.opened
     anchors.fill: parent
     threads: root.threads
     foreground: root.foreground

--- a/BlipWindow.qml
+++ b/BlipWindow.qml
@@ -46,6 +46,7 @@ FloatingWindow {
   readonly property string seenTs: view.seenTs
   readonly property bool peeking: view.peeking
   readonly property string activeLastTs: view.activeLastTs
+  function manageContact(handle) { return view.openContactManagement(handle) }
   function openThread(t) { view.openThread(t) }
   function shareLink(url) { return view.shareLink(url) }
   function pushReload() { view.pushReload() }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,3 +403,11 @@ through bounded stdin. There is no settings surface or saved display-name
 override. Each native mutation retains its preview, exact token/revision
 validation, independent local/Mac write gates, and private Mac undo receipt.
 The small read-only contact review and its cache remain independent.
+
+Contact management opens only in the detached window. `BarWidget.manageContact`
+shows the window once, then hands the handle to its view; a second ensure before
+the deferred show can recreate the window and lose that handoff. Existing open
+workspaces refuse a different handle so editors and previews survive. Initial
+access checks queue the handoff. The TypeScript broker supplies `initialToken`
+only for one matching person, opening read-only card details after the worker
+exits. Choosing a person still grants no write authority.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,3 +394,12 @@ to whatever has focus otherwise.
 - **Attachments out.** `send POSIX file` works on Sequoia IF the file is staged
   in `~/Pictures/` — from anywhere else Messages fails silently (`error=25`,
   "Not Delivered"). Verified delivered for PNG and PDF. See ROADMAP.md.
+
+## Draft contact management
+
+`ContactWorkspace.qml` hosts `ContactManagement.qml` and the existing card
+compare/editor views. `ContactOperations.qml` talks to `contact-management.ts`
+through bounded stdin. There is no settings surface or saved display-name
+override. Each native mutation retains its preview, exact token/revision
+validation, independent local/Mac write gates, and private Mac undo receipt.
+The small read-only contact review and its cache remain independent.

--- a/ContactCardCompare.qml
+++ b/ContactCardCompare.qml
@@ -1,0 +1,799 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+
+// Local comparison and revision-pinned management of the exact active
+// Contacts cards selected by the bridge. Apple's link action remains separate.
+ColumnLayout {
+  id: root
+
+  property var resolver: null
+  property var comparison: null
+  // Cross-name merge: the user explicitly combined two named candidates.
+  // The scope is merge-only — per-card edit/delete and linking keep
+  // single-person authority.
+  readonly property bool crossMerge: comparison !== null
+    && String(comparison.otherOwnerToken || "") !== ""
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  property bool combinedExpanded: false
+  property bool showSharedFields: false
+  property var editorCard: null
+  property var editorInitialCard: null
+  property string editorMode: "edit"
+  readonly property int sharedCount: sharedRowCount(comparison)
+
+  onComparisonChanged: {
+    showSharedFields = false
+    combinedExpanded = false
+    editorCard = null
+    editorInitialCard = null
+  }
+
+  spacing: space(20)
+
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function cleanLabel(value) {
+    var label = String(value || "").trim()
+    var apple = /^_\$!<(.+)>!\$_$/.exec(label)
+    return apple ? apple[1] : label
+  }
+  function displayFieldLabel(fieldType, value) {
+    var detail = cleanLabel(value)
+    return detail === "" || detail.toLowerCase() === fieldType.toLowerCase()
+      ? fieldType
+      : fieldType + " · " + detail
+  }
+  function appendRow(rows, label, value) {
+    var text = String(value || "").trim()
+    if (text !== "") rows.push({ label: label, value: text })
+  }
+  function addressText(address) {
+    var parts = []
+    var street = String(address && address.street || "").trim()
+    var city = String(address && address.city || "").trim()
+    var state = String(address && address.state || "").trim()
+    var postal = String(address && address.postalCode || "").trim()
+    var country = String(address && address.country || "").trim()
+    if (street !== "") parts.push(street)
+    var locality = [city, state, postal].filter(function(value) { return value !== "" }).join(" ")
+    if (locality !== "") parts.push(locality)
+    if (country !== "") parts.push(country)
+    return parts.join(", ")
+  }
+  function cardRows(card) {
+    if (!card) return []
+    var rows = []
+    appendRow(rows, "Display name", card.displayName)
+    appendRow(rows, "First name", card.firstName)
+    appendRow(rows, "Middle name", card.middleName)
+    appendRow(rows, "Last name", card.lastName)
+    appendRow(rows, "Nickname", card.nickname)
+    appendRow(rows, "Organization", card.organization)
+    appendRow(rows, "Department", card.department)
+    appendRow(rows, "Job title", card.jobTitle)
+    appendRow(rows, "Birthday", card.birthday)
+    var groups = [
+      { name: "Phone", values: card.phones || [] },
+      { name: "Email", values: card.emails || [] },
+      { name: "Website", values: card.urls || [] }
+    ]
+    for (var groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      var group = groups[groupIndex]
+      for (var valueIndex = 0; valueIndex < group.values.length; valueIndex++) {
+        var item = group.values[valueIndex]
+        appendRow(rows, displayFieldLabel(group.name, item.label), item.value)
+      }
+    }
+    var addresses = card.addresses || []
+    for (var addressIndex = 0; addressIndex < addresses.length; addressIndex++) {
+      var address = addresses[addressIndex]
+      appendRow(rows, displayFieldLabel("Address", address.label), addressText(address))
+    }
+    appendRow(rows, "Notes", card.note)
+    return rows
+  }
+  function rowKey(row) {
+    return String(row && row.label || "").toLowerCase() + "\u0000"
+      + String(row && row.value || "").toLowerCase()
+  }
+  function sharedRowMap(value) {
+    var result = ({})
+    if (!value || !Array.isArray(value.cards) || value.cards.length < 2) return result
+    var counts = ({})
+    for (var cardIndex = 0; cardIndex < value.cards.length; cardIndex++) {
+      var perCard = ({})
+      var rows = cardRows(value.cards[cardIndex])
+      for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) perCard[rowKey(rows[rowIndex])] = true
+      var keys = Object.keys(perCard)
+      for (var keyIndex = 0; keyIndex < keys.length; keyIndex++)
+        counts[keys[keyIndex]] = Number(counts[keys[keyIndex]] || 0) + 1
+    }
+    var allKeys = Object.keys(counts)
+    for (var index = 0; index < allKeys.length; index++) {
+      var key = allKeys[index]
+      if (counts[key] === value.cards.length) result[key] = true
+    }
+    return result
+  }
+  function sharedRowCount(value) { return Object.keys(sharedRowMap(value)).length }
+  function visibleRows(card) {
+    var rows = cardRows(card)
+    if (showSharedFields) return rows
+    var shared = sharedRowMap(comparison)
+    return rows.filter(function(row) { return !shared[rowKey(row)] })
+  }
+  function unionRows(value) {
+    if (!value || !Array.isArray(value.cards)) return []
+    var result = []
+    var seen = ({})
+    for (var cardIndex = 0; cardIndex < value.cards.length; cardIndex++) {
+      var rows = cardRows(value.cards[cardIndex])
+      for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+        var row = rows[rowIndex]
+        var key = rowKey(row)
+        if (seen[key]) continue
+        seen[key] = true
+        result.push(row)
+      }
+    }
+    return result
+  }
+  function missingFields(card) {
+    if (!card) return []
+    var missing = []
+    if (String(card.firstName || "") === "" && String(card.lastName || "") === "") missing.push("name")
+    if (!card.phones || card.phones.length === 0) missing.push("phone")
+    if (!card.emails || card.emails.length === 0) missing.push("email")
+    if (!card.addresses || card.addresses.length === 0) missing.push("address")
+    if (String(card.birthday || "") === "") missing.push("birthday")
+    return missing
+  }
+  function missingDetails(card) {
+    var missing = missingFields(card)
+    return missing.length === 0 ? "Core details present" : "Missing: " + missing.join(", ")
+  }
+  function incompleteCardCount(value) {
+    if (!value || !Array.isArray(value.cards)) return 0
+    var count = 0
+    for (var i = 0; i < value.cards.length; i++) if (missingFields(value.cards[i]).length > 0) count++
+    return count
+  }
+  function cloneList(value) {
+    return JSON.parse(JSON.stringify(Array.isArray(value) ? value : []))
+  }
+  function uniqueList(cards, property, address) {
+    var result = []
+    var seen = ({})
+    for (var i = 0; i < cards.length; i++) {
+      var values = cards[i] && Array.isArray(cards[i][property]) ? cards[i][property] : []
+      for (var j = 0; j < values.length; j++) {
+        var item = values[j]
+        var key = address
+          ? [item.street, item.city, item.state, item.postalCode, item.country, item.countryCode]
+            .join("\u0000").toLowerCase()
+          : String(item.value || "").toLowerCase()
+        if (key === "" || seen[key]) continue
+        seen[key] = true
+        result.push(JSON.parse(JSON.stringify(item)))
+      }
+    }
+    return result
+  }
+  function mergedDraft(target) {
+    var cards = comparison && Array.isArray(comparison.cards) ? comparison.cards : []
+    var draft = ({})
+    var scalars = ["firstName", "middleName", "lastName", "nickname", "organization",
+      "department", "jobTitle", "birthday", "note"]
+    for (var i = 0; i < scalars.length; i++) {
+      var key = scalars[i]
+      draft[key] = String(target && target[key] || "")
+      if (draft[key] !== "") continue
+      for (var j = 0; j < cards.length; j++) {
+        var candidate = String(cards[j] && cards[j][key] || "")
+        if (candidate !== "") { draft[key] = candidate; break }
+      }
+    }
+    draft.phones = uniqueList(cards, "phones", false)
+    draft.emails = uniqueList(cards, "emails", false)
+    draft.urls = uniqueList(cards, "urls", false)
+    draft.addresses = uniqueList(cards, "addresses", true)
+    return draft
+  }
+  function editCard(card) {
+    if (resolver) resolver.cancelMutation()
+    editorMode = "edit"
+    editorCard = card
+    editorInitialCard = card
+  }
+  function mergeInto(card) {
+    if (resolver) resolver.cancelMutation()
+    editorMode = "consolidate"
+    editorCard = card
+    editorInitialCard = mergedDraft(card)
+  }
+
+  ContactCardEditor {
+    Layout.fillWidth: true
+    visible: root.editorCard !== null
+    resolver: root.resolver
+    card: root.editorCard
+    comparison: root.comparison
+    initialCard: root.editorInitialCard
+    mode: root.editorMode
+    foreground: root.foreground
+    urgent: root.urgent
+    accent: root.accent
+    fontFamily: root.fontFamily
+    fontScale: root.fontScale
+    density: root.density
+    cornerScale: root.cornerScale
+    onCloseRequested: {
+      root.editorCard = null
+      root.editorInitialCard = null
+      root.editorMode = "edit"
+    }
+  }
+
+  RowLayout {
+    visible: root.editorCard === null
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: root.space(2)
+      Text {
+        Layout.fillWidth: true
+        text: root.comparison ? root.comparison.name : "Contact cards"
+        textFormat: Text.PlainText
+        elide: Text.ElideRight
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.body)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.comparison
+          ? root.comparison.cardCount + " source cards · " + root.comparison.sourceCount
+            + (root.comparison.sourceCount === 1 ? " Contacts source" : " Contacts sources")
+          : ""
+        textFormat: Text.PlainText
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+    SmallButton {
+      label: "Reload cards from Mac"
+      enabled: root.resolver && !root.resolver.loading && root.comparison
+      onClicked: root.resolver.compareCards(root.comparison.handle, root.comparison.ownerToken)
+    }
+    SmallButton {
+      label: "Back to contact tasks"
+      enabled: root.resolver && !root.resolver.loading
+      onClicked: root.resolver.cancelComparison()
+    }
+  }
+
+  ActionHeader {
+    visible: root.editorCard === null
+    Layout.topMargin: root.space(4)
+    title: "Compare source cards"
+    detail: root.showSharedFields || root.sharedCount === 0
+      ? "Showing every discovered value."
+      : root.sharedCount + (root.sharedCount === 1 ? " shared value is" : " shared values are")
+        + " tucked away so differences stand out."
+  }
+
+  RowLayout {
+    visible: root.editorCard === null
+    Layout.fillWidth: true
+    spacing: root.space(8)
+    Text {
+      Layout.fillWidth: true
+      text: root.showSharedFields ? "ALL FIELDS" : "DIFFERENCES ONLY"
+      textFormat: Text.PlainText
+      color: root.accent
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: true
+    }
+    SmallButton {
+      visible: root.sharedCount > 0
+      label: root.showSharedFields ? "Show differences only" : "Show all fields"
+      onClicked: root.showSharedFields = !root.showSharedFields
+    }
+  }
+
+  GridLayout {
+    visible: root.editorCard === null
+    Layout.fillWidth: true
+    columns: root.width >= root.space(820) && root.comparison && root.comparison.cardCount === 2 ? 2 : 1
+    columnSpacing: root.space(12)
+    rowSpacing: root.space(12)
+
+    Repeater {
+      model: root.comparison ? root.comparison.cards : []
+      delegate: Rectangle {
+        id: cardBox
+        required property var modelData
+        readonly property var displayedRows: root.visibleRows(modelData)
+        Layout.fillWidth: true
+        Layout.preferredWidth: root.space(390)
+        Layout.alignment: Qt.AlignTop
+        implicitHeight: cardContents.implicitHeight + root.space(28)
+        radius: root.corner(root.space(12))
+        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.045)
+        border.width: 1
+        border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+
+        ColumnLayout {
+          id: cardContents
+          anchors.fill: parent
+          anchors.margins: root.space(14)
+          spacing: root.space(10)
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Text {
+              Layout.fillWidth: true
+              text: "SOURCE CARD " + cardBox.modelData.cardNumber
+              textFormat: Text.PlainText
+              elide: Text.ElideRight
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+              font.bold: true
+            }
+            InfoPill { label: cardBox.modelData.sourceName }
+          }
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Text {
+              Layout.fillWidth: true
+              text: root.missingDetails(cardBox.modelData)
+              textFormat: Text.PlainText
+              elide: Text.ElideRight
+              color: root.missingFields(cardBox.modelData).length > 0 ? root.urgent : root.accent
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+            }
+            SmallButton {
+              visible: !root.crossMerge
+              label: "Edit in Blip…"
+              primary: true
+              enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+              onClicked: root.editCard(cardBox.modelData)
+            }
+            SmallButton {
+              label: "Open on Mac…"
+              enabled: root.resolver && !root.resolver.loading
+              onClicked: root.resolver.openOnMac(root.comparison.handle, cardBox.modelData.token)
+            }
+          }
+
+          Rectangle {
+            Layout.fillWidth: true
+            implicitHeight: 1
+            color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.13)
+          }
+
+          Text {
+            Layout.fillWidth: true
+            visible: cardBox.displayedRows.length === 0
+            text: "No card-specific values."
+            textFormat: Text.PlainText
+            color: Qt.darker(root.foreground, 1.4)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+
+          Repeater {
+            model: cardBox.displayedRows
+            delegate: RowLayout {
+              required property var modelData
+              Layout.fillWidth: true
+              spacing: root.space(10)
+              Text {
+                Layout.preferredWidth: root.space(106)
+                Layout.alignment: Qt.AlignTop
+                text: String(modelData.label || "")
+                textFormat: Text.PlainText
+                wrapMode: Text.WordWrap
+                color: Qt.darker(root.foreground, 1.45)
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+              }
+              Text {
+                Layout.fillWidth: true
+                text: String(modelData.value || "")
+                textFormat: Text.PlainText
+                wrapMode: Text.WrapAnywhere
+                color: root.foreground
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  ActionHeader {
+    // With a single card there is nothing to consolidate â hide the section
+    // instead of presenting a preview with no action.
+    visible: root.editorCard === null && root.comparison !== null
+      && root.comparison.cardCount > 1
+    Layout.topMargin: root.space(20)
+    title: "Consolidate into one card"
+    detail: root.crossMerge
+      ? "You marked these differently-named cards as the same person. Pick the card that should survive — the name (and every other field) can be adjusted in the review before anything is saved."
+      : root.incompleteCardCount(root.comparison) === 0
+        ? "Choose this option to build one editable card and delete the other source cards after confirmation."
+        : "Choose this option to fill blanks, combine unique values, and delete the other source cards after review."
+  }
+
+  Rectangle {
+    // Single card, but another NAME uses this handle: point at the one real
+    // path to a merge (make the names match) instead of a dead end.
+    visible: root.editorCard === null && root.comparison !== null
+      && root.comparison.cardCount === 1
+      && root.resolver && root.resolver.candidates.length > 1
+    Layout.topMargin: root.space(20)
+    Layout.fillWidth: true
+    implicitHeight: samePersonHint.implicitHeight + root.space(24)
+    radius: root.corner(root.space(10))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.05)
+    border.width: 1
+    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.22)
+
+    ColumnLayout {
+      id: samePersonHint
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(6)
+      Text {
+        Layout.fillWidth: true
+        text: "SAME PERSON UNDER ANOTHER NAME?"
+        textFormat: Text.PlainText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: {
+          var others = []
+          var cands = root.resolver ? root.resolver.candidates : []
+          for (var i = 0; i < cands.length; i++) {
+            if (!root.comparison || cands[i].token !== root.comparison.ownerToken)
+              others.push("“" + String(cands[i].name || "") + "”")
+          }
+          return "This person has only one card, so there is nothing to consolidate. If "
+            + (others.length > 0 ? others.join(" or ") : "the other name")
+            + " is really the same person — a married-name change, say — go back and use "
+            + "Merge with… on that person’s row. You can adjust the surviving name "
+            + "during the merge review."
+        }
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.3)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+  }
+
+  Rectangle {
+    visible: root.editorCard === null && root.comparison !== null
+      && root.comparison.cardCount > 1
+    Layout.fillWidth: true
+    implicitHeight: combinedContents.implicitHeight + root.space(24)
+    radius: root.corner(root.space(10))
+    color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.065)
+    border.width: 1
+    border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.28)
+
+    ColumnLayout {
+      id: combinedContents
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(8)
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: root.space(8)
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: root.space(2)
+          Text {
+            Layout.fillWidth: true
+            text: "MERGED PREVIEW"
+            textFormat: Text.PlainText
+            color: root.accent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: "Unique values Blip discovered across every active source card."
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.35)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+        SmallButton {
+          label: root.combinedExpanded ? "Hide preview" : "Show merged values"
+          onClicked: root.combinedExpanded = !root.combinedExpanded
+        }
+      }
+      Repeater {
+        model: root.combinedExpanded ? root.unionRows(root.comparison) : []
+        delegate: RowLayout {
+          required property var modelData
+          Layout.fillWidth: true
+          spacing: root.space(10)
+          Text {
+            Layout.preferredWidth: root.space(112)
+            Layout.alignment: Qt.AlignTop
+            text: String(modelData.label || "")
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.45)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          Text {
+            Layout.fillWidth: true
+            text: String(modelData.value || "")
+            textFormat: Text.PlainText
+            wrapMode: Text.WrapAnywhere
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        visible: root.comparison && root.comparison.cardCount > 1
+        spacing: root.space(8)
+        Text {
+          Layout.fillWidth: true
+          text: "Choose the source card—and therefore the named Contacts source—that should remain."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+        Repeater {
+          model: root.comparison ? root.comparison.cards : []
+          delegate: SmallButton {
+            required property var modelData
+            label: "Merge into " + modelData.sourceName + " · card " + modelData.cardNumber + "…"
+            enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+            onClicked: root.mergeInto(modelData)
+          }
+        }
+      }
+    }
+  }
+
+  ActionHeader {
+    visible: root.editorCard === null && root.comparison && root.comparison.cardCount > 1
+      && !root.crossMerge
+    Layout.topMargin: root.space(20)
+    title: "Or link cards · optional"
+    detail: "An alternative to consolidation: keep both source cards and ask Contacts to present them as one person. Checking makes no changes."
+  }
+
+  Rectangle {
+    visible: root.editorCard === null && root.comparison && root.comparison.cardCount > 1
+      && !root.crossMerge
+    Layout.fillWidth: true
+    implicitHeight: linkContents.implicitHeight + root.space(24)
+    radius: root.corner(root.space(10))
+    color: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+      ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.09)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+    border.width: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready ? 2 : 1
+    border.color: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+      ? root.urgent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+
+    ColumnLayout {
+      id: linkContents
+      anchors.fill: parent
+      anchors.margins: root.space(12)
+      spacing: root.space(9)
+
+      RowLayout {
+        Layout.fillWidth: true
+        visible: !root.resolver || root.resolver.linkPreview === null
+        spacing: root.space(10)
+        Text {
+          Layout.fillWidth: true
+          text: "Contacts keeps the source accounts authoritative. Blip only selects the exact cards and requests Apple’s action."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+        }
+        SmallButton {
+          primary: true
+          label: "Prepare link in Contacts…"
+          enabled: root.resolver && !root.resolver.loading && root.comparison
+            && root.resolver.contactWrites && root.comparison.writeEnabled
+          onClicked: root.resolver.prepareLink()
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.linkPreview !== null
+        text: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+          ? "CONFIRM AN UPSTREAM CONTACTS CHANGE"
+          : "CONTACTS DID NOT OFFER THIS ACTION"
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+          ? root.urgent : root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.linkPreview !== null
+        text: root.resolver && root.resolver.linkPreview
+          ? root.resolver.linkPreview.ready
+            ? "Run Contacts’ “" + root.resolver.linkPreview.action + "” on these exact "
+              + root.resolver.linkPreview.cardCount + " cards? This changes Contacts and may sync to their source accounts. Blip cannot provide an automatic unlink receipt."
+            : "Contacts disabled “" + root.resolver.linkPreview.action
+              + "” for this selection. The cards may already be linked or ineligible. Nothing changed."
+          : ""
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.linkPreview !== null
+        spacing: root.space(8)
+        Item { Layout.fillWidth: true }
+        SmallButton {
+          label: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+            ? "Cancel" : "Dismiss"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.resolver.cancelLink()
+        }
+        SmallButton {
+          visible: root.resolver && root.resolver.linkPreview && root.resolver.linkPreview.ready
+          danger: true
+          primary: true
+          label: root.resolver && root.resolver.linkPreview
+            ? "Run “" + root.resolver.linkPreview.action + "”"
+            : "Run Contacts action"
+          enabled: root.resolver && !root.resolver.loading && root.resolver.linkPreview
+            && root.resolver.linkPreview.ready && root.resolver.linkPreview.writeEnabled
+          onClicked: root.resolver.linkCards()
+        }
+      }
+    }
+  }
+
+  Text {
+    visible: root.editorCard === null && root.resolver && !root.resolver.contactWrites
+    Layout.fillWidth: true
+    text: "Editing, deleting, consolidating, and linking are disabled by the local and Mac write gates. Viewing and opening exact cards remain read-only."
+    textFormat: Text.PlainText
+    wrapMode: Text.WordWrap
+    color: Qt.darker(root.foreground, 1.35)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+
+  component ActionHeader: RowLayout {
+    property string title: ""
+    property string detail: ""
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: root.space(1)
+      Text {
+        Layout.fillWidth: true
+        text: parent.parent.title.toUpperCase()
+        textFormat: Text.PlainText
+        color: root.accent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: parent.parent.detail
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+  }
+
+  component InfoPill: Rectangle {
+    property string label: ""
+    implicitWidth: Math.min(pillText.implicitWidth + root.space(12), root.space(220))
+    implicitHeight: pillText.implicitHeight + root.space(6)
+    radius: height / 2
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.07)
+    border.width: 1
+    border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+    Text {
+      id: pillText
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: root.space(6)
+      anchors.rightMargin: root.space(6)
+      text: parent.label
+      textFormat: Text.PlainText
+      elide: Text.ElideRight
+      color: Qt.darker(root.foreground, 1.25)
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+    }
+  }
+
+  component SmallButton: Rectangle {
+    id: button
+    property string label: ""
+    property bool danger: false
+    property bool primary: false
+    signal clicked()
+    implicitWidth: buttonText.implicitWidth + root.space(16)
+    implicitHeight: buttonText.implicitHeight + root.space(10)
+    radius: root.corner(root.space(7))
+    opacity: enabled ? 1.0 : 0.45
+    color: buttonHover.hovered
+      ? Qt.rgba((danger ? root.urgent : root.accent).r,
+                (danger ? root.urgent : root.accent).g,
+                (danger ? root.urgent : root.accent).b, 0.18)
+      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+    border.width: 1
+    border.color: danger ? root.urgent : primary ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
+    Text {
+      id: buttonText
+      anchors.centerIn: parent
+      text: button.label
+      textFormat: Text.PlainText
+      color: button.danger ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: button.primary
+    }
+    HoverHandler { id: buttonHover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
+    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+  }
+}

--- a/ContactCardCompare.qml
+++ b/ContactCardCompare.qml
@@ -169,6 +169,27 @@ ColumnLayout {
   function cloneList(value) {
     return JSON.parse(JSON.stringify(Array.isArray(value) ? value : []))
   }
+  function addressFields() {
+    return ["street", "city", "state", "postalCode", "country", "countryCode"]
+  }
+  function addressField(item, name) {
+    return String(item && item[name] || "").trim().toLowerCase()
+  }
+  // True when `sparse` adds nothing beyond `full`: every field empty or equal,
+  // case-insensitively. Source cards routinely disagree only by an unset
+  // field — the same Home address with countryCode "us" on one card and unset
+  // on the other — and an exact-match key kept both on the merged card.
+  // Collapsing strict subsets keeps one copy without ever guessing between
+  // genuinely different values. Labels stay out of it, as they always were.
+  function addressSubsumes(full, sparse) {
+    var fields = addressFields()
+    for (var i = 0; i < fields.length; i++) {
+      var have = addressField(full, fields[i])
+      var add = addressField(sparse, fields[i])
+      if (add !== "" && add !== have) return false
+    }
+    return true
+  }
   function uniqueList(cards, property, address) {
     var result = []
     var seen = ({})
@@ -176,10 +197,26 @@ ColumnLayout {
       var values = cards[i] && Array.isArray(cards[i][property]) ? cards[i][property] : []
       for (var j = 0; j < values.length; j++) {
         var item = values[j]
-        var key = address
-          ? [item.street, item.city, item.state, item.postalCode, item.country, item.countryCode]
-            .join("\u0000").toLowerCase()
-          : String(item.value || "").toLowerCase()
+        if (address) {
+          var fields = addressFields()
+          var empty = true
+          for (var f = 0; f < fields.length; f++)
+            if (addressField(item, fields[f]) !== "") { empty = false; break }
+          if (empty) continue
+          var absorbed = false
+          for (var k = 0; k < result.length; k++) {
+            if (addressSubsumes(result[k], item)) { absorbed = true; break }
+            if (addressSubsumes(item, result[k])) {
+              // The newcomer is the more complete record — keep it, in place.
+              result[k] = JSON.parse(JSON.stringify(item))
+              absorbed = true
+              break
+            }
+          }
+          if (!absorbed) result.push(JSON.parse(JSON.stringify(item)))
+          continue
+        }
+        var key = String(item.value || "").toLowerCase()
         if (key === "" || seen[key]) continue
         seen[key] = true
         result.push(JSON.parse(JSON.stringify(item)))

--- a/ContactCardCompare.qml
+++ b/ContactCardCompare.qml
@@ -279,7 +279,7 @@ ColumnLayout {
     }
   }
 
-  RowLayout {
+  ColumnLayout {
     visible: root.editorCard === null
     Layout.fillWidth: true
     spacing: root.space(10)
@@ -299,7 +299,7 @@ ColumnLayout {
       Text {
         Layout.fillWidth: true
         text: root.comparison
-          ? root.comparison.cardCount + " source cards · " + root.comparison.sourceCount
+          ? root.comparison.cardCount + (root.comparison.cardCount === 1 ? " card · " : " cards · ") + root.comparison.sourceCount
             + (root.comparison.sourceCount === 1 ? " Contacts source" : " Contacts sources")
           : ""
         textFormat: Text.PlainText
@@ -309,19 +309,20 @@ ColumnLayout {
       }
     }
     SmallButton {
-      label: "Reload cards from Mac"
+      label: "Reload cards"
       enabled: root.resolver && !root.resolver.loading && root.comparison
       onClicked: root.resolver.compareCards(root.comparison.handle, root.comparison.ownerToken)
     }
     SmallButton {
-      label: "Back to contact tasks"
+      visible: root.resolver && root.resolver.candidates.length > 1
+      label: "Choose another person"
       enabled: root.resolver && !root.resolver.loading
       onClicked: root.resolver.cancelComparison()
     }
   }
 
   ActionHeader {
-    visible: root.editorCard === null
+    visible: root.editorCard === null && root.comparison && root.comparison.cardCount > 1
     Layout.topMargin: root.space(4)
     title: "Compare source cards"
     detail: root.showSharedFields || root.sharedCount === 0
@@ -330,8 +331,8 @@ ColumnLayout {
         + " tucked away so differences stand out."
   }
 
-  RowLayout {
-    visible: root.editorCard === null
+  ColumnLayout {
+    visible: root.editorCard === null && root.comparison && root.comparison.cardCount > 1
     Layout.fillWidth: true
     spacing: root.space(8)
     Text {
@@ -364,7 +365,8 @@ ColumnLayout {
         required property var modelData
         readonly property var displayedRows: root.visibleRows(modelData)
         Layout.fillWidth: true
-        Layout.preferredWidth: root.space(390)
+        Layout.preferredWidth: Math.min(root.width, root.space(390))
+        Layout.minimumWidth: 0
         Layout.alignment: Qt.AlignTop
         implicitHeight: cardContents.implicitHeight + root.space(28)
         radius: root.corner(root.space(12))
@@ -378,12 +380,12 @@ ColumnLayout {
           anchors.margins: root.space(14)
           spacing: root.space(10)
 
-          RowLayout {
+          ColumnLayout {
             Layout.fillWidth: true
             spacing: root.space(8)
             Text {
               Layout.fillWidth: true
-              text: "SOURCE CARD " + cardBox.modelData.cardNumber
+              text: root.comparison && root.comparison.cardCount === 1 ? "CONTACT DETAILS" : "SOURCE CARD " + cardBox.modelData.cardNumber
               textFormat: Text.PlainText
               elide: Text.ElideRight
               color: root.foreground
@@ -394,11 +396,13 @@ ColumnLayout {
             InfoPill { label: cardBox.modelData.sourceName }
           }
 
-          RowLayout {
+          GridLayout {
+            columns: root.width >= root.space(440) ? 2 : 1
             Layout.fillWidth: true
-            spacing: root.space(8)
+            columnSpacing: root.space(8)
             Text {
               Layout.fillWidth: true
+              visible: false
               text: root.missingDetails(cardBox.modelData)
               textFormat: Text.PlainText
               elide: Text.ElideRight
@@ -408,13 +412,13 @@ ColumnLayout {
             }
             SmallButton {
               visible: !root.crossMerge
-              label: "Edit in Blip…"
+              label: "Edit contact…"
               primary: true
               enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
               onClicked: root.editCard(cardBox.modelData)
             }
             SmallButton {
-              label: "Open on Mac…"
+              label: "Open on Mac ↗"
               enabled: root.resolver && !root.resolver.loading
               onClicked: root.resolver.openOnMac(root.comparison.handle, cardBox.modelData.token)
             }
@@ -549,7 +553,7 @@ ColumnLayout {
       anchors.fill: parent
       anchors.margins: root.space(12)
       spacing: root.space(8)
-      RowLayout {
+      ColumnLayout {
         Layout.fillWidth: true
         spacing: root.space(8)
         ColumnLayout {
@@ -606,7 +610,7 @@ ColumnLayout {
           }
         }
       }
-      RowLayout {
+      ColumnLayout {
         Layout.fillWidth: true
         visible: root.comparison && root.comparison.cardCount > 1
         spacing: root.space(8)
@@ -659,7 +663,7 @@ ColumnLayout {
       anchors.margins: root.space(12)
       spacing: root.space(9)
 
-      RowLayout {
+      ColumnLayout {
         Layout.fillWidth: true
         visible: !root.resolver || root.resolver.linkPreview === null
         spacing: root.space(10)
@@ -711,7 +715,7 @@ ColumnLayout {
         font.family: root.fontFamily
         font.pixelSize: root.fontSize(Style.font.caption)
       }
-      RowLayout {
+      ColumnLayout {
         Layout.fillWidth: true
         visible: root.resolver && root.resolver.linkPreview !== null
         spacing: root.space(8)
@@ -801,36 +805,15 @@ ColumnLayout {
     }
   }
 
-  component SmallButton: Rectangle {
-    id: button
+  component SmallButton: ContactButton {
     property string label: ""
     property bool danger: false
     property bool primary: false
-    signal clicked()
-    implicitWidth: buttonText.implicitWidth + root.space(16)
-    implicitHeight: buttonText.implicitHeight + root.space(10)
-    radius: root.corner(root.space(7))
-    opacity: enabled ? 1.0 : 0.45
-    color: buttonHover.hovered
-      ? Qt.rgba((danger ? root.urgent : root.accent).r,
-                (danger ? root.urgent : root.accent).g,
-                (danger ? root.urgent : root.accent).b, 0.18)
-      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
-      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
-    border.width: 1
-    border.color: danger ? root.urgent : primary ? root.accent
-      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
-    Text {
-      id: buttonText
-      anchors.centerIn: parent
-      text: button.label
-      textFormat: Text.PlainText
-      color: button.danger ? root.urgent : root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: root.fontSize(Style.font.caption)
-      font.bold: button.primary
-    }
-    HoverHandler { id: buttonHover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
-    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+    text: label
+    foreground: danger ? root.urgent : root.foreground
+    accent: root.accent
+    fontFamily: root.fontFamily
+    fontSize: root.fontSize(Style.font.caption)
+    Layout.maximumWidth: Math.max(1, root.width - root.space(56))
   }
 }

--- a/ContactCardEditor.qml
+++ b/ContactCardEditor.qml
@@ -4,7 +4,7 @@ import qs.Commons
 import qs.Ui
 
 // Full, local editor for the bounded Contacts fields exposed by the bridge.
-// Saving is always a two-step preview/apply operation in BlipIdentities.
+// Saving is always a two-step preview/apply operation in ContactOperations.
 ColumnLayout {
   id: root
 

--- a/ContactCardEditor.qml
+++ b/ContactCardEditor.qml
@@ -1,0 +1,757 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// Full, local editor for the bounded Contacts fields exposed by the bridge.
+// Saving is always a two-step preview/apply operation in BlipIdentities.
+ColumnLayout {
+  id: root
+
+  property var resolver: null
+  property var card: null
+  property var comparison: null
+  property var initialCard: null
+  property string mode: "edit"
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  readonly property bool isMerge: mode === "consolidate"
+  readonly property bool previewOpen: resolver && resolver.mutationPreview !== null
+
+  signal closeRequested()
+
+  spacing: space(14)
+
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function text(value) { return String(value || "") }
+  function cleanLabel(value) {
+    var label = text(value)
+    var apple = /^_\$!<(.+)>!\$_$/.exec(label)
+    return apple ? apple[1] : label
+  }
+  function loadValueModel(model, values) {
+    model.clear()
+    var source = Array.isArray(values) ? values : []
+    for (var i = 0; i < source.length && i < 16; i++) {
+      var item = source[i] || ({})
+      model.append({
+        label: cleanLabel(item.label),
+        originalLabel: text(item.label),
+        value: text(item.value)
+      })
+    }
+  }
+  function loadAddressModel(model, values) {
+    model.clear()
+    var source = Array.isArray(values) ? values : []
+    for (var i = 0; i < source.length && i < 16; i++) {
+      var item = source[i] || ({})
+      model.append({
+        label: cleanLabel(item.label),
+        originalLabel: text(item.label),
+        street: text(item.street),
+        city: text(item.city),
+        state: text(item.state),
+        postalCode: text(item.postalCode),
+        country: text(item.country),
+        countryCode: text(item.countryCode)
+      })
+    }
+  }
+  function reload() {
+    var source = initialCard || card
+    if (!source) return
+    firstName.text = text(source.firstName)
+    middleName.text = text(source.middleName)
+    lastName.text = text(source.lastName)
+    nickname.text = text(source.nickname)
+    organization.text = text(source.organization)
+    department.text = text(source.department)
+    jobTitle.text = text(source.jobTitle)
+    birthday.text = text(source.birthday)
+    notes.text = text(source.note)
+    loadValueModel(phones, source.phones)
+    loadValueModel(emails, source.emails)
+    loadValueModel(urls, source.urls)
+    loadAddressModel(addresses, source.addresses)
+  }
+  function modelValues(model, keys) {
+    var result = []
+    for (var i = 0; i < model.count; i++) {
+      var source = model.get(i)
+      var item = ({})
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j]
+        var value = text(source[key]).trim()
+        if (key === "label") {
+          var original = text(source.originalLabel).trim()
+          item[key] = original !== "" && value === cleanLabel(original) ? original : value
+        } else item[key] = value
+      }
+      var meaningful = false
+      for (var k = 0; k < keys.length; k++) {
+        if (keys[k] !== "label" && item[keys[k]] !== "") meaningful = true
+      }
+      if (meaningful) result.push(item)
+    }
+    return result
+  }
+  function draft() {
+    return {
+      firstName: firstName.text.trim(), middleName: middleName.text.trim(),
+      lastName: lastName.text.trim(), nickname: nickname.text.trim(),
+      organization: organization.text.trim(), department: department.text.trim(),
+      jobTitle: jobTitle.text.trim(), birthday: birthday.text.trim(), note: notes.text.trim(),
+      phones: modelValues(phones, ["label", "value"]),
+      emails: modelValues(emails, ["label", "value"]),
+      urls: modelValues(urls, ["label", "value"]),
+      addresses: modelValues(addresses,
+        ["label", "street", "city", "state", "postalCode", "country", "countryCode"])
+    }
+  }
+  function review() {
+    if (!resolver || !card) return
+    if (isMerge) resolver.prepareConsolidation(card, draft())
+    else resolver.prepareCardEdit(card, draft())
+  }
+  function removedCardsLabel() {
+    if (!resolver || !resolver.mutationPreview) return ""
+    var cards = comparison && Array.isArray(comparison.cards) ? comparison.cards : []
+    var result = []
+    for (var i = 0; i < cards.length; i++) {
+      var candidate = cards[i]
+      if (!candidate || candidate.cardNumber === resolver.mutationPreview.cardNumber) continue
+      result.push(candidate.sourceName + " · card " + candidate.cardNumber)
+    }
+    return result.length > 0 ? result.join("; ")
+      : resolver.mutationPreview.sourceCardCount + " other source card(s)"
+  }
+  function addressSummary(value) {
+    if (!value) return ""
+    var parts = [value.street, value.city, value.state, value.postalCode, value.country]
+    var result = []
+    for (var i = 0; i < parts.length; i++) {
+      var part = text(parts[i]).trim()
+      if (part !== "") result.push(part)
+    }
+    return result.join(", ")
+  }
+  function closeEditor() {
+    if (resolver && resolver.loading) return
+    if (resolver) resolver.cancelMutation()
+    closeRequested()
+  }
+
+  onCardChanged: Qt.callLater(reload)
+  onInitialCardChanged: Qt.callLater(reload)
+  Component.onCompleted: reload()
+
+  ListModel { id: phones }
+  ListModel { id: emails }
+  ListModel { id: urls }
+  ListModel { id: addresses }
+
+  RowLayout {
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: root.space(2)
+      Text {
+        Layout.fillWidth: true
+        text: root.previewOpen
+          ? root.isMerge ? "Review merged contact" : "Review contact changes"
+          : root.isMerge ? "Build one merged contact" : "Edit source card " + (root.card ? root.card.cardNumber : "")
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.body)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.previewOpen
+          ? "Nothing has been written to Mac Contacts yet. Review the result and source-card outcome below."
+          : root.isMerge
+          ? (root.card ? root.card.sourceName : "Contacts source") + " · card "
+            + (root.card ? root.card.cardNumber : "") + " will remain; the other source cards will be deleted after confirmation."
+          : (root.card ? root.card.sourceName : "Contacts source") + " · card "
+            + (root.card ? root.card.cardNumber : "")
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+    }
+    ActionButton { label: "Close editor"; enabled: !root.resolver || !root.resolver.loading; onClicked: root.closeEditor() }
+  }
+
+  NoticeBox {
+    visible: !root.previewOpen
+    tone: root.isMerge ? "warning" : "info"
+    message: root.isMerge
+      ? "Review every field below. Blip started with the target card’s choices, filled its blanks, and combined unique phone, email, website, and address values. The target card’s photo is retained; photos on deleted source cards are not copied."
+      : "Changes stay in this form until you click Review changes. Blip then rechecks the exact Mac card and shows a separate confirmation before saving. The existing photo is retained."
+  }
+
+  SectionTitle { visible: !root.previewOpen; label: "NAME & WORK" }
+  GridLayout {
+    visible: !root.previewOpen
+    Layout.fillWidth: true
+    columns: width >= root.space(720) ? 2 : 1
+    columnSpacing: root.space(12)
+    rowSpacing: root.space(9)
+    Field { id: firstName; title: "First name"; maximum: 160 }
+    Field { id: middleName; title: "Middle name"; maximum: 160 }
+    Field { id: lastName; title: "Last name"; maximum: 160 }
+    Field { id: nickname; title: "Nickname"; maximum: 160 }
+    Field { id: organization; title: "Organization" }
+    Field { id: department; title: "Department" }
+    Field { id: jobTitle; title: "Job title" }
+    Field { id: birthday; title: "Birthday"; hint: "YYYY-MM-DD or --MM-DD"; maximum: 10 }
+  }
+
+  ValueList { visible: !root.previewOpen; title: "PHONE NUMBERS"; model: phones; emptyLabel: "Add phone" }
+  ValueList { visible: !root.previewOpen; title: "EMAIL ADDRESSES"; model: emails; emptyLabel: "Add email" }
+  ValueList { visible: !root.previewOpen; title: "WEBSITES"; model: urls; emptyLabel: "Add website" }
+
+  RowLayout {
+    visible: !root.previewOpen
+    Layout.fillWidth: true
+    SectionTitle { Layout.fillWidth: true; label: "POSTAL ADDRESSES" }
+  }
+  Text {
+    Layout.fillWidth: true
+    visible: !root.previewOpen && addresses.count === 0
+    text: "No postal addresses"
+    textFormat: Text.PlainText
+    color: Qt.darker(root.foreground, 1.4)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+  Repeater {
+    model: root.previewOpen ? null : addresses
+    delegate: Rectangle {
+      id: addressRow
+      required property int index
+      required property string label
+      required property string street
+      required property string city
+      required property string state
+      required property string postalCode
+      required property string country
+      required property string countryCode
+      Layout.fillWidth: true
+      implicitHeight: addressFields.implicitHeight + root.space(20)
+      radius: root.corner(root.space(8))
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.035)
+      border.width: 1
+      border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.16)
+      ColumnLayout {
+        id: addressFields
+        anchors.fill: parent
+        anchors.margins: root.space(10)
+        spacing: root.space(7)
+        RowLayout {
+          Layout.fillWidth: true
+          Text { Layout.fillWidth: true; text: "ADDRESS " + (addressRow.index + 1); textFormat: Text.PlainText;
+            color: root.foreground; font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption); font.bold: true }
+          ActionButton { danger: true; label: "Remove"; enabled: !root.previewOpen; onClicked: addresses.remove(addressRow.index) }
+        }
+        GridLayout {
+          Layout.fillWidth: true
+          columns: width >= root.space(700) ? 2 : 1
+          columnSpacing: root.space(10); rowSpacing: root.space(7)
+          AddressField { title: "Label"; role: "label"; value: addressRow.label; row: addressRow.index; maximum: 80 }
+          AddressField { title: "Street"; role: "street"; value: addressRow.street; row: addressRow.index; maximum: 320 }
+          AddressField { title: "City"; role: "city"; value: addressRow.city; row: addressRow.index; maximum: 320 }
+          AddressField { title: "State / region"; role: "state"; value: addressRow.state; row: addressRow.index; maximum: 320 }
+          AddressField { title: "Postal code"; role: "postalCode"; value: addressRow.postalCode; row: addressRow.index; maximum: 80 }
+          AddressField { title: "Country"; role: "country"; value: addressRow.country; row: addressRow.index; maximum: 160 }
+          AddressField { title: "Country code"; role: "countryCode"; value: addressRow.countryCode; row: addressRow.index; maximum: 8 }
+        }
+      }
+    }
+  }
+  RowLayout {
+    visible: !root.previewOpen
+    Layout.fillWidth: true
+    Layout.topMargin: root.space(2)
+    Layout.bottomMargin: root.space(4)
+    Item { Layout.fillWidth: true }
+    ActionButton {
+      label: "Add address"
+      enabled: addresses.count < 16 && !root.previewOpen
+      onClicked: addresses.append({ label: "", originalLabel: "", street: "", city: "", state: "",
+        postalCode: "", country: "", countryCode: "" })
+    }
+  }
+
+  SectionTitle { visible: !root.previewOpen; label: "NOTES" }
+  TextField {
+    id: notes
+    Layout.fillWidth: true
+    placeholderText: "Notes"
+    foreground: root.foreground; accent: root.accent
+    font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+    maximumLength: 1000
+    enabled: !root.previewOpen
+    visible: !root.previewOpen
+  }
+
+  MutationReview {
+    Layout.fillWidth: true
+    visible: root.resolver && root.resolver.mutationPreview !== null
+    preview: root.resolver ? root.resolver.mutationPreview : null
+  }
+
+  RowLayout {
+    Layout.fillWidth: true
+    visible: !root.resolver || root.resolver.mutationPreview === null
+    spacing: root.space(8)
+    ActionButton {
+      visible: !root.isMerge
+      danger: true
+      label: "Delete this source card…"
+      enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+      onClicked: root.resolver.prepareCardDelete(root.card)
+    }
+    Item { Layout.fillWidth: true }
+    ActionButton { label: "Discard draft"; onClicked: root.closeEditor() }
+    ActionButton {
+      primary: true
+      label: root.isMerge ? "Review merged contact…" : "Review changes…"
+      enabled: root.resolver && !root.resolver.loading && root.resolver.contactWrites
+      onClicked: root.review()
+    }
+  }
+
+  component SectionTitle: Text {
+    property string label: ""
+    Layout.fillWidth: true
+    text: label
+    textFormat: Text.PlainText
+    color: root.accent
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+    font.bold: true
+  }
+
+  component Field: ColumnLayout {
+    id: fieldBox
+    property alias text: input.text
+    property string title: ""
+    property string hint: ""
+    property int maximum: 320
+    Layout.fillWidth: true
+    spacing: root.space(4)
+    Text { text: parent.title; textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.25);
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+    TextField {
+      id: input
+      Layout.fillWidth: true
+      placeholderText: fieldBox.hint
+      foreground: root.foreground; accent: root.accent
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+      maximumLength: fieldBox.maximum
+      enabled: !root.previewOpen
+    }
+  }
+
+  component ValueList: ColumnLayout {
+    id: valueList
+    property string title: ""
+    property string emptyLabel: "Add value"
+    required property ListModel model
+    Layout.fillWidth: true
+    spacing: root.space(6)
+    SectionTitle { label: valueList.title }
+    Text {
+      Layout.fillWidth: true
+      visible: parent.model.count === 0
+      text: "None"
+      textFormat: Text.PlainText
+      color: Qt.darker(root.foreground, 1.4)
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption)
+    }
+    Repeater {
+      model: parent.model
+      delegate: RowLayout {
+        id: valueRow
+        required property int index
+        required property string label
+        required property string value
+        Layout.fillWidth: true
+        spacing: root.space(7)
+        TextField {
+          Layout.preferredWidth: root.space(150)
+          text: valueRow.label
+          placeholderText: "Label"
+          foreground: root.foreground; accent: root.accent
+          font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+          maximumLength: 80
+          enabled: !root.previewOpen
+          onTextChanged: valueList.model.setProperty(valueRow.index, "label", text)
+        }
+        TextField {
+          Layout.fillWidth: true
+          text: valueRow.value
+          placeholderText: "Value"
+          foreground: root.foreground; accent: root.accent
+          font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+          maximumLength: 320
+          enabled: !root.previewOpen
+          onTextChanged: valueList.model.setProperty(valueRow.index, "value", text)
+        }
+        ActionButton { danger: true; label: "Remove"; enabled: !root.previewOpen; onClicked: valueList.model.remove(valueRow.index) }
+      }
+    }
+    RowLayout {
+      Layout.fillWidth: true
+      Layout.topMargin: root.space(2)
+      Layout.bottomMargin: root.space(4)
+      Item { Layout.fillWidth: true }
+      ActionButton {
+        label: valueList.emptyLabel
+        enabled: valueList.model.count < 16 && !root.previewOpen
+        onClicked: valueList.model.append({ label: "", originalLabel: "", value: "" })
+      }
+    }
+  }
+
+  component AddressField: ColumnLayout {
+    property string title: ""
+    property string role: ""
+    property string value: ""
+    property int row: 0
+    property int maximum: 320
+    Layout.fillWidth: true
+    spacing: root.space(3)
+    Text { text: parent.title; textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.3);
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+    TextField {
+      Layout.fillWidth: true; text: parent.value
+      foreground: root.foreground; accent: root.accent
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.bodySmall)
+      maximumLength: parent.maximum
+      enabled: !root.previewOpen
+      onTextChanged: addresses.setProperty(parent.row, parent.role, text)
+    }
+  }
+
+  component NoticeBox: Rectangle {
+    property string tone: "info"
+    property string message: ""
+    Layout.fillWidth: true
+    implicitHeight: noticeText.implicitHeight + root.space(20)
+    radius: root.corner(root.space(8))
+    color: tone === "warning" ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.08)
+      : Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.07)
+    border.width: 1
+    border.color: tone === "warning" ? root.urgent : Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.38)
+    Text { id: noticeText; anchors.fill: parent; anchors.margins: root.space(10); text: parent.message;
+      textFormat: Text.PlainText; wrapMode: Text.WordWrap; color: root.foreground;
+      font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+  }
+
+  component MutationReview: Rectangle {
+    id: reviewBox
+    required property var preview
+    Layout.fillWidth: true
+    implicitHeight: reviewContent.implicitHeight + root.space(28)
+    radius: root.corner(root.space(12))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.035)
+    border.width: 1
+    border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.42)
+
+    ColumnLayout {
+      id: reviewContent
+      anchors.fill: parent
+      anchors.margins: root.space(14)
+      spacing: root.space(14)
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        spacing: root.space(4)
+        Text {
+          Layout.fillWidth: true
+          text: reviewBox.preview && reviewBox.preview.action === "consolidate"
+            ? "REVIEW CONSOLIDATION" : reviewBox.preview && reviewBox.preview.action === "delete"
+              ? "REVIEW DELETION" : "REVIEW CONTACT CHANGES"
+          textFormat: Text.PlainText
+          color: root.accent
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.caption)
+          font.bold: true
+        }
+        Text {
+          Layout.fillWidth: true
+          text: "This is a read-only preview. Nothing below has been saved to Contacts."
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.bodySmall)
+          font.bold: true
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        implicitHeight: sourceOutcome.implicitHeight + root.space(20)
+        radius: root.corner(root.space(8))
+        color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.07)
+        border.width: 1
+        border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.3)
+        ColumnLayout {
+          id: sourceOutcome
+          anchors.fill: parent
+          anchors.margins: root.space(10)
+          spacing: root.space(6)
+          ReviewOutcomeRow {
+            label: reviewBox.preview && reviewBox.preview.action === "delete" ? "DELETE" : "KEEP AND UPDATE"
+            value: reviewBox.preview
+              ? reviewBox.preview.sourceName + " · card " + reviewBox.preview.cardNumber : ""
+            danger: reviewBox.preview && reviewBox.preview.action === "delete"
+          }
+          ReviewOutcomeRow {
+            visible: reviewBox.preview && reviewBox.preview.action === "consolidate"
+            label: "DELETE AFTER MERGE"
+            value: root.removedCardsLabel()
+            danger: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: reviewBox.preview
+              ? "Different from the surviving card: " + reviewBox.preview.changedFields.join(", ") + "."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.3)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+        }
+      }
+
+      SectionTitle {
+        label: reviewBox.preview && reviewBox.preview.action === "delete"
+          ? "CONTACT CARD TO DELETE" : reviewBox.preview && reviewBox.preview.action === "consolidate"
+            ? "MERGED CONTACT TO KEEP" : "CONTACT AFTER SAVING"
+      }
+      GridLayout {
+        Layout.fillWidth: true
+        columns: width >= root.space(720) ? 2 : 1
+        columnSpacing: root.space(10)
+        rowSpacing: root.space(8)
+        ReviewField { label: "First name"; value: firstName.text }
+        ReviewField { label: "Middle name"; value: middleName.text }
+        ReviewField { label: "Last name"; value: lastName.text }
+        ReviewField { label: "Nickname"; value: nickname.text }
+        ReviewField { label: "Organization"; value: organization.text }
+        ReviewField { label: "Department"; value: department.text }
+        ReviewField { label: "Job title"; value: jobTitle.text }
+        ReviewField { label: "Birthday"; value: birthday.text }
+      }
+      ReviewValueList { title: "PHONE NUMBERS"; sourceModel: phones }
+      ReviewValueList { title: "EMAIL ADDRESSES"; sourceModel: emails }
+      ReviewValueList { title: "WEBSITES"; sourceModel: urls }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        visible: addresses.count > 0
+        spacing: root.space(6)
+        SectionTitle { label: "POSTAL ADDRESSES" }
+        Repeater {
+          model: addresses
+          delegate: ReviewOutcomeRow {
+            required property string street
+            required property string city
+            required property string state
+            required property string postalCode
+            required property string country
+            value: root.addressSummary({ street: street, city: city, state: state,
+              postalCode: postalCode, country: country })
+          }
+        }
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        visible: notes.text.trim() !== ""
+        spacing: root.space(6)
+        SectionTitle { label: "NOTES" }
+        Text {
+          Layout.fillWidth: true
+          text: notes.text
+          textFormat: Text.PlainText
+          wrapMode: Text.WordWrap
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: root.fontSize(Style.font.bodySmall)
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        implicitHeight: finalConfirmation.implicitHeight + root.space(22)
+        radius: root.corner(root.space(9))
+        color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.08)
+        border.width: 1
+        border.color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.65)
+        ColumnLayout {
+          id: finalConfirmation
+          anchors.fill: parent
+          anchors.margins: root.space(11)
+          spacing: root.space(8)
+          Text {
+            Layout.fillWidth: true
+            text: "FINAL CONFIRMATION"
+            textFormat: Text.PlainText
+            color: root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: reviewBox.preview ? reviewBox.preview.action === "edit"
+              ? "Save this reviewed contact to " + reviewBox.preview.sourceName + "?"
+              : reviewBox.preview.action === "delete"
+                ? "Delete this reviewed source card from " + reviewBox.preview.sourceName + "?"
+                : "Save the reviewed merged contact to " + reviewBox.preview.sourceName
+                  + " and delete " + reviewBox.preview.sourceCardCount + " other source card(s)?"
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: reviewBox.preview ? reviewBox.preview.action === "delete"
+              ? "Undo can recreate the text fields in the default writable account, but cannot restore the original account placement, links, or photo."
+              : reviewBox.preview.action === "consolidate"
+                ? "Undo can recreate removed text fields as new cards, but their original account placement, links, and photos cannot be guaranteed."
+                : "An owner-only undo receipt will be saved on the Mac."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: Qt.darker(root.foreground, 1.25)
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Item { Layout.fillWidth: true }
+            ActionButton { label: "Back to edit"; onClicked: root.resolver.cancelMutation() }
+            ActionButton {
+              danger: reviewBox.preview && reviewBox.preview.action !== "edit"
+              primary: true
+              label: reviewBox.preview && reviewBox.preview.action === "edit"
+                ? "Save to Mac Contacts" : reviewBox.preview && reviewBox.preview.action === "delete"
+                  ? "Delete card from Contacts" : "Merge and delete source cards"
+              enabled: root.resolver && !root.resolver.loading && reviewBox.preview
+                && reviewBox.preview.writeEnabled
+              onClicked: root.resolver.applyMutation()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  component ReviewField: Rectangle {
+    property string label: ""
+    property string value: ""
+    Layout.fillWidth: true
+    visible: value.trim() !== ""
+    implicitHeight: reviewFieldContent.implicitHeight + root.space(16)
+    radius: root.corner(root.space(7))
+    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.045)
+    ColumnLayout {
+      id: reviewFieldContent
+      anchors.fill: parent
+      anchors.margins: root.space(8)
+      spacing: root.space(2)
+      Text { text: parent.parent.label; textFormat: Text.PlainText; color: Qt.darker(root.foreground, 1.35);
+        font.family: root.fontFamily; font.pixelSize: root.fontSize(Style.font.caption) }
+      Text { Layout.fillWidth: true; text: parent.parent.value; textFormat: Text.PlainText;
+        wrapMode: Text.WordWrap; color: root.foreground; font.family: root.fontFamily;
+        font.pixelSize: root.fontSize(Style.font.bodySmall); font.bold: true }
+    }
+  }
+
+  component ReviewValueList: ColumnLayout {
+    id: reviewList
+    property string title: ""
+    required property ListModel sourceModel
+    Layout.fillWidth: true
+    visible: sourceModel.count > 0
+    spacing: root.space(6)
+    SectionTitle { label: reviewList.title }
+    Repeater {
+      model: reviewList.sourceModel
+      delegate: ReviewOutcomeRow {}
+    }
+  }
+
+  component ReviewOutcomeRow: RowLayout {
+    required property string label
+    required property string value
+    property bool danger: false
+    Layout.fillWidth: true
+    spacing: root.space(10)
+    Text {
+      Layout.preferredWidth: root.space(170)
+      text: parent.label === "" ? "UNLABELED" : parent.label.toUpperCase()
+      textFormat: Text.PlainText
+      color: parent.danger ? root.urgent : Qt.darker(root.foreground, 1.3)
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: true
+    }
+    Text {
+      Layout.fillWidth: true
+      text: parent.value
+      textFormat: Text.PlainText
+      wrapMode: Text.WordWrap
+      color: root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.bodySmall)
+    }
+  }
+
+  component ActionButton: Rectangle {
+    id: button
+    property string label: ""
+    property bool danger: false
+    property bool primary: false
+    signal clicked()
+    implicitWidth: buttonText.implicitWidth + root.space(16)
+    implicitHeight: buttonText.implicitHeight + root.space(10)
+    radius: root.corner(root.space(7)); opacity: enabled ? 1.0 : 0.45
+    color: hover.hovered ? Qt.rgba((danger ? root.urgent : root.accent).r,
+      (danger ? root.urgent : root.accent).g, (danger ? root.urgent : root.accent).b, 0.18)
+      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+    border.width: 1; border.color: danger ? root.urgent : primary ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
+    Text { id: buttonText; anchors.centerIn: parent; text: button.label; textFormat: Text.PlainText;
+      color: button.danger ? root.urgent : root.foreground; font.family: root.fontFamily;
+      font.pixelSize: root.fontSize(Style.font.caption); font.bold: button.primary }
+    HoverHandler { id: hover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
+    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+  }
+}

--- a/ContactManagement.qml
+++ b/ContactManagement.qml
@@ -89,7 +89,8 @@ ColumnLayout {
           ? root.resolver.candidates.length + " different people are named for this " + root.handleNoun() + " in Contacts. Pick who this conversation belongs to — from there you can merge the cards or remove the " + root.handleNoun() + " from the wrong one."
           : root.selectedCandidate && root.selectedCandidate.recordCount > 1
             ? root.selectedCandidate.recordCount + " source cards found. Compare, edit, consolidate, delete, or link them from Blip."
-            : "One source card found. You can review, edit, or delete it from Blip."
+            : root.selectedCandidate ? "One source card found. You can review, edit, or delete it from Blip."
+              : "Choose a person to review their source cards."
         textFormat: Text.PlainText
         wrapMode: Text.WordWrap
         color: Qt.darker(root.foreground, 1.35)

--- a/ContactManagement.qml
+++ b/ContactManagement.qml
@@ -1,0 +1,547 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+ColumnLayout {
+  id: root
+  property var resolver: null
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: Color.accent
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  property real density: 1.0
+  property real cornerScale: 1.0
+  property bool discardUnsavedConfirm: false
+  readonly property string animatedDots: "…"
+  readonly property bool unsavedContactsError: resolver && /unsaved|pending changes/i.test(resolver.error)
+  property string selectedToken: ""
+  readonly property bool macReviewExpanded: true
+  readonly property var selectedCandidate: candidateForToken(selectedToken)
+  signal closeRequested()
+  function fontSize(value) { return Math.max(1, Math.round(value * fontScale)) }
+  function space(value) { return Math.max(1, Math.round(Style.spaceReal(value) * density)) }
+  function corner(value) { return Math.max(0, Math.round(value * cornerScale)) }
+  function handleNoun() { return resolver && resolver.activeHandle.indexOf("@") >= 0 ? "email" : "number" }
+  function handleKey(value) { return resolver ? resolver.handleKey(value) : "" }
+  function candidateForToken(token) {
+    return resolver ? resolver.candidates.find(c => c.token === token) || null : null
+  }
+  function selectCandidate(candidate) {
+    if (!candidate || !resolver || resolver.loading) return
+    resolver.cancelRepair()
+    resolver.cancelComparison()
+    selectedToken = candidate.token
+    resolver.compareCards(resolver.activeHandle, candidate.token)
+  }
+  Connections {
+    target: root.resolver
+    function onActiveHandleChanged() { root.selectedToken = "" }
+    function onCandidatesChanged() {
+      if (!root.candidateForToken(root.selectedToken)) root.selectedToken = ""
+    }
+  }
+  Rectangle {
+    Layout.fillWidth: true
+    implicitHeight: guide.implicitHeight + root.space(20)
+    color: "transparent"
+    ColumnLayout {
+      id: guide
+      anchors.left: parent.left; anchors.right: parent.right; anchors.top: parent.top
+      spacing: root.space(12)
+      Rectangle {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        implicitHeight: 1
+        color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+      }
+
+      RowLayout {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        spacing: root.space(8)
+        SectionHeading { label: "MANAGE MAC CONTACTS" }
+        SmallButton {
+          visible: contactWorkspace.editorCard === null
+            && (!root.resolver || root.resolver.mutationPreview === null)
+            && (!root.resolver || root.resolver.repairPreview === null)
+            && (!root.resolver || root.resolver.comparison === null)
+          label: "Refresh source cards"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: root.resolver.findCandidates(root.resolver.activeHandle)
+        }
+        SmallButton {
+          visible: !root.resolver || root.resolver.comparison === null
+          label: "Back to contact review"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: {
+            if (root.resolver.comparison) root.resolver.cancelComparison()
+            root.closeRequested()
+          }
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        text: root.resolver && root.resolver.candidates.length > 1
+          ? root.resolver.candidates.length + " different people are named for this " + root.handleNoun() + " in Contacts. Pick who this conversation belongs to — from there you can merge the cards or remove the " + root.handleNoun() + " from the wrong one."
+          : root.selectedCandidate && root.selectedCandidate.recordCount > 1
+            ? root.selectedCandidate.recordCount + " source cards found. Compare, edit, consolidate, delete, or link them from Blip."
+            : "One source card found. You can review, edit, or delete it from Blip."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        visible: root.macReviewExpanded
+        spacing: root.space(12)
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.candidates.length > 0 && root.selectedCandidate === null
+        text: "Pick a person below. That only opens their cards for review — it is temporary, never saved, and changes nothing in Contacts."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.urgent
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+        font.bold: true
+      }
+
+      Repeater {
+        model: root.resolver ? root.resolver.candidates : []
+        delegate: Rectangle {
+          id: sourceCandidate
+          required property var modelData
+          readonly property bool intended: root.selectedToken === modelData.token
+          property bool cardsExpanded: !intended && modelData.recordCount <= 3
+          visible: !(intended && root.resolver && root.resolver.comparison
+            && root.resolver.comparison.ownerToken === modelData.token)
+          Layout.fillWidth: true
+          implicitHeight: sourceGroup.implicitHeight + root.space(16)
+          radius: root.corner(root.space(9))
+          color: intended
+            ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.09)
+            : root.selectedCandidate
+              ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.07)
+              : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.04)
+          border.width: 1
+          border.color: intended
+            ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.35)
+            : root.selectedCandidate
+              ? Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.35)
+              : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.2)
+
+          ColumnLayout {
+            id: sourceGroup
+            anchors.fill: parent
+            anchors.margins: root.space(8)
+            spacing: root.space(6)
+            RowLayout {
+              Layout.fillWidth: true
+              spacing: root.space(8)
+              Text {
+                Layout.fillWidth: true
+                text: (sourceCandidate.intended ? "WORKING ON: "
+                  : root.selectedCandidate
+                    ? "OTHER PERSON USING THIS " + root.handleNoun().toUpperCase() + ": "
+                    : "POSSIBLE PERSON: ")
+                  + String(sourceCandidate.modelData.name || "")
+                textFormat: Text.PlainText
+                wrapMode: Text.WordWrap
+                color: sourceCandidate.intended || !root.selectedCandidate
+                  ? root.foreground : root.urgent
+                font.family: root.fontFamily
+                font.pixelSize: root.fontSize(Style.font.caption)
+                font.bold: true
+              }
+              SmallButton {
+                // Explicit same-person declaration: opens the standard
+                // compare/merge workspace spanning BOTH people's cards.
+                visible: !sourceCandidate.intended && root.selectedCandidate !== null
+                  && root.resolver && root.resolver.contactWrites
+                label: "Merge with " + (root.selectedCandidate ? root.selectedCandidate.name : "") + "…"
+                enabled: root.resolver && !root.resolver.loading
+                onClicked: root.resolver.compareCards(
+                  root.resolver.activeHandle, root.selectedToken, sourceCandidate.modelData.token)
+              }
+              SmallButton {
+                label: !sourceCandidate.intended ? "Work on this person…"
+                  : root.resolver && root.resolver.comparison
+                  && root.resolver.comparison.ownerToken === sourceCandidate.modelData.token
+                  ? "Contact workspace open"
+                  : sourceCandidate.modelData.recordCount === 1 ? "Manage contact…"
+                    : "Manage " + sourceCandidate.modelData.recordCount + " cards…"
+                enabled: root.resolver && !root.resolver.loading
+                  && (!sourceCandidate.intended || !root.resolver.comparison
+                    || root.resolver.comparison.ownerToken !== sourceCandidate.modelData.token)
+                onClicked: {
+                  if (sourceCandidate.intended) root.resolver.compareCards(
+                    root.resolver.activeHandle, sourceCandidate.modelData.token)
+                  else root.selectCandidate(sourceCandidate.modelData)
+                }
+              }
+              SmallButton {
+                label: sourceCandidate.cardsExpanded
+                  ? "Hide cards"
+                  : "Show " + sourceCandidate.modelData.recordCount
+                    + (sourceCandidate.modelData.recordCount === 1 ? " card" : " cards")
+                enabled: root.resolver && !root.resolver.loading
+                onClicked: sourceCandidate.cardsExpanded = !sourceCandidate.cardsExpanded
+              }
+            }
+            Text {
+              Layout.fillWidth: true
+              text: sourceCandidate.intended
+                ? "You’re reviewing this person’s cards temporarily — nothing is saved as a Blip name, and every Mac Contacts change asks for its own confirmation."
+                : root.selectedCandidate
+                  ? "A different person? Remove just this " + root.handleNoun() + " from their card. The same person under another name (a married-name change, say)? Merge the cards — you can adjust the surviving name during the review."
+                  : "Opens their cards for review — from there you can edit them, merge duplicates, or remove this " + root.handleNoun() + " from the wrong card."
+              textFormat: Text.PlainText
+              wrapMode: Text.WordWrap
+              color: Qt.darker(root.foreground, 1.4)
+              font.family: root.fontFamily
+              font.pixelSize: root.fontSize(Style.font.caption)
+            }
+            Repeater {
+              model: sourceCandidate.cardsExpanded ? sourceCandidate.modelData.cards : []
+              delegate: RowLayout {
+                id: sourceCard
+                required property var modelData
+                required property int index
+                Layout.fillWidth: true
+                spacing: root.space(8)
+                Text {
+                  Layout.fillWidth: true
+                  text: "Card " + (sourceCard.index + 1) + " of " + sourceCandidate.modelData.recordCount
+                    + " · " + sourceCard.modelData.sourceName
+                    + (sourceCandidate.modelData.sourceCount > 1
+                      ? " · source " + sourceCard.modelData.accountNumber
+                        + " of " + sourceCandidate.modelData.sourceCount : "")
+                    + (sourceCard.modelData.matchCount > 1
+                      ? " · " + sourceCard.modelData.matchCount + " matching fields" : "")
+                    + (sourceCard.modelData.hasPhoto ? " · has photo" : "")
+                  textFormat: Text.PlainText
+                  elide: Text.ElideRight
+                  color: Qt.darker(root.foreground, 1.4)
+                  font.family: root.fontFamily
+                  font.pixelSize: root.fontSize(Style.font.caption)
+                }
+                SmallButton {
+                  label: "Open card " + (sourceCard.index + 1) + " on Mac…"
+                  enabled: root.resolver && !root.resolver.loading
+                  onClicked: root.resolver.openOnMac(root.resolver.activeHandle, sourceCard.modelData.token)
+                }
+                SmallButton {
+                  visible: !sourceCandidate.intended && root.selectedCandidate !== null
+                    && root.resolver && root.resolver.contactWrites
+                  danger: true
+                  label: "Remove this " + root.handleNoun() + "…"
+                  enabled: root.resolver && !root.resolver.loading
+                  onClicked: root.resolver.inspectOnMac(
+                    root.resolver.activeHandle, sourceCard.modelData.token, root.selectedToken)
+                }
+              }
+            }
+          }
+        }
+      }
+
+      ContactCardCompare {
+        id: contactWorkspace
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.comparison !== null
+          && root.resolver.comparison.ownerToken === root.selectedToken
+        resolver: root.resolver
+        comparison: root.resolver ? root.resolver.comparison : null
+        foreground: root.foreground
+        urgent: root.urgent
+        accent: root.accent
+        fontFamily: root.fontFamily
+        fontScale: root.fontScale
+        density: root.density
+        cornerScale: root.cornerScale
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        visible: root.resolver && root.resolver.repairPreview !== null
+        implicitHeight: repairConfirmation.implicitHeight + root.space(20)
+        radius: root.corner(root.space(9))
+        color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.09)
+        border.width: 2
+        border.color: root.urgent
+
+        ColumnLayout {
+          id: repairConfirmation
+          anchors.fill: parent
+          anchors.margins: root.space(10)
+          spacing: root.space(7)
+          Text {
+            Layout.fillWidth: true
+            text: root.resolver && root.resolver.repairPreview
+              ? "Remove " + root.resolver.repairPreview.handle + " from “"
+                + root.resolver.repairPreview.name + "”?"
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.bodySmall)
+            font.bold: true
+          }
+          Text {
+            Layout.fillWidth: true
+            text: root.resolver && root.resolver.repairPreview
+              ? "Verified card " + root.resolver.repairPreview.cardNumber + " of "
+                + root.resolver.repairPreview.cardCount + " from "
+                + root.resolver.repairPreview.sourceName + ". This will remove "
+                + root.resolver.repairPreview.fieldCount + " matching "
+                + root.resolver.repairPreview.kind
+                + (root.resolver.repairPreview.fieldCount === 1 ? " field" : " fields")
+                + " from synced Mac Contacts. An undo receipt will be saved on the Mac."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          Text {
+            Layout.fillWidth: true
+            visible: root.resolver && root.resolver.repairPreview
+              && !root.resolver.repairPreview.writeEnabled
+            text: "The Mac-side contact-writes gate is disabled. Re-run setup with explicit contact-write access."
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+            font.bold: true
+          }
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: root.space(8)
+            Item { Layout.fillWidth: true }
+            SmallButton {
+              label: "Cancel"
+              enabled: root.resolver && !root.resolver.loading
+              onClicked: root.resolver.cancelRepair()
+            }
+            SmallButton {
+              danger: true
+              primary: true
+              label: "Remove from Mac Contacts"
+              enabled: root.resolver && !root.resolver.loading
+                && root.resolver.repairPreview && root.resolver.repairPreview.writeEnabled
+              onClicked: root.resolver.removeOnMac()
+            }
+          }
+        }
+      }
+
+      Rectangle {
+        Layout.fillWidth: true
+        // The undo offer belongs to the contact it changed — one merge's
+        // receipt must not follow the user into another person's workspace.
+        // The token stays in memory, so returning to that contact within the
+        // session re-offers it (the private Mac receipt outlives both).
+        visible: root.resolver && /^undo:[0-9a-f]{32}$/.test(root.resolver.undoToken)
+          && root.handleKey(root.resolver.undoHandle)
+             === root.handleKey(root.resolver.activeHandle)
+        implicitHeight: undoContents.implicitHeight + root.space(18)
+        radius: root.corner(root.space(9))
+        color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.12)
+        border.width: 1
+        border.color: root.accent
+        RowLayout {
+          id: undoContents
+          anchors.fill: parent
+          anchors.margins: root.space(9)
+          spacing: root.space(8)
+          Text {
+            Layout.fillWidth: true
+            text: root.resolver
+              ? (root.resolver.undoAction === "edit" ? "Edited one source card for “"
+                : root.resolver.undoAction === "delete" ? "Deleted one source card for “"
+                : root.resolver.undoAction === "consolidate"
+                  ? "Consolidated " + root.resolver.undoCardCount + " source cards for “"
+                  : "Removed " + root.resolver.undoHandle + " from “")
+                + root.resolver.undoName
+                + "”. Undo is available here now; its private Mac receipt expires in seven days."
+              : ""
+            textFormat: Text.PlainText
+            wrapMode: Text.WordWrap
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontSize(Style.font.caption)
+          }
+          SmallButton {
+            primary: true
+            label: "Undo Mac change"
+            enabled: root.resolver && !root.resolver.loading
+            onClicked: root.resolver.undoOnMac()
+          }
+        }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.resolver && !root.resolver.contactWrites
+        text: "Contact editing is disabled. Set contact_writes=on locally and enable the separate owner-only gate on the Mac to use it. Viewing and opening cards remain read-only."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: contactWorkspace.editorCard === null && root.resolver
+          && root.resolver.candidates.length > 0 && root.selectedCandidate !== null
+        text: "Viewing or opening a card makes no change. Editing, deletion, consolidation, and handle removal all require a separate confirmation."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+
+      }
+    }
+  }
+
+  Text {
+    Layout.fillWidth: true
+    visible: root.resolver && (root.resolver.error !== "" || root.resolver.notice !== "")
+    // While an operation runs ("Consolidating the verified source cards…"),
+    // the notice's ellipsis animates as a three-dot progress indicator.
+    text: root.resolver && root.resolver.error !== ""
+      ? root.resolver.error
+      : root.resolver && root.resolver.loading
+        ? String(root.resolver.notice).replace(/…$/, "") + root.animatedDots
+        : String(root.resolver ? root.resolver.notice : "")
+    textFormat: Text.PlainText
+    wrapMode: Text.WordWrap
+    color: root.resolver && root.resolver.error !== "" ? root.urgent : Qt.darker(root.foreground, 1.4)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+  }
+
+  Rectangle {
+    Layout.fillWidth: true
+    implicitHeight: unsavedRecovery.implicitHeight + root.space(20)
+    visible: root.unsavedContactsError
+    radius: root.corner(root.space(8))
+    color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.07)
+    border.width: 1
+    border.color: Qt.rgba(root.urgent.r, root.urgent.g, root.urgent.b, 0.55)
+
+    ColumnLayout {
+      id: unsavedRecovery
+      anchors.fill: parent
+      anchors.margins: root.space(10)
+      spacing: root.space(8)
+
+      Text {
+        Layout.fillWidth: true
+        text: root.discardUnsavedConfirm
+          ? "Discard every pending change currently open in Contacts on the Mac?"
+          : "Contacts is holding an unfinished in-memory edit."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.bodySmall)
+        font.bold: true
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.discardUnsavedConfirm
+          ? "This closes Contacts without saving. Continue only if the pending edit is the failed Blip attempt; any separate edit you made directly on the Mac would also be discarded."
+          : "Finish or discard a real edit in Contacts on the Mac. If this was left by Blip’s failed save, Blip can close Contacts without saving it after one more confirmation."
+        textFormat: Text.PlainText
+        wrapMode: Text.WordWrap
+        color: Qt.darker(root.foreground, 1.3)
+        font.family: root.fontFamily
+        font.pixelSize: root.fontSize(Style.font.caption)
+      }
+      RowLayout {
+        Layout.fillWidth: true
+        Item { Layout.fillWidth: true }
+        SmallButton {
+          visible: root.discardUnsavedConfirm
+          label: "Cancel"
+          onClicked: root.discardUnsavedConfirm = false
+        }
+        SmallButton {
+          danger: root.discardUnsavedConfirm
+          primary: !root.discardUnsavedConfirm
+          label: root.discardUnsavedConfirm
+            ? "Discard and close Contacts" : "Resolve pending edit…"
+          enabled: root.resolver && !root.resolver.loading
+          onClicked: {
+            if (!root.discardUnsavedConfirm) {
+              root.discardUnsavedConfirm = true
+              return
+            }
+            root.discardUnsavedConfirm = false
+            root.resolver.discardUnsavedContacts()
+          }
+        }
+      }
+    }
+  }
+
+  component SectionHeading: Text {
+    property string label: ""
+    Layout.fillWidth: true
+    text: label
+    textFormat: Text.PlainText
+    color: Qt.darker(root.foreground, 1.2)
+    font.family: root.fontFamily
+    font.pixelSize: root.fontSize(Style.font.caption)
+    font.bold: true
+  }
+
+  component SmallButton: Rectangle {
+    id: button
+    property string label: ""
+    property bool danger: false
+    property bool primary: false
+    signal clicked()
+    implicitWidth: buttonText.implicitWidth + root.space(16)
+    implicitHeight: buttonText.implicitHeight + root.space(10)
+    radius: root.corner(root.space(7))
+    opacity: enabled ? 1.0 : 0.45
+    color: buttonHover.hovered
+      ? Qt.rgba((danger ? root.urgent : root.accent).r,
+                (danger ? root.urgent : root.accent).g,
+                (danger ? root.urgent : root.accent).b, 0.18)
+      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
+    border.width: 1
+    border.color: danger ? root.urgent : primary ? root.accent
+      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
+    Text {
+      id: buttonText
+      anchors.centerIn: parent
+      text: button.label
+      textFormat: Text.PlainText
+      color: button.danger ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize(Style.font.caption)
+      font.bold: button.primary
+    }
+    HoverHandler { id: buttonHover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
+    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+  }
+
+}

--- a/ContactManagement.qml
+++ b/ContactManagement.qml
@@ -57,9 +57,9 @@ ColumnLayout {
         color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
       }
 
-      RowLayout {
+      ColumnLayout {
         Layout.fillWidth: true
-        visible: root.macReviewExpanded
+        visible: root.macReviewExpanded && (!root.resolver || root.resolver.comparison === null)
         spacing: root.space(8)
         SectionHeading { label: "MANAGE MAC CONTACTS" }
         SmallButton {
@@ -71,20 +71,12 @@ ColumnLayout {
           enabled: root.resolver && !root.resolver.loading
           onClicked: root.resolver.findCandidates(root.resolver.activeHandle)
         }
-        SmallButton {
-          visible: !root.resolver || root.resolver.comparison === null
-          label: "Back to contact review"
-          enabled: root.resolver && !root.resolver.loading
-          onClicked: {
-            if (root.resolver.comparison) root.resolver.cancelComparison()
-            root.closeRequested()
-          }
-        }
+
       }
 
       Text {
         Layout.fillWidth: true
-        visible: root.macReviewExpanded
+        visible: root.macReviewExpanded && (!root.resolver || root.resolver.comparison === null)
         text: root.resolver && root.resolver.candidates.length > 1
           ? root.resolver.candidates.length + " different people are named for this " + root.handleNoun() + " in Contacts. Pick who this conversation belongs to — from there you can merge the cards or remove the " + root.handleNoun() + " from the wrong one."
           : root.selectedCandidate && root.selectedCandidate.recordCount > 1
@@ -106,13 +98,13 @@ ColumnLayout {
       Text {
         Layout.fillWidth: true
         visible: root.resolver && root.resolver.candidates.length > 0 && root.selectedCandidate === null
-        text: "Pick a person below. That only opens their cards for review — it is temporary, never saved, and changes nothing in Contacts."
+        text: "Choose a person to review their cards."
         textFormat: Text.PlainText
         wrapMode: Text.WordWrap
-        color: root.urgent
+        color: Qt.darker(root.foreground, 1.35)
         font.family: root.fontFamily
         font.pixelSize: root.fontSize(Style.font.caption)
-        font.bold: true
+        font.bold: false
       }
 
       Repeater {
@@ -144,7 +136,7 @@ ColumnLayout {
             anchors.fill: parent
             anchors.margins: root.space(8)
             spacing: root.space(6)
-            RowLayout {
+            ColumnLayout {
               Layout.fillWidth: true
               spacing: root.space(8)
               Text {
@@ -173,7 +165,7 @@ ColumnLayout {
                   root.resolver.activeHandle, root.selectedToken, sourceCandidate.modelData.token)
               }
               SmallButton {
-                label: !sourceCandidate.intended ? "Work on this person…"
+                label: !sourceCandidate.intended ? "Review cards…"
                   : root.resolver && root.resolver.comparison
                   && root.resolver.comparison.ownerToken === sourceCandidate.modelData.token
                   ? "Contact workspace open"
@@ -203,7 +195,7 @@ ColumnLayout {
                 ? "You’re reviewing this person’s cards temporarily — nothing is saved as a Blip name, and every Mac Contacts change asks for its own confirmation."
                 : root.selectedCandidate
                   ? "A different person? Remove just this " + root.handleNoun() + " from their card. The same person under another name (a married-name change, say)? Merge the cards — you can adjust the surviving name during the review."
-                  : "Opens their cards for review — from there you can edit them, merge duplicates, or remove this " + root.handleNoun() + " from the wrong card."
+                  : "Review, edit, merge cards, or remove this " + root.handleNoun() + " from the wrong card."
               textFormat: Text.PlainText
               wrapMode: Text.WordWrap
               color: Qt.darker(root.foreground, 1.4)
@@ -212,7 +204,7 @@ ColumnLayout {
             }
             Repeater {
               model: sourceCandidate.cardsExpanded ? sourceCandidate.modelData.cards : []
-              delegate: RowLayout {
+              delegate: ColumnLayout {
                 id: sourceCard
                 required property var modelData
                 required property int index
@@ -326,7 +318,7 @@ ColumnLayout {
             font.pixelSize: root.fontSize(Style.font.caption)
             font.bold: true
           }
-          RowLayout {
+          ColumnLayout {
             Layout.fillWidth: true
             spacing: root.space(8)
             Item { Layout.fillWidth: true }
@@ -361,7 +353,7 @@ ColumnLayout {
         color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.12)
         border.width: 1
         border.color: root.accent
-        RowLayout {
+        ColumnLayout {
           id: undoContents
           anchors.fill: parent
           anchors.margins: root.space(9)
@@ -474,7 +466,7 @@ ColumnLayout {
         font.family: root.fontFamily
         font.pixelSize: root.fontSize(Style.font.caption)
       }
-      RowLayout {
+      ColumnLayout {
         Layout.fillWidth: true
         Item { Layout.fillWidth: true }
         SmallButton {
@@ -512,37 +504,15 @@ ColumnLayout {
     font.bold: true
   }
 
-  component SmallButton: Rectangle {
-    id: button
+  component SmallButton: ContactButton {
     property string label: ""
     property bool danger: false
     property bool primary: false
-    signal clicked()
-    implicitWidth: buttonText.implicitWidth + root.space(16)
-    implicitHeight: buttonText.implicitHeight + root.space(10)
-    radius: root.corner(root.space(7))
-    opacity: enabled ? 1.0 : 0.45
-    color: buttonHover.hovered
-      ? Qt.rgba((danger ? root.urgent : root.accent).r,
-                (danger ? root.urgent : root.accent).g,
-                (danger ? root.urgent : root.accent).b, 0.18)
-      : primary ? Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.2)
-      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.055)
-    border.width: 1
-    border.color: danger ? root.urgent : primary ? root.accent
-      : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.3)
-    Text {
-      id: buttonText
-      anchors.centerIn: parent
-      text: button.label
-      textFormat: Text.PlainText
-      color: button.danger ? root.urgent : root.foreground
-      font.family: root.fontFamily
-      font.pixelSize: root.fontSize(Style.font.caption)
-      font.bold: button.primary
-    }
-    HoverHandler { id: buttonHover; enabled: button.enabled; cursorShape: Qt.PointingHandCursor }
-    TapHandler { enabled: button.enabled; onTapped: button.clicked() }
+    text: label
+    foreground: danger ? root.urgent : root.foreground
+    accent: root.accent
+    fontFamily: root.fontFamily
+    fontSize: root.fontSize(Style.font.caption)
+    Layout.maximumWidth: Math.max(1, root.width - root.space(56))
   }
-
 }

--- a/ContactOperations.qml
+++ b/ContactOperations.qml
@@ -1,0 +1,1027 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Short-lived, bounded bridge between the contact workspace and contact-management.ts.
+// No writable contact/config file is parsed inside the shell process.
+Item {
+  id: root
+  visible: false
+  implicitWidth: 0
+  implicitHeight: 0
+
+  readonly property string home: Quickshell.env("HOME")
+  readonly property string runtimeDirectory: Quickshell.env("XDG_RUNTIME_DIR")
+  readonly property string vcardUriPrefix: "file://" + runtimeDirectory + "/blip/vcards/"
+  readonly property string helperPath:
+    decodeURIComponent(Qt.resolvedUrl("contact-management.ts").toString().replace(/^file:\/\//, ""))
+
+  property var candidates: []
+  property var audit: null
+  property var repairPreview: null
+  property var comparison: null
+  property var linkPreview: null
+  property var mutationPreview: null
+  property var mutationRequest: null
+  property string comparisonOwnerToken: ""
+  // Set only for an explicit cross-name merge (two candidates the user
+  // identified as the same person); "" for the normal single-person scope.
+  property string comparisonOtherOwnerToken: ""
+  property string activeHandle: ""
+  property bool contactWrites: false
+  property string pendingRepairToken: ""
+  property string pendingOwnerToken: ""
+  property string undoToken: ""
+  property string undoHandle: ""
+  property string undoName: ""
+  property int undoFieldCount: 0
+  property string undoAction: ""
+  property int undoCardCount: 0
+  property bool loaded: false
+  property bool loading: false
+  property string error: ""
+  property string notice: "Loading contact access…"
+  property string currentOperation: ""
+  property bool reloadAfterExit: false
+  property bool readSilently: false
+  property string pendingReviewHandle: ""
+  property bool refreshCandidatesAfterExit: false
+  property int pendingAuditCount: 0
+  property bool quietAudit: false
+  // The cleanup scan runs on its own dedicated process (auditWorker) so a
+  // long scan can start the moment a mutation lands without contending with
+  // navigation, edits, or merges on the interactive worker.
+  property bool auditRunning: false
+  property string pendingAuditFingerprint: ""
+  property string auditFingerprint: ""
+  property bool vcardReported: false
+  property bool vcardClipboardPending: false
+  property string pendingVcardPayload: ""
+  property string pendingVcardFileName: ""
+
+  // Fired after any operation that changed Mac Contacts (edit, delete,
+  // merge, link, field removal, undo) so listeners can refresh derived
+  // views like the cleanup scan.
+  signal contactsMutated()
+  signal vcardFinished(string message, bool success)
+
+  function safeText(value, maximum) {
+    if (typeof value !== "string" || value.length > maximum) return ""
+    return value
+      .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+      .replace(/\s+/g, " ").trim()
+  }
+
+  function safeError(value) {
+    return safeText(String(value || "Contact operation failed"), 180)
+      || "Contact operation failed"
+  }
+
+  function handleKey(value) {
+    var handle = String(value || "")
+    if (handle.indexOf("@") >= 0) return "email:" + handle.toLowerCase()
+    var digits = handle.replace(/\D/g, "")
+    return "phone:" + (digits.length >= 10 ? digits.slice(-10) : digits)
+  }
+
+  function validToken(value) {
+    return typeof value === "string" && /^sha256:[0-9a-f]{64}$/.test(value)
+  }
+
+  function validRevision(value) {
+    return typeof value === "string" && /^sha256:[0-9a-f]{64}$/.test(value)
+  }
+
+  function safeCandidate(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var name = safeText(value.name, 160)
+    var records = Number(value.recordCount)
+    var sources = Number(value.sourceCount)
+    if (name === "" || !validToken(value.token)
+        || !Number.isInteger(records) || records < 1 || records > 64
+        || !Number.isInteger(sources) || sources < 1 || sources > 64) return null
+    if (!Array.isArray(value.cards) || value.cards.length !== records) return null
+    var cards = []
+    var accounts = ({})
+    var tokens = ({})
+    tokens[value.token] = true
+    for (var i = 0; i < value.cards.length; i++) {
+      var rawCard = value.cards[i]
+      if (!rawCard || typeof rawCard !== "object" || Array.isArray(rawCard)
+          || !validToken(rawCard.token) || tokens[rawCard.token]) return null
+      var account = Number(rawCard.accountNumber)
+      var sourceName = safeText(rawCard.sourceName, 120)
+      if (!Number.isInteger(account) || account < 1 || account > 64) return null
+      if (sourceName === "") return null
+      tokens[rawCard.token] = true
+      accounts[account] = true
+      cards.push({
+        token: rawCard.token,
+        accountNumber: account,
+        sourceName: sourceName,
+        hasPhoto: rawCard.hasPhoto === true,
+        matchCount: Number.isInteger(Number(rawCard.matchCount))
+          && Number(rawCard.matchCount) >= 1 && Number(rawCard.matchCount) <= 8
+          ? Number(rawCard.matchCount) : 1
+      })
+    }
+    if (Object.keys(accounts).length !== sources) return null
+    return {
+      token: value.token,
+      name: name,
+      recordCount: records,
+      sourceCount: sources,
+      hasPhoto: value.hasPhoto === true,
+      cards: cards
+    }
+  }
+
+  function safeAudit(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handleCount = Number(value.handleCount)
+    var noMatchCount = Number(value.noMatchCount)
+    if (!Number.isInteger(handleCount) || handleCount < 1 || handleCount > 200
+        || handleCount !== pendingAuditCount
+        || !Number.isInteger(noMatchCount) || noMatchCount < 0 || noMatchCount > handleCount)
+      return null
+    var seen = ({})
+    function entries(raw, kind) {
+      if (!Array.isArray(raw) || raw.length > 200) return null
+      var result = []
+      for (var i = 0; i < raw.length; i++) {
+        var item = raw[i]
+        if (!item || typeof item !== "object" || Array.isArray(item)) return null
+        var handle = root.safeText(item.handle, 320)
+        var key = root.handleKey(handle)
+        var options = root.validatedList(item.candidates, function(candidate) {
+          return root.safeCandidate(candidate)
+        }, 8)
+        if (handle === "" || seen[key] || options === null) return null
+        if (kind === "single" && (options.length !== 1 || options[0].recordCount !== 1)) return null
+        if (kind === "duplicate" && (options.length !== 1 || options[0].recordCount < 2)) return null
+        if (kind === "conflict" && options.length < 2) return null
+        seen[key] = true
+        result.push({ handle: handle, candidates: options })
+      }
+      return result
+    }
+    var singleCards = entries(value.singleCards, "single")
+    var duplicates = entries(value.duplicates, "duplicate")
+    var conflicts = entries(value.conflicts, "conflict")
+    if (singleCards === null || duplicates === null || conflicts === null
+        || noMatchCount + singleCards.length + duplicates.length + conflicts.length !== handleCount)
+      return null
+    return { handleCount: handleCount, noMatchCount: noMatchCount,
+      singleCards: singleCards, duplicates: duplicates, conflicts: conflicts }
+  }
+
+  function safeRepairPreview(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var kind = value.kind === "phone" ? "phone" : value.kind === "email" ? "email" : ""
+    var fieldCount = Number(value.fieldCount)
+    var cardNumber = Number(value.cardNumber)
+    var cardCount = Number(value.cardCount)
+    var accountNumber = Number(value.accountNumber)
+    var sourceName = safeText(value.sourceName, 120)
+    if (handle === "" || name === "" || kind === ""
+        || !Number.isInteger(fieldCount) || fieldCount < 1 || fieldCount > 8
+        || !Number.isInteger(cardNumber) || cardNumber < 1 || cardNumber > 64
+        || !Number.isInteger(cardCount) || cardCount < cardNumber || cardCount > 64
+        || !Number.isInteger(accountNumber) || accountNumber < 1 || accountNumber > 64
+        || sourceName === ""
+        || !Array.isArray(value.labels) || value.labels.length !== fieldCount) return null
+    var labels = []
+    for (var i = 0; i < value.labels.length; i++) {
+      if (typeof value.labels[i] !== "string" || value.labels[i].length > 80) return null
+      labels.push(safeText(value.labels[i], 80))
+    }
+    return {
+      handle: handle, name: name, kind: kind, fieldCount: fieldCount,
+      labels: labels, cardNumber: cardNumber, cardCount: cardCount,
+      accountNumber: accountNumber, sourceName: sourceName,
+      writeEnabled: value.writeEnabled === true,
+      token: pendingRepairToken, ownerToken: pendingOwnerToken
+    }
+  }
+
+  function safeOptionalText(value, maximum) {
+    if (typeof value !== "string" || value.length > maximum) return null
+    return value
+      .replace(/[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g, " ")
+      .replace(/\s+/g, " ").trim()
+  }
+
+  function safeLabeledValues(value) {
+    if (!Array.isArray(value) || value.length > 16) return null
+    var result = []
+    for (var i = 0; i < value.length; i++) {
+      var item = value[i]
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null
+      var label = safeOptionalText(item.label, 80)
+      var itemValue = safeOptionalText(item.value, 320)
+      if (label === null || itemValue === null || itemValue === "") return null
+      result.push({ label: label, value: itemValue })
+    }
+    return result
+  }
+
+  function safeAddresses(value) {
+    if (!Array.isArray(value) || value.length > 16) return null
+    var result = []
+    var keys = ["label", "street", "city", "state", "postalCode", "country", "countryCode"]
+    var limits = [80, 320, 320, 320, 80, 160, 8]
+    for (var i = 0; i < value.length; i++) {
+      var item = value[i]
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null
+      var address = ({})
+      for (var keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+        var cleaned = safeOptionalText(item[keys[keyIndex]], limits[keyIndex])
+        if (cleaned === null) return null
+        address[keys[keyIndex]] = cleaned
+      }
+      if (address.street === "" && address.city === "" && address.state === ""
+          && address.postalCode === "" && address.country === "") return null
+      result.push(address)
+    }
+    return result
+  }
+
+  function safeComparisonCard(value, expectedNumber, seenTokens) {
+    if (!value || typeof value !== "object" || Array.isArray(value) || !validToken(value.token)
+        || seenTokens[value.token]) return null
+    var cardNumber = Number(value.cardNumber)
+    var accountNumber = Number(value.accountNumber)
+    var sourceName = safeText(value.sourceName, 120)
+    if (!Number.isInteger(cardNumber) || cardNumber !== expectedNumber
+        || !Number.isInteger(accountNumber) || accountNumber < 1 || accountNumber > 64
+        || sourceName === "") return null
+    var scalarKeys = ["displayName", "firstName", "middleName", "lastName", "nickname",
+      "organization", "department", "jobTitle", "birthday", "note"]
+    var scalarLimits = [160, 160, 160, 160, 160, 320, 320, 320, 10, 1000]
+    if (!validRevision(value.revision)) return null
+    var card = ({ token: value.token, revision: value.revision,
+      cardNumber: cardNumber, accountNumber: accountNumber,
+      sourceName: sourceName,
+      hasPhoto: value.hasPhoto === true })
+    seenTokens[value.token] = true
+    for (var i = 0; i < scalarKeys.length; i++) {
+      var text = safeOptionalText(value[scalarKeys[i]], scalarLimits[i])
+      if (text === null) return null
+      card[scalarKeys[i]] = text
+    }
+    if (card.birthday !== "" && !/^(?:[0-9]{4}\-|--)[0-9]{2}\-[0-9]{2}$/.test(card.birthday)) return null
+    card.phones = safeLabeledValues(value.phones)
+    card.emails = safeLabeledValues(value.emails)
+    card.urls = safeLabeledValues(value.urls)
+    card.addresses = safeAddresses(value.addresses)
+    if (card.phones === null || card.emails === null || card.urls === null || card.addresses === null)
+      return null
+    return card
+  }
+
+  function safeComparison(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var cardCount = Number(value.cardCount)
+    var sourceCount = Number(value.sourceCount)
+    if (handle === "" || name === "" || !Number.isInteger(cardCount) || cardCount < 1 || cardCount > 8
+        || !Number.isInteger(sourceCount) || sourceCount < 1 || sourceCount > 8
+        || !Array.isArray(value.cards) || value.cards.length !== cardCount) return null
+    var seen = ({})
+    var accounts = ({})
+    var cards = []
+    for (var i = 0; i < value.cards.length; i++) {
+      var card = safeComparisonCard(value.cards[i], i + 1, seen)
+      if (!card) return null
+      accounts[card.accountNumber] = true
+      cards.push(card)
+    }
+    if (Object.keys(accounts).length !== sourceCount) return null
+    return { handle: handle, name: name, cardCount: cardCount, sourceCount: sourceCount,
+      writeEnabled: value.writeEnabled === true, cards: cards, ownerToken: comparisonOwnerToken,
+      otherOwnerToken: comparisonOtherOwnerToken }
+  }
+
+
+  function safeMutationPreview(value, requireApplied) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var action = ["edit", "delete", "consolidate"].indexOf(value.action) >= 0 ? value.action : ""
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var cardNumber = Number(value.cardNumber)
+    var cardCount = Number(value.cardCount)
+    var accountNumber = Number(value.accountNumber)
+    var sourceName = safeText(value.sourceName, 120)
+    var sourceCardCount = Number(value.sourceCardCount)
+    if (action === "" || handle === "" || name === "" || !validRevision(value.planHash)
+        || !Number.isInteger(cardNumber) || cardNumber < 1 || cardNumber > 8
+        || !Number.isInteger(cardCount) || cardCount < cardNumber || cardCount > 8
+        || !Number.isInteger(accountNumber) || accountNumber < 1 || accountNumber > 64
+        || sourceName === ""
+        || !Number.isInteger(sourceCardCount) || sourceCardCount < 0 || sourceCardCount > 7
+        || !Array.isArray(value.changedFields) || value.changedFields.length < 1
+        || value.changedFields.length > 13) return null
+    var changed = []
+    for (var i = 0; i < value.changedFields.length; i++) {
+      var field = safeText(value.changedFields[i], 40)
+      if (field === "") return null
+      changed.push(field)
+    }
+    if (requireApplied === true && (value.applied !== true
+        || !/^undo:[0-9a-f]{32}$/.test(String(value.undoToken || "")))) return null
+    if (requireApplied === true && action !== "delete"
+        && (!validRevision(value.revision) || safeText(value.displayName, 160) === "")) return null
+    return { action: action, handle: handle, name: name, cardNumber: cardNumber,
+      cardCount: cardCount, accountNumber: accountNumber, sourceCardCount: sourceCardCount,
+      sourceName: sourceName,
+      changedFields: changed, planHash: value.planHash, writeEnabled: value.writeEnabled === true,
+      applied: value.applied === true, undoToken: String(value.undoToken || ""),
+      revision: String(value.revision || ""), displayName: safeText(value.displayName || "", 160) }
+  }
+
+  function safeLinkPreview(value, requireLinked) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null
+    var handle = safeText(value.handle, 320)
+    var name = safeText(value.name, 160)
+    var cardCount = Number(value.cardCount)
+    var sourceCount = Number(value.sourceCount)
+    var action = safeText(value.action, 80)
+    if (handle === "" || name === "" || !Number.isInteger(cardCount) || cardCount < 2 || cardCount > 8
+        || !Number.isInteger(sourceCount) || sourceCount < 1 || sourceCount > 8
+        || ["Link Selected Cards", "Merge Selected Cards", "Merge and Link Selected Cards"].indexOf(action) < 0)
+      return null
+    if (requireLinked === true && value.linked !== true) return null
+    if (requireLinked !== true && typeof value.ready !== "boolean") return null
+    return { handle: handle, name: name, cardCount: cardCount, sourceCount: sourceCount,
+      writeEnabled: value.writeEnabled === true, action: action,
+      ready: requireLinked === true ? false : value.ready, linked: value.linked === true }
+  }
+
+  function validatedList(value, validator, maximum) {
+    if (!Array.isArray(value) || value.length > maximum) return null
+    var result = []
+    for (var i = 0; i < value.length; i++) {
+      var item = validator(value[i])
+      if (!item) return null
+      result.push(item)
+    }
+    return result
+  }
+
+  function start(operation, payload, quiet) {
+    if (worker.running) return false
+    error = ""
+    currentOperation = operation
+    if (operation === "vcard") vcardReported = false
+    reloadAfterExit = false
+    refreshCandidatesAfterExit = false
+    // A periodic read is bookkeeping, not a visible operation. Toggling
+    // `loading` here used to disable and repaint every contact row at 5 s.
+    loading = quiet !== true
+    worker.payload = payload === undefined ? "" : JSON.stringify(payload)
+    worker.stdinEnabled = worker.payload !== ""
+    worker.command = ["bun", helperPath, operation]
+    worker.running = true
+    return true
+  }
+
+  function load(silent) {
+    readSilently = silent === true
+    return start("read", undefined, readSilently && loaded)
+  }
+
+  function findCandidates(handle) {
+    var requested = safeText(String(handle || ""), 320)
+    if (requested === "") return false
+    // A click that lands during the tiny local-file refresh window must not
+    // be lost. Finish that read, then begin the user-visible Mac lookup.
+    if (worker.running) {
+      if (currentOperation === "read" && readSilently) {
+        pendingReviewHandle = requested
+        return true
+      }
+      return false
+    }
+    activeHandle = requested
+    candidates = []
+    repairPreview = null
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+    pendingRepairToken = ""
+    pendingOwnerToken = ""
+    notice = "Checking matching cards on the Mac…"
+    return start("candidates", { handle: activeHandle }, false)
+  }
+
+  // quiet = an automatic freshness re-scan after a contact mutation: it must
+  // not clobber the mutation's own success notice. Previous results stay
+  // visible (stale) while the fresh scan runs; auditRunning drives the UI's
+  // in-progress state.
+  function auditContacts(handles, quiet) {
+    if (auditWorker.running) return false
+    if (!Array.isArray(handles) || handles.length < 1 || handles.length > 200) return false
+    var accepted = []
+    var seen = ({})
+    for (var i = 0; i < handles.length; i++) {
+      var handle = safeText(handles[i], 320)
+      var key = handleKey(handle)
+      if (handle === "" || seen[key]) return false
+      seen[key] = true
+      accepted.push(handle)
+    }
+    quietAudit = quiet === true
+    pendingAuditCount = accepted.length
+    pendingAuditFingerprint = JSON.stringify(Object.keys(seen).sort())
+    if (!quietAudit) notice = "Scanning matching Contacts cards; nothing will be changed…"
+    auditWorker.payload = JSON.stringify({ handles: accepted })
+    auditWorker.stdinEnabled = true
+    auditWorker.command = ["bun", helperPath, "audit"]
+    auditRunning = true
+    auditWorker.running = true
+    return true
+  }
+
+  function consumeAudit(text) {
+    auditRunning = false
+    var result = null
+    try { result = JSON.parse(text) } catch (e) { result = null }
+    var audited = result && result.ok === true ? safeAudit(result.audit) : null
+    if (!audited) {
+      if (!quietAudit) error = "Identity helper returned an invalid contact audit"
+      return
+    }
+    audit = audited
+    auditFingerprint = pendingAuditFingerprint
+    if (!quietAudit) notice = result.cached === true
+      ? "Cleanup results are current — Contacts hasn't changed since the last scan"
+      : "Contact cleanup scan finished; nothing was changed"
+  }
+
+  function clearAudit() {
+    if (auditWorker.running) return false
+    audit = null
+    pendingAuditCount = 0
+    pendingAuditFingerprint = ""
+    auditFingerprint = ""
+    return true
+  }
+
+  function dismissReview() {
+    if (worker.running) return false
+    activeHandle = ""
+    candidates = []
+    repairPreview = null
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+    pendingRepairToken = ""
+    pendingOwnerToken = ""
+    error = ""
+    notice = ""
+    return true
+  }
+
+  function openOnMac(handle, token) {
+    notice = "Opening one Contacts card on the Mac; no data will be changed…"
+    return start("open", { handle: handle, token: token })
+  }
+
+  function copyVCard(handle) {
+    notice = "Exporting the contact from the Mac…"
+    return start("vcard", { handle: handle })
+  }
+
+  function reportVCard(message, success) {
+    if (currentOperation !== "vcard" || vcardReported) return
+    vcardReported = true
+    vcardFinished(message, success === true)
+  }
+
+  function startVcardClipboard() {
+    if (pendingVcardPayload === "") return
+    vcardClipboard.payload = pendingVcardPayload
+    vcardClipboard.fileName = pendingVcardFileName
+    vcardClipboardPending = true
+    vcardClipboard.stdinEnabled = true
+    vcardClipboard.running = true
+  }
+
+  function serveVCard(fileUri, fileName) {
+    pendingVcardPayload = "copy\n" + fileUri + "\n"
+    pendingVcardFileName = fileName
+    vcardClipboardPending = true
+    if (vcardClipboard.running) {
+      vcardClipboard.replacing = true
+      vcardClipboard.running = false
+    } else {
+      startVcardClipboard()
+    }
+  }
+
+  function compareCards(handle, ownerToken, otherOwnerToken) {
+    if (!validToken(ownerToken)) return false
+    var cross = otherOwnerToken !== undefined && otherOwnerToken !== null
+      && String(otherOwnerToken) !== ""
+    if (cross && (!validToken(otherOwnerToken) || otherOwnerToken === ownerToken)) return false
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ownerToken
+    comparisonOtherOwnerToken = cross ? String(otherOwnerToken) : ""
+    notice = cross
+      ? "Loading both people's card details from Contacts…"
+      : "Loading the active card details from Contacts…"
+    var payload = ({ handle: handle, ownerToken: ownerToken })
+    if (cross) payload.otherOwnerToken = String(otherOwnerToken)
+    return start("compare", payload)
+  }
+
+  function prepareCardEdit(card, draft) {
+    if (!contactWrites || !comparison || !card || !validToken(card.token)
+        || !validRevision(card.revision) || !validToken(comparison.ownerToken)
+        || String(comparison.otherOwnerToken || "") !== "") return false
+    mutationPreview = null
+    mutationRequest = { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      token: card.token, revision: card.revision, card: draft }
+    notice = "Verifying this contact edit on the Mac…"
+    return start("edit-prepare", mutationRequest)
+  }
+
+  function prepareCardDelete(card) {
+    if (!contactWrites || !comparison || !card || !validToken(card.token)
+        || !validRevision(card.revision) || !validToken(comparison.ownerToken)
+        || String(comparison.otherOwnerToken || "") !== "") return false
+    mutationPreview = null
+    mutationRequest = { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      token: card.token, revision: card.revision }
+    notice = "Verifying this source-card deletion on the Mac…"
+    return start("delete-prepare", mutationRequest)
+  }
+
+  function prepareConsolidation(targetCard, draft) {
+    if (!contactWrites || !comparison || comparison.cards.length < 2 || !targetCard
+        || !validToken(targetCard.token) || !validToken(comparison.ownerToken)) return false
+    var revisions = []
+    for (var i = 0; i < comparison.cards.length; i++) {
+      var card = comparison.cards[i]
+      if (!validToken(card.token) || !validRevision(card.revision)) return false
+      revisions.push({ token: card.token, revision: card.revision })
+    }
+    mutationPreview = null
+    mutationRequest = { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      targetToken: targetCard.token, revisions: revisions, card: draft }
+    if (String(comparison.otherOwnerToken || "") !== "")
+      mutationRequest.otherOwnerToken = comparison.otherOwnerToken
+    notice = "Verifying the merged card and every source card on the Mac…"
+    return start("merge-prepare", mutationRequest)
+  }
+
+  function applyMutation() {
+    if (!contactWrites || !mutationPreview || !mutationPreview.writeEnabled || !mutationRequest
+        || !validRevision(mutationPreview.planHash)) return false
+    var operation = mutationPreview.action === "edit" ? "edit"
+      : mutationPreview.action === "delete" ? "delete" : "merge"
+    var request = ({})
+    var keys = Object.keys(mutationRequest)
+    for (var i = 0; i < keys.length; i++) request[keys[i]] = mutationRequest[keys[i]]
+    request.planHash = mutationPreview.planHash
+    notice = operation === "edit" ? "Saving the verified contact edit…"
+      : operation === "delete" ? "Deleting the verified source card…"
+      : "Consolidating the verified source cards…"
+    return start(operation, request)
+  }
+
+  function cancelMutation() {
+    if (worker.running) return false
+    mutationPreview = null
+    mutationRequest = null
+    notice = "No Contacts data was changed"
+    return true
+  }
+
+  function discardUnsavedContacts() {
+    if (!contactWrites) return false
+    notice = "Closing Contacts on the Mac without saving its pending edit…"
+    return start("discard-unsaved", {})
+  }
+
+  function prepareLink() {
+    if (!contactWrites || !comparison || !comparison.writeEnabled
+        || !validToken(comparison.ownerToken)) return false
+    linkPreview = null
+    notice = "Selecting the exact cards and checking Apple’s link action…"
+    return start("link-prepare", {
+      handle: comparison.handle, ownerToken: comparison.ownerToken
+    })
+  }
+
+  function linkCards() {
+    if (!contactWrites || !comparison || !linkPreview || !linkPreview.ready
+        || !linkPreview.writeEnabled || !validToken(comparison.ownerToken)) return false
+    notice = "Running Contacts’ verified “" + linkPreview.action + "” action…"
+    return start("link", { handle: comparison.handle, ownerToken: comparison.ownerToken,
+      expectedAction: linkPreview.action })
+  }
+
+  function cancelLink() {
+    if (worker.running) return false
+    linkPreview = null
+    notice = "No Contacts data was changed"
+    return true
+  }
+
+  function cancelComparison() {
+    if (worker.running) return false
+    comparison = null
+    linkPreview = null
+    mutationPreview = null
+    mutationRequest = null
+    comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+    notice = candidates.length > 1 ? "Contacts has conflicting names" : "Contacts has one matching name"
+    return true
+  }
+
+  function inspectOnMac(handle, token, ownerToken) {
+    if (!contactWrites || !validToken(token) || !validToken(ownerToken) || token === ownerToken)
+      return false
+    pendingRepairToken = token
+    pendingOwnerToken = ownerToken
+    repairPreview = null
+    notice = "Verifying the exact field with Contacts on the Mac…"
+    return start("inspect", { handle: handle, token: token, ownerToken: ownerToken })
+  }
+
+  function cancelRepair() {
+    if (worker.running) return false
+    repairPreview = null
+    pendingRepairToken = ""
+    pendingOwnerToken = ""
+    notice = candidates.length > 1 ? "Contacts has conflicting names" : "Contacts has one matching name"
+    return true
+  }
+
+  function removeOnMac() {
+    if (!contactWrites || !repairPreview || !repairPreview.writeEnabled
+        || !validToken(repairPreview.token)
+        || !validToken(repairPreview.ownerToken)) return false
+    notice = "Removing the verified field from Mac Contacts…"
+    return start("remove", {
+      handle: repairPreview.handle, token: repairPreview.token,
+      ownerToken: repairPreview.ownerToken
+    })
+  }
+
+  function undoOnMac() {
+    if (!contactWrites || !/^undo:[0-9a-f]{32}$/.test(undoToken)) return false
+    notice = "Undoing the last Blip contact change…"
+    return start("undo", { undoToken: undoToken })
+  }
+
+  function consume(raw) {
+    if (raw.length > 49152) {
+      error = "Identity helper returned too much data"
+      reportVCard(error, false)
+      return
+    }
+    var result
+    try { result = JSON.parse(raw.trim()) }
+    catch (e) {
+      error = "Identity helper returned invalid JSON"
+      reportVCard(error, false)
+      return
+    }
+    if (!result || result.ok !== true) {
+      error = safeError(result ? result.error : "Identity helper failed")
+      reportVCard(error, false)
+      return
+    }
+    if (currentOperation === "read") {
+      contactWrites = result.contactWrites === true
+      loaded = true
+      if (!readSilently) notice = ""
+      return
+    }
+    if (currentOperation === "candidates") {
+      var options = validatedList(result.candidates, function(value) { return root.safeCandidate(value) }, 8)
+      var handle = safeText(result.handle, 320)
+      if (options === null || handle === "") {
+        error = "Identity helper returned an invalid candidate list"
+        return
+      }
+      var totalCards = 0
+      var allTokens = ({})
+      for (var candidateIndex = 0; candidateIndex < options.length; candidateIndex++) {
+        var option = options[candidateIndex]
+        if (allTokens[option.token]) { error = "Identity helper returned duplicate contact tokens"; return }
+        allTokens[option.token] = true
+        totalCards += option.cards.length
+        for (var cardIndex = 0; cardIndex < option.cards.length; cardIndex++) {
+          var cardToken = option.cards[cardIndex].token
+          if (allTokens[cardToken]) { error = "Identity helper returned duplicate contact tokens"; return }
+          allTokens[cardToken] = true
+        }
+      }
+      if (totalCards > 64) { error = "Identity helper returned too many contact cards"; return }
+      activeHandle = handle
+      candidates = options
+      notice = options.length === 0
+        ? "No matching contact cards were found"
+        : options.length === 1 ? "Contacts has one matching name" : "Contacts has conflicting names"
+      return
+    }
+    if (currentOperation === "vcard") {
+      var copiedName = safeText(result.name, 160)
+      var copiedHandle = safeText(result.handle, 320)
+      var copiedFileName = safeText(result.fileName, 160)
+      var copiedFileUri = safeText(result.fileUri, 700)
+      var copiedBytes = Number(result.bytes)
+      if (copiedName === "" || copiedHandle === "" || !Number.isInteger(copiedBytes)
+          || copiedBytes < 1 || copiedBytes > 2097152
+          || copiedFileName === "" || !copiedFileName.endsWith(".vcf")
+          || root.runtimeDirectory === ""
+          || !copiedFileUri.startsWith(root.vcardUriPrefix)
+          || copiedFileUri.indexOf("..") >= 0 || !copiedFileUri.endsWith(".vcf")) {
+        error = "Contacts returned an invalid vCard confirmation"
+        reportVCard(error, false)
+        return
+      }
+      // Keep wl-copy alive inside the shell process. A short-lived helper can
+      // write the .vcf, but if it owns the Wayland selection and then exits,
+      // the clipboard immediately becomes empty.
+      serveVCard(copiedFileUri, copiedFileName)
+      return
+    }
+    if (currentOperation === "discard-unsaved") {
+      if (typeof result.discarded !== "boolean") {
+        error = "Contacts returned an invalid unsaved-change confirmation"
+        return
+      }
+      notice = result.discarded
+        ? "Discarded the pending Contacts edit and closed Contacts on the Mac"
+        : "Contacts had no pending edit to discard"
+      return
+    }
+    if (currentOperation === "open") {
+      var openedName = safeText(result.name, 160)
+      var openedCard = Number(result.cardNumber)
+      var openedCount = Number(result.cardCount)
+      var openedAccount = Number(result.accountNumber)
+      var openedSource = safeText(result.sourceName, 120)
+      if (result.opened !== true || openedName === ""
+          || !Number.isInteger(openedCard) || openedCard < 1 || openedCard > 64
+          || !Number.isInteger(openedCount) || openedCount < 1 || openedCount > 64
+          || openedCard > openedCount
+          || !Number.isInteger(openedAccount) || openedAccount < 1 || openedAccount > 64
+          || openedSource === "") {
+        error = "Contacts.app did not open the selected card"
+        return
+      }
+      notice = "Opened “" + openedName + "” card " + openedCard + " of " + openedCount
+        + " from " + openedSource + " in Contacts on the Mac. Nothing was changed."
+      return
+    }
+    if (currentOperation === "compare") {
+      var compared = safeComparison(result.comparison)
+      if (!compared || !validToken(compared.ownerToken)) {
+        error = "Contacts returned an invalid card comparison"
+        return
+      }
+      comparison = compared
+      linkPreview = null
+      notice = "Loaded " + compared.cardCount + " active cards for comparison; nothing was changed"
+      return
+    }
+    if (currentOperation === "edit-prepare" || currentOperation === "delete-prepare"
+        || currentOperation === "merge-prepare") {
+      var mutation = safeMutationPreview(result.preview, false)
+      var expectedAction = currentOperation === "edit-prepare" ? "edit"
+        : currentOperation === "delete-prepare" ? "delete" : "consolidate"
+      if (!mutation || mutation.action !== expectedAction || !comparison
+          || mutation.handle !== comparison.handle) {
+        error = "Contacts returned an invalid contact-change preview"
+        return
+      }
+      mutationPreview = mutation
+      notice = "Verified the exact Mac Contacts change; review the confirmation"
+      return
+    }
+    if (currentOperation === "edit" || currentOperation === "delete"
+        || currentOperation === "merge") {
+      var appliedMutation = safeMutationPreview(result, true)
+      var appliedAction = currentOperation === "edit" ? "edit"
+        : currentOperation === "delete" ? "delete" : "consolidate"
+      if (!appliedMutation || appliedMutation.action !== appliedAction) {
+        error = "Contacts did not confirm the contact change"
+        return
+      }
+      undoToken = appliedMutation.undoToken
+      undoHandle = appliedMutation.handle
+      undoName = appliedMutation.name
+      undoFieldCount = appliedMutation.changedFields.length
+      undoAction = appliedMutation.action
+      undoCardCount = appliedMutation.action === "consolidate"
+        ? appliedMutation.sourceCardCount + 1 : 1
+      mutationPreview = null
+      mutationRequest = null
+      comparison = null
+      linkPreview = null
+      comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+      notice = appliedMutation.action === "edit"
+        ? "Saved the contact card in Mac Contacts"
+        : appliedMutation.action === "delete"
+          ? "Deleted the source card from Mac Contacts"
+          : "Consolidated " + undoCardCount + " source cards in Mac Contacts"
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+      return
+    }
+    if (currentOperation === "link-prepare") {
+      var prepared = safeLinkPreview(result.preview, false)
+      if (!prepared || !comparison || prepared.handle !== comparison.handle
+          || prepared.cardCount !== comparison.cardCount) {
+        error = "Contacts returned an invalid link preview"
+        return
+      }
+      linkPreview = prepared
+      notice = prepared.ready
+        ? "Contacts is ready; review the final link confirmation"
+        : "Contacts does not offer a link for this exact selection; the cards may already be linked"
+      return
+    }
+    if (currentOperation === "link") {
+      var linked = safeLinkPreview(result, true)
+      if (!linked || !comparison || linked.handle !== comparison.handle
+          || linked.cardCount !== comparison.cardCount) {
+        error = "Contacts did not confirm the link action"
+        return
+      }
+      notice = "Contacts ran “" + linked.action + "” for the exact " + linked.cardCount + " cards"
+      comparison = null
+      linkPreview = null
+      comparisonOwnerToken = ""
+    comparisonOtherOwnerToken = ""
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+      return
+    }
+    if (currentOperation === "inspect") {
+      var preview = safeRepairPreview(result.preview)
+      if (!preview || !validToken(preview.token)) {
+        error = "Contacts returned an invalid repair preview"
+        return
+      }
+      repairPreview = preview
+      notice = preview.writeEnabled
+        ? "Verified the exact Mac Contacts field; review the confirmation below"
+        : "The Mac-side contact-writes gate is disabled"
+      return
+    }
+    if (currentOperation === "remove") {
+      var removedPreview = safeRepairPreview(result)
+      var returnedUndo = safeText(result.undoToken, 40)
+      if (!removedPreview || result.removed !== true || !/^undo:[0-9a-f]{32}$/.test(returnedUndo)) {
+        error = "Contacts did not confirm the removal"
+        return
+      }
+      undoToken = returnedUndo
+      undoHandle = removedPreview.handle
+      undoName = removedPreview.name
+      undoFieldCount = removedPreview.fieldCount
+      undoAction = "field-removal"
+      undoCardCount = 1
+      repairPreview = null
+      pendingRepairToken = ""
+      pendingOwnerToken = ""
+      notice = "Removed the verified " + removedPreview.kind + " from “" + removedPreview.name + "” on the Mac"
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+      return
+    }
+    if (currentOperation === "undo") {
+      var restoredHandle = safeText(result.handle, 320)
+      var restoredName = safeText(result.name, 160)
+      var restoredCount = Number(result.fieldCount)
+      var restoredCards = Number(result.cardCount)
+      var restoredAction = ["field-removal", "edit", "delete", "consolidate"].indexOf(result.action) >= 0
+        ? result.action : ""
+      if (result.restored !== true || restoredHandle === "" || restoredName === ""
+          || restoredAction === ""
+          || !Number.isInteger(restoredCards) || restoredCards < 1 || restoredCards > 8
+          || !Number.isInteger(restoredCount) || restoredCount < 1 || restoredCount > 13) {
+        error = "Contacts did not confirm the restore"
+        return
+      }
+      undoToken = ""
+      undoHandle = ""
+      undoName = ""
+      undoFieldCount = 0
+      undoAction = ""
+      undoCardCount = 0
+      notice = result.alreadyPresent === true
+        ? "The field was already present in Mac Contacts"
+        : restoredAction === "delete" ? "Recreated the deleted card for “" + restoredName + "”"
+          : restoredAction === "consolidate" ? "Restored " + restoredCards + " pre-merge cards"
+            : "Undid the contact change for “" + restoredName + "”"
+      refreshCandidatesAfterExit = true
+      contactsMutated()
+    }
+  }
+
+  Process {
+    id: worker
+    property string payload: ""
+    stdout: StdioCollector { onStreamFinished: root.consume(text) }
+    onStarted: {
+      if (payload !== "") write(payload)
+      stdinEnabled = false
+    }
+    onExited: function(code, status) {
+      root.loading = false
+      if (code !== 0 && root.error === "") root.error = "Contact operation failed"
+      if (root.currentOperation === "vcard" && !root.vcardReported
+          && !root.vcardClipboardPending)
+        root.reportVCard(root.error || "Could not copy the contact vCard", false)
+      if (root.pendingReviewHandle !== "") {
+        var requested = root.pendingReviewHandle
+        root.pendingReviewHandle = ""
+        Qt.callLater(function() { root.findCandidates(requested) })
+        return
+      }
+      if (root.refreshCandidatesAfterExit) {
+        root.refreshCandidatesAfterExit = false
+        var active = root.activeHandle
+        if (active !== "") Qt.callLater(function() { root.findCandidates(active) })
+        return
+      }
+      if (root.reloadAfterExit) {
+        root.reloadAfterExit = false
+        Qt.callLater(function() { root.load(true) })
+      }
+    }
+  }
+
+  Process {
+    id: auditWorker
+    property string payload: ""
+    stdout: StdioCollector { onStreamFinished: root.consumeAudit(text) }
+    onStarted: {
+      if (payload !== "") write(payload)
+      stdinEnabled = false
+    }
+    onExited: function(code, status) {
+      root.auditRunning = false
+    }
+  }
+
+  Process {
+    id: vcardClipboard
+    property string payload: ""
+    property string fileName: ""
+    property bool replacing: false
+    command: ["wl-copy", "--foreground", "--type", "x-special/gnome-copied-files"]
+    onStarted: {
+      write(payload)
+      stdinEnabled = false
+      root.vcardClipboardPending = false
+      root.pendingVcardPayload = ""
+      root.pendingVcardFileName = ""
+      root.notice = "Copied “" + fileName + "” — paste it as a vCard file"
+      root.reportVCard(root.notice, true)
+    }
+    onExited: function(code, status) {
+      if (replacing) {
+        replacing = false
+        Qt.callLater(root.startVcardClipboard)
+        return
+      }
+      if (root.vcardClipboardPending && !root.vcardReported) {
+        root.vcardClipboardPending = false
+        root.reportVCard("Could not keep the vCard on the clipboard", false)
+      }
+    }
+  }
+
+  Timer {
+    interval: 5000
+    repeat: true
+    running: true
+    // Source repair is deliberate and stable while open. Only poll the local
+    // bridge configuration from the overview, and never overlap another operation.
+    onTriggered: if (!worker.running && root.activeHandle === "") root.load(true)
+  }
+
+  Component.onCompleted: load(false)
+}

--- a/ContactOperations.qml
+++ b/ContactOperations.qml
@@ -16,6 +16,8 @@ Item {
   readonly property string helperPath:
     decodeURIComponent(Qt.resolvedUrl("contact-management.ts").toString().replace(/^file:\/\//, ""))
 
+  property string initialToken: ""
+  signal initialContactReady(string token)
   property var candidates: []
   property var audit: null
   property var repairPreview: null
@@ -399,13 +401,14 @@ Item {
     // A click that lands during the tiny local-file refresh window must not
     // be lost. Finish that read, then begin the user-visible Mac lookup.
     if (worker.running) {
-      if (currentOperation === "read" && readSilently) {
+      if (currentOperation === "read") {
         pendingReviewHandle = requested
         return true
       }
       return false
     }
     activeHandle = requested
+    initialToken = ""
     candidates = []
     repairPreview = null
     comparison = null
@@ -476,6 +479,7 @@ Item {
   function dismissReview() {
     if (worker.running) return false
     activeHandle = ""
+    initialToken = ""
     candidates = []
     repairPreview = null
     comparison = null
@@ -736,6 +740,8 @@ Item {
       if (totalCards > 64) { error = "Identity helper returned too many contact cards"; return }
       activeHandle = handle
       candidates = options
+      initialToken = validToken(result.initialToken) && options.length === 1
+        && options[0].token === result.initialToken ? result.initialToken : ""
       notice = options.length === 0
         ? "No matching contact cards were found"
         : options.length === 1 ? "Contacts has one matching name" : "Contacts has conflicting names"
@@ -964,6 +970,12 @@ Item {
         root.refreshCandidatesAfterExit = false
         var active = root.activeHandle
         if (active !== "") Qt.callLater(function() { root.findCandidates(active) })
+        return
+      }
+      if (root.initialToken !== "" && root.error === "") {
+        var token = root.initialToken
+        root.initialToken = ""
+        Qt.callLater(function() { root.initialContactReady(token) })
         return
       }
       if (root.reloadAfterExit) {

--- a/ContactReview.qml
+++ b/ContactReview.qml
@@ -24,6 +24,7 @@ FocusScope {
   visible: opened
   readonly property string helper: decodeURIComponent(Qt.resolvedUrl("contact-review.ts").toString().replace(/^file:\/\//, ""))
   signal closed()
+  property bool detached: false
   signal manageRequested(string handle)
 
   function close() { opened = false; closed() }
@@ -140,9 +141,12 @@ FocusScope {
       color: root.error !== "" ? Color.urgent : root.foreground
       font.family: root.fontFamily; font.pixelSize: root.fontSize
     }
-    QQC.Button {
+    ContactButton {
+      Layout.fillWidth: true
+      foreground: root.foreground; accent: root.accent
+      fontFamily: root.fontFamily; fontSize: root.fontSize
       visible: root.model !== null && root.model.view === "cards"
-      text: "Manage contact…"
+      text: root.detached ? "Manage contact…" : "Manage contact ↗"
       enabled: !root.busy
       onClicked: root.manageRequested(root.model.detail)
     }

--- a/ContactReview.qml
+++ b/ContactReview.qml
@@ -24,6 +24,7 @@ FocusScope {
   visible: opened
   readonly property string helper: decodeURIComponent(Qt.resolvedUrl("contact-review.ts").toString().replace(/^file:\/\//, ""))
   signal closed()
+  signal manageRequested(string handle)
 
   function close() { opened = false; closed() }
   function textField(value, maximum) { return typeof value === "string" ? value.slice(0, maximum) : "" }
@@ -138,6 +139,12 @@ FocusScope {
       textFormat: Text.PlainText; wrapMode: Text.WordWrap
       color: root.error !== "" ? Color.urgent : root.foreground
       font.family: root.fontFamily; font.pixelSize: root.fontSize
+    }
+    QQC.Button {
+      visible: root.model !== null && root.model.view === "cards"
+      text: "Manage contact…"
+      enabled: !root.busy
+      onClicked: root.manageRequested(root.model.detail)
     }
     PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
     Flickable {

--- a/ContactWorkspace.qml
+++ b/ContactWorkspace.qml
@@ -24,6 +24,7 @@ FocusScope {
   Keys.onEscapePressed: close()
   ContactOperations {
     id: operations
+    objectName: "blipContactOperations"
     onContactsMutated: root.contactsMutated()
   }
   ColumnLayout {

--- a/ContactWorkspace.qml
+++ b/ContactWorkspace.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// Session-only contact workspace; native writes keep their own previews and gates.
+FocusScope {
+  id: root
+  property bool opened: false
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color accent: "#0a84ff"
+  property string fontFamily: Style.font.family
+  property real fontScale: 1.0
+  visible: opened
+  signal closed()
+  signal contactsMutated()
+  function review(handle) {
+    if (operations.loading) return
+    if (operations.findCandidates(handle)) { opened = true; forceActiveFocus() }
+  }
+  function close() { if (!operations.loading) { opened = false; operations.dismissReview(); closed() } }
+  Keys.onEscapePressed: close()
+  ContactOperations {
+    id: operations
+    onContactsMutated: root.contactsMutated()
+  }
+  ColumnLayout {
+    anchors.fill: parent
+    spacing: Style.space(10)
+    RowLayout {
+      Layout.fillWidth: true
+      PanelActionButton {
+        iconText: "←"; tooltipText: "Back to contact review"
+        enabled: !operations.loading
+        foreground: root.foreground; hoverColor: root.accent
+        onClicked: root.close()
+      }
+      Text {
+        Layout.fillWidth: true
+        text: "Manage contact"; textFormat: Text.PlainText
+        color: root.foreground; font.family: root.fontFamily
+        font.pixelSize: Math.round(Style.font.body * root.fontScale)
+      }
+      QQC.Button {
+        text: "Copy vCard"; enabled: !operations.loading
+        onClicked: operations.copyVCard(operations.activeHandle)
+      }
+    }
+    Text {
+      Layout.fillWidth: true
+      text: operations.activeHandle; textFormat: Text.PlainText
+      color: root.foreground; font.family: root.fontFamily
+      font.pixelSize: Math.round(Style.font.caption * root.fontScale)
+    }
+    Flickable {
+      Layout.fillWidth: true; Layout.fillHeight: true
+      contentWidth: width; contentHeight: management.implicitHeight
+      clip: true; boundsBehavior: Flickable.StopAtBounds
+      QQC.ScrollBar.vertical: QQC.ScrollBar { }
+      ContactManagement {
+        id: management
+        width: parent.width
+        resolver: operations
+        foreground: root.foreground; urgent: root.urgent; accent: root.accent
+        fontFamily: root.fontFamily; fontScale: root.fontScale
+        onCloseRequested: root.close()
+      }
+    }
+  }
+}

--- a/ContactWorkspace.qml
+++ b/ContactWorkspace.qml
@@ -17,8 +17,10 @@ FocusScope {
   signal closed()
   signal contactsMutated()
   function review(handle) {
-    if (operations.loading) return
-    if (operations.findCandidates(handle)) { opened = true; forceActiveFocus() }
+    if (opened) return operations.activeHandle === handle
+    if (!operations.findCandidates(handle)) return false
+    opened = true; forceActiveFocus()
+    return true
   }
   function close() { if (!operations.loading) { opened = false; operations.dismissReview(); closed() } }
   Keys.onEscapePressed: close()
@@ -26,6 +28,7 @@ FocusScope {
     id: operations
     objectName: "blipContactOperations"
     onContactsMutated: root.contactsMutated()
+    onInitialContactReady: function(token) { if (root.opened) management.selectCandidate(management.candidateForToken(token)) }
   }
   ColumnLayout {
     anchors.fill: parent
@@ -33,7 +36,7 @@ FocusScope {
     RowLayout {
       Layout.fillWidth: true
       PanelActionButton {
-        iconText: "←"; tooltipText: "Back to contact review"
+        iconText: "←"; tooltipText: "Back"; focusable: true
         enabled: !operations.loading
         foreground: root.foreground; hoverColor: root.accent
         onClicked: root.close()
@@ -44,7 +47,10 @@ FocusScope {
         color: root.foreground; font.family: root.fontFamily
         font.pixelSize: Math.round(Style.font.body * root.fontScale)
       }
-      QQC.Button {
+      ContactButton {
+        foreground: root.foreground; accent: root.accent
+        fontFamily: root.fontFamily
+        fontSize: Math.round(Style.font.bodySmall * root.fontScale)
         text: "Copy vCard"; enabled: !operations.loading
         onClicked: operations.copyVCard(operations.activeHandle)
       }

--- a/README.md
+++ b/README.md
@@ -525,6 +525,57 @@ Contacts fingerprint still match. The feature adds no settings page or display
 name overrides. Configuration stays in `bridge.conf`. Review requires no Swift
 helper; the optional availability check needs Automation → Contacts on the Mac.
 
+## Contact management (draft)
+
+From Contact review, choose **Manage contact…** to compare, edit, consolidate,
+delete, or link matching source cards. Selecting a person is temporary.
+**Copy vCard** exports a contact file for pasting into a conversation.
+
+The optional compiled helper requires Swift Command Line Tools on the Mac;
+installation skips it when unavailable. To opt into writes explicitly, run
+`BLIP_CONTACT_WRITES=on scripts/blip-setup`. This sets `contact_writes=on` in
+`bridge.conf` and installs the independent owner-only Mac write gate.
+
+Each source card now has an **Edit in Blip…** workspace for names, organization
+and job fields, birthday, notes, labeled phone numbers, email addresses,
+websites, and postal addresses. Edits and whole-card deletions are first shown
+as a read-only change preview. The Mac bridge then re-resolves the opaque card
+token and requires the card's content revision to be unchanged before it
+saves. The card photo is retained on edit but is not editable in Blip.
+
+For duplicates, choose **Merge into card N…** to build an editable combined
+card. The selected card and its account remain authoritative; its scalar
+choices win, blanks are filled from the other cards, and unique collection
+values are combined. After a destructive confirmation, Blip batches the target
+update and same-account source-card deletions in one save through Apple's
+current Contacts framework. When source cards cross account stores, Blip first
+saves the complete surviving card and then deletes sources in account-scoped
+requests; this avoids Contacts' unsupported cross-store save while keeping the
+merged data safe before any source is removed. This deterministic path does not
+depend on Apple's menu item being enabled.
+
+From that comparison Blip can ask Contacts to select the exact cards and report
+Apple's currently enabled **Link Selected Cards** or **Merge Selected Cards**
+action. Nothing happens until a second confirmation names that exact action.
+The action is pinned through the SSH bridge and refused if it changes before
+the click. It changes Contacts and may sync upstream; unlike the narrow
+phone/email repair below, Blip cannot provide an automatic unlink receipt.
+This handoff needs Automation → Contacts and Accessibility for
+`/usr/libexec/sshd-keygen-wrapper` on the Mac.
+
+For a handle attached to the wrong person, Blip can also inspect the exact
+card, show a destructive confirmation, remove only that verified phone/email
+through Contacts.app, and offer an immediate undo; its private receipt expires
+after seven days. Edits, deletions, consolidations, and narrow field removals
+all require `contact_writes=on` plus the
+separate owner-only Mac gate. Whole-card deletion uses Apple's public Contacts
+framework. Blip never writes the private Contacts SQLite database or deletes a
+possibly shared number without confirmation. Edit undo
+restores the exact card fields if the card has not changed again. Delete and
+consolidation undo can recreate the text fields as new cards, but Contacts does
+not expose a supported way to restore their original synced-account placement,
+links, or photos; the confirmation says this explicitly.
+
 ## Keyboard
 
 | where | key | does |

--- a/README.md
+++ b/README.md
@@ -527,7 +527,12 @@ helper; the optional availability check needs Automation → Contacts on the Mac
 
 ## Contact management (draft)
 
-From Contact review, choose **Manage contact…** to compare, edit, consolidate,
+Quick review stays in the menubar. Management uses the resizable window; one
+matching person opens directly to their cards, while conflicting matches ask
+you to choose. A single card shows its details without comparison controls.
+
+From Contact review, choose **Manage contact ↗** to open the selected contact
+in the detached Blip window and compare, edit, consolidate,
 delete, or link matching source cards. Selecting a person is temporary.
 **Copy vCard** exports a contact file for pasting into a conversation.
 

--- a/bridge/BRIDGE-VERSION
+++ b/bridge/BRIDGE-VERSION
@@ -3,3 +3,4 @@ vendored: imsg imsg-send contacts tcc-check
 blip-only (NOT upstream): imsg-read blip-check blip-dispatch
 blip extensions: Messages pin order; bounded read-only contact review, store-fingerprint audit, and card availability check
 sync: scripts/sync-bridge.sh <sha-or-tag>
+blip draft extensions: gated card compare/edit/delete/consolidation, link handoff, undo, and vCard export

--- a/bridge/mac/contact-delete.swift
+++ b/bridge/mac/contact-delete.swift
@@ -1,0 +1,670 @@
+#!/usr/bin/env swift
+import Contacts
+import Foundation
+
+private let maxInputBytes = 48 * 1024
+private let maxPersonIds = 7
+private let maxValues = 16
+private let maxNameHandles = 128
+private let maxVCardBytes = 2 * 1024 * 1024
+private let maxVCardResponseBytes = 3 * 1024 * 1024
+private let allowedId = try! NSRegularExpression(pattern: "^[A-Za-z0-9._:-]{1,200}$")
+private let forbiddenDirectionals = Set<UInt32>(
+    Array(0x202A...0x202E) + Array(0x2066...0x2069)
+)
+
+private struct LabeledValue: Decodable {
+    let label: String
+    let value: String
+}
+
+private struct PostalAddress: Decodable {
+    let label: String
+    let street: String
+    let city: String
+    let state: String
+    let postalCode: String
+    let country: String
+    let countryCode: String
+}
+
+private struct Card: Decodable {
+    let firstName: String
+    let middleName: String
+    let lastName: String
+    let nickname: String
+    let organization: String
+    let department: String
+    let jobTitle: String
+    let birthday: String
+    let note: String
+    let phones: [LabeledValue]
+    let emails: [LabeledValue]
+    let urls: [LabeledValue]
+    let addresses: [PostalAddress]
+}
+
+private struct Request: Decodable {
+    let operation: String
+    let personUids: [String]?
+    let targetUid: String?
+    let sourceUids: [String]?
+    let card: Card?
+    let handles: [String]?
+}
+
+private struct ResolvedName: Encodable {
+    let handle: String
+    let name: String
+    let shortName: String
+}
+
+private struct CardCounts: Encodable {
+    let uid: String
+    let phones: Int
+    let emails: Int
+    let urls: Int
+    let addresses: Int
+}
+
+private struct Response: Encodable {
+    let ok: Bool
+    let availableCount: Int?
+    let deletedCount: Int?
+    let updated: Bool?
+    let error: String?
+    let names: [ResolvedName]?
+    // Failure stage, machine-readable: callers pick recovery per stage
+    // instead of parsing the human message.
+    var stage: String? = nil
+    // "counts" op only: fresh CNContactStore collection sizes per card, the
+    // staleness cross-check for Contacts.app's describe view.
+    var counts: [CardCounts]? = nil
+}
+
+private struct VCardResponse: Encodable {
+    let ok: Bool
+    let name: String
+    let vcard: String
+}
+
+private func failure(_ message: String, code: Int) -> NSError {
+    NSError(domain: "BlipContacts", code: code,
+            userInfo: [NSLocalizedDescriptionKey: message])
+}
+
+private func emit<T: Encodable>(_ response: T, maximum: Int = 4096) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(response), data.count <= maximum else {
+        FileHandle.standardOutput.write(Data("{\"error\":\"Contacts mutation response failed\",\"ok\":false}".utf8))
+        return
+    }
+    FileHandle.standardOutput.write(data)
+}
+
+private func boundedInput() throws -> Data {
+    var result = Data()
+    while true {
+        let chunk = try FileHandle.standardInput.read(upToCount: 4096) ?? Data()
+        if chunk.isEmpty { return result }
+        if result.count + chunk.count > maxInputBytes {
+            throw failure("Contacts mutation request is too large", code: 1)
+        }
+        result.append(chunk)
+    }
+}
+
+private func validId(_ identifier: String) -> Bool {
+    let range = NSRange(identifier.startIndex..<identifier.endIndex, in: identifier)
+    return allowedId.firstMatch(in: identifier, range: range)?.range == range
+}
+
+private func validateIds(_ identifiers: [String], minimum: Int = 1,
+                         maximum: Int = maxPersonIds) throws {
+    guard identifiers.count >= minimum, identifiers.count <= maximum,
+          Set(identifiers).count == identifiers.count else {
+        throw failure("Contacts mutation card list is invalid", code: 2)
+    }
+    guard identifiers.allSatisfy(validId) else {
+        throw failure("Contacts mutation card id is invalid", code: 3)
+    }
+}
+
+private func validateText(_ value: String, maximum: Int, required: Bool = false) throws {
+    guard value.count <= maximum, (!required || !value.isEmpty),
+          value.unicodeScalars.allSatisfy({
+              !CharacterSet.controlCharacters.contains($0)
+                  && !forbiddenDirectionals.contains($0.value)
+          }) else {
+        throw failure("Contacts mutation contains an invalid field", code: 4)
+    }
+}
+
+private func resolvedNames(_ handles: [String], in store: CNContactStore) throws -> [ResolvedName] {
+    guard !handles.isEmpty, handles.count <= maxNameHandles,
+          Set(handles).count == handles.count else {
+        throw failure("Contacts name request is invalid", code: 21)
+    }
+    let keys: [CNKeyDescriptor] = [
+        CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+        CNContactNicknameKey as CNKeyDescriptor,
+        CNContactOrganizationNameKey as CNKeyDescriptor,
+        CNContactPhoneNumbersKey as CNKeyDescriptor,
+        CNContactEmailAddressesKey as CNKeyDescriptor,
+    ]
+    func normalized(_ value: String) -> String {
+        if value.contains("@") { return value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        let digits = value.filter(\.isNumber)
+        return digits.count >= 10 ? String(digits.suffix(10)) : digits
+    }
+    var wanted: [String: String] = [:]
+    for handle in handles where wanted[normalized(handle)] == nil {
+        wanted[normalized(handle)] = handle
+    }
+    var found: [String: ResolvedName] = [:]
+    let request = CNContactFetchRequest(keysToFetch: keys)
+    request.unifyResults = true
+    try store.enumerateContacts(with: request) { contact, _ in
+        let keys = contact.phoneNumbers.map { normalized($0.value.stringValue) }
+            + contact.emailAddresses.map { normalized($0.value as String) }
+        let hits = Set(keys).intersection(wanted.keys)
+        if hits.isEmpty { return }
+        let formatted = CNContactFormatter.string(from: contact, style: .fullName) ?? ""
+        let full = !formatted.isEmpty ? formatted
+            : (!contact.organizationName.isEmpty ? contact.organizationName : contact.nickname)
+        if full.isEmpty { return }
+        let short = !contact.givenName.isEmpty ? contact.givenName
+            : (!contact.nickname.isEmpty ? contact.nickname : full)
+        for key in hits where found[key] == nil {
+            found[key] = ResolvedName(handle: wanted[key]!, name: full, shortName: short)
+        }
+    }
+    var result: [ResolvedName] = []
+    for handle in handles {
+        try validateText(handle, maximum: 320, required: true)
+        if let name = found[normalized(handle)] {
+            result.append(ResolvedName(handle: handle, name: name.name, shortName: name.shortName))
+        }
+    }
+    return result
+}
+
+private func validateLabeled(_ values: [LabeledValue]) throws {
+    guard values.count <= maxValues else {
+        throw failure("Contacts mutation has too many field values", code: 5)
+    }
+    for item in values {
+        try validateText(item.label, maximum: 80)
+        try validateText(item.value, maximum: 320, required: true)
+    }
+}
+
+private func validateCard(_ card: Card) throws {
+    for value in [card.firstName, card.middleName, card.lastName, card.nickname] {
+        try validateText(value, maximum: 160)
+    }
+    for value in [card.organization, card.department, card.jobTitle] {
+        try validateText(value, maximum: 320)
+    }
+    try validateText(card.birthday, maximum: 10)
+    try validateText(card.note, maximum: 1000)
+    guard !card.firstName.isEmpty || !card.lastName.isEmpty
+            || !card.nickname.isEmpty || !card.organization.isEmpty else {
+        throw failure("Contact needs a name, nickname, or organization", code: 6)
+    }
+    try validateLabeled(card.phones)
+    try validateLabeled(card.emails)
+    try validateLabeled(card.urls)
+    guard card.addresses.count <= maxValues else {
+        throw failure("Contacts mutation has too many postal addresses", code: 7)
+    }
+    for address in card.addresses {
+        try validateText(address.label, maximum: 80)
+        try validateText(address.street, maximum: 320)
+        try validateText(address.city, maximum: 320)
+        try validateText(address.state, maximum: 320)
+        try validateText(address.postalCode, maximum: 80)
+        try validateText(address.country, maximum: 160)
+        try validateText(address.countryCode, maximum: 8)
+        guard !address.street.isEmpty || !address.city.isEmpty || !address.state.isEmpty
+                || !address.postalCode.isEmpty || !address.country.isEmpty else {
+            throw failure("Contacts mutation contains an empty postal address", code: 8)
+        }
+    }
+}
+
+private let mutationKeys: [CNKeyDescriptor] = [
+    CNContactIdentifierKey as CNKeyDescriptor,
+    CNContactGivenNameKey as CNKeyDescriptor,
+    CNContactMiddleNameKey as CNKeyDescriptor,
+    CNContactFamilyNameKey as CNKeyDescriptor,
+    CNContactNicknameKey as CNKeyDescriptor,
+    CNContactOrganizationNameKey as CNKeyDescriptor,
+    CNContactDepartmentNameKey as CNKeyDescriptor,
+    CNContactJobTitleKey as CNKeyDescriptor,
+    CNContactBirthdayKey as CNKeyDescriptor,
+    CNContactPhoneNumbersKey as CNKeyDescriptor,
+    CNContactEmailAddressesKey as CNKeyDescriptor,
+    CNContactUrlAddressesKey as CNKeyDescriptor,
+    CNContactPostalAddressesKey as CNKeyDescriptor
+]
+
+private func exactContacts(_ identifiers: [String], in store: CNContactStore,
+                           keys: [CNKeyDescriptor]) throws -> [CNContact] {
+    let request = CNContactFetchRequest(keysToFetch: keys)
+    request.predicate = CNContact.predicateForContacts(withIdentifiers: identifiers)
+    request.unifyResults = false
+    var byIdentifier: [String: CNContact] = [:]
+    try store.enumerateContacts(with: request) { contact, _ in
+        guard identifiers.contains(contact.identifier), byIdentifier[contact.identifier] == nil else {
+            return
+        }
+        byIdentifier[contact.identifier] = contact
+    }
+    return identifiers.compactMap { byIdentifier[$0] }
+}
+
+private func exactContact(_ identifier: String, in store: CNContactStore,
+                          keys: [CNKeyDescriptor]) throws -> CNContact {
+    let contacts = try exactContacts([identifier], in: store, keys: keys)
+    guard contacts.count == 1, contacts[0].identifier == identifier else {
+        throw failure("A selected Contacts source card no longer exists", code: 9)
+    }
+    return contacts[0]
+}
+
+private func containerIdentifier(for contact: CNContact, in store: CNContactStore) throws -> String {
+    let predicate = CNContainer.predicateForContainerOfContact(withIdentifier: contact.identifier)
+    let containers = try store.containers(matching: predicate)
+    guard containers.count == 1 else {
+        throw failure("Contacts could not identify a selected card's account", code: 20)
+    }
+    return containers[0].identifier
+}
+
+private func requireMissing(_ identifiers: [String], in store: CNContactStore) throws {
+    let remaining = try exactContacts(
+        identifiers, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor]
+    )
+    if !remaining.isEmpty {
+        throw failure("Contacts did not delete every selected source card", code: 19)
+    }
+}
+
+private func dateComponents(_ value: String) throws -> DateComponents? {
+    if value.isEmpty { return nil }
+    let yearless = value.hasPrefix("--")
+    let pattern = yearless ? "^--[0-9]{2}-[0-9]{2}$" : "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    guard value.range(of: pattern, options: .regularExpression) != nil else {
+        throw failure("Contact birthday is invalid", code: 10)
+    }
+    let parts = value.split(separator: "-").compactMap { Int($0) }
+    let month = yearless ? parts[0] : parts[1]
+    let day = yearless ? parts[1] : parts[2]
+    guard (1...12).contains(month), (1...31).contains(day) else {
+        throw failure("Contact birthday is invalid", code: 10)
+    }
+    var result = DateComponents()
+    if !yearless { result.year = parts[0] }
+    result.month = month
+    result.day = day
+    return result
+}
+
+// Reuse the contact's own CNLabeledValue objects for unchanged label+value
+// pairs instead of rebuilding every collection. Replacing a value Contacts
+// already has forces contactsd to fault the old row out and delete it — and
+// one dangling stored row then fails the WHOLE save with Cocoa 134092
+// ("Unhandled error occurred during faulting"), persistently, even when the
+// new values are identical. Verified live 2026-09-03: an update sending a
+// card's exact current values failed on every attempt until unchanged rows
+// were left untouched. (The JXA editor learned the same lesson earlier:
+// unchanged collections retain their source fields.)
+// Contacts.app's scripting layer reports an UNLABELED value under a default
+// kind name — an email stored with label "" comes back as "Email", an
+// unlabeled phone as "Phone" (observed live 2026-09-03). Drafts built from
+// that view must not write those names back as literal custom labels, and
+// must still MATCH the unlabeled source rows, so kind-default names
+// normalize to nil on both sides of the comparison.
+private func normalizedLabel(_ label: String?, defaults: [String]) -> String? {
+    guard let label = label, !label.isEmpty, !defaults.contains(label) else { return nil }
+    return label
+}
+
+private func reuseLabeled<T: NSCopying & NSSecureCoding>(
+    _ existing: [CNLabeledValue<T>], desired: [LabeledValue], kindDefaults: [String],
+    matches: (T, String) -> Bool, build: (String) -> T
+) -> [CNLabeledValue<T>] {
+    var pool = existing
+    return desired.map { item in
+        let label = normalizedLabel(item.label, defaults: kindDefaults)
+        if let index = pool.firstIndex(where: {
+            normalizedLabel($0.label, defaults: kindDefaults) == label && matches($0.value, item.value)
+        }) {
+            return pool.remove(at: index)
+        }
+        return CNLabeledValue(label: label, value: build(item.value))
+    }
+}
+
+private func sameAddress(_ value: CNPostalAddress, _ desired: PostalAddress) -> Bool {
+    value.street == desired.street && value.city == desired.city
+        && value.state == desired.state && value.postalCode == desired.postalCode
+        && value.country == desired.country && value.isoCountryCode == desired.countryCode
+}
+
+private func apply(_ card: Card, to contact: CNMutableContact) throws {
+    if contact.givenName != card.firstName { contact.givenName = card.firstName }
+    if contact.middleName != card.middleName { contact.middleName = card.middleName }
+    if contact.familyName != card.lastName { contact.familyName = card.lastName }
+    if contact.nickname != card.nickname { contact.nickname = card.nickname }
+    if contact.organizationName != card.organization { contact.organizationName = card.organization }
+    if contact.departmentName != card.department { contact.departmentName = card.department }
+    if contact.jobTitle != card.jobTitle { contact.jobTitle = card.jobTitle }
+    // A synced birthday carries calendar/timeZone/era the draft's bare
+    // year-month-day components lack; leave an equal birthday untouched
+    // rather than rewriting it in a different encoding.
+    let birthday = try dateComponents(card.birthday)
+    let sameBirthday = (birthday == nil) == (contact.birthday == nil)
+        && birthday?.year == contact.birthday?.year
+        && birthday?.month == contact.birthday?.month
+        && birthday?.day == contact.birthday?.day
+    if !sameBirthday { contact.birthday = birthday }
+    let phones = reuseLabeled(contact.phoneNumbers, desired: card.phones,
+                              kindDefaults: ["Phone"],
+                              matches: { $0.stringValue == $1 },
+                              build: { CNPhoneNumber(stringValue: $0) })
+    if phones != contact.phoneNumbers { contact.phoneNumbers = phones }
+    let emails = reuseLabeled(contact.emailAddresses, desired: card.emails,
+                              kindDefaults: ["Email"],
+                              matches: { ($0 as String) == $1 },
+                              build: { $0 as NSString })
+    if emails != contact.emailAddresses { contact.emailAddresses = emails }
+    let urls = reuseLabeled(contact.urlAddresses, desired: card.urls,
+                            kindDefaults: ["Url", "URL", "Website"],
+                            matches: { ($0 as String) == $1 },
+                            build: { $0 as NSString })
+    if urls != contact.urlAddresses { contact.urlAddresses = urls }
+    var addressPool = contact.postalAddresses
+    let addresses = card.addresses.map { desired -> CNLabeledValue<CNPostalAddress> in
+        let label = normalizedLabel(desired.label, defaults: ["Address"])
+        if let index = addressPool.firstIndex(where: {
+            normalizedLabel($0.label, defaults: ["Address"]) == label && sameAddress($0.value, desired)
+        }) {
+            return addressPool.remove(at: index)
+        }
+        let address = CNMutablePostalAddress()
+        address.street = desired.street
+        address.city = desired.city
+        address.state = desired.state
+        address.postalCode = desired.postalCode
+        address.country = desired.country
+        address.isoCountryCode = desired.countryCode
+        return CNLabeledValue(label: label, value: address.copy() as! CNPostalAddress)
+    }
+    if addresses != contact.postalAddresses { contact.postalAddresses = addresses }
+}
+
+private func safeMessage(_ error: Error, stage: String) -> String {
+    let nsError = error as NSError
+    let raw: String
+    if nsError.domain == NSCocoaErrorDomain && nsError.code == 134092 {
+        raw = stage == "delete sources"
+            ? "Contacts saved the merged contact but could not delete an old source card; reload the cards and try again"
+            : "Contacts could not commit this save after several attempts; the card may have a damaged stored value — open it once in Contacts on the Mac, then retry"
+    } else {
+        raw = nsError.localizedDescription
+    }
+    // The stage and code make a report diagnosable without exposing content.
+    let suffix = stage.isEmpty ? "" : " (stage: \(stage), code \(nsError.code))"
+    let cleaned = raw.unicodeScalars.map { scalar -> Character in
+        if CharacterSet.controlCharacters.contains(scalar) { return " " }
+        return Character(String(scalar))
+    }
+    let body = String(cleaned).split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+    return String(body.prefix(180 - min(suffix.count, 60))) + suffix
+}
+
+var mutationStage = ""
+
+private func isTransientSaveError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == NSCocoaErrorDomain && nsError.code == 134092
+}
+
+/// Contacts throws Cocoa 134092 when a save lands while contactsd is
+/// rebuilding its unified graph or mid-account refresh — and Blip's own
+/// preflight launches Contacts.app moments earlier, which kicks off CardDAV
+/// refreshes of every account. Each retry therefore waits briefly and runs
+/// the whole stage again against a FRESH store session, refetching every
+/// object by its pinned identifier (the same medicine the cross-account
+/// delete path always needed). Anything else still fails immediately.
+private func withFreshStoreRetry(_ stage: String, attempts: Int = 3,
+                                 _ body: (CNContactStore) throws -> Void) throws {
+    for attempt in 1...attempts {
+        mutationStage = stage
+        do {
+            try body(CNContactStore())
+            return
+        } catch {
+            guard isTransientSaveError(error), attempt < attempts else { throw error }
+            usleep(attempt == 1 ? 700_000 : 1_500_000)
+        }
+    }
+}
+
+private func mutableCard(_ card: Card, uid: String, in session: CNContactStore) throws -> CNMutableContact {
+    let target = try exactContact(uid, in: session, keys: mutationKeys)
+    guard let mutable = target.mutableCopy() as? CNMutableContact else {
+        throw failure("Contacts returned a read-only target card", code: 17)
+    }
+    try apply(card, to: mutable)
+    return mutable
+}
+do {
+    let request = try JSONDecoder().decode(Request.self, from: boundedInput())
+    guard ["available", "delete", "update", "consolidate", "names", "vcard", "counts"].contains(request.operation) else {
+        throw failure("Contacts mutation operation is invalid", code: 11)
+    }
+    guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+        throw failure("Contacts access is not authorized on the Mac", code: 12)
+    }
+    let store = CNContactStore()
+
+    if request.operation == "names" {
+        guard let handles = request.handles else {
+            throw failure("Contacts name request is missing", code: 22)
+        }
+        emit(Response(ok: true, availableCount: nil, deletedCount: nil,
+                      updated: nil, error: nil,
+                      names: try resolvedNames(handles, in: store)))
+        exit(0)
+    }
+
+    if request.operation == "vcard" {
+        guard let targetUid = request.targetUid, validId(targetUid), let card = request.card else {
+            throw failure("Contacts vCard request is incomplete", code: 23)
+        }
+        try validateCard(card)
+        let keys: [CNKeyDescriptor] = [
+            CNContactIdentifierKey as CNKeyDescriptor,
+            CNContactVCardSerialization.descriptorForRequiredKeys()
+        ]
+        let target = try exactContact(targetUid, in: store, keys: keys)
+        guard let mutable = target.mutableCopy() as? CNMutableContact else {
+            throw failure("Contacts returned a read-only vCard", code: 24)
+        }
+        try apply(card, to: mutable)
+        let data = try CNContactVCardSerialization.data(with: [mutable])
+        guard !data.isEmpty, data.count <= maxVCardBytes else {
+            throw failure("The contact vCard is too large to copy", code: 25)
+        }
+        let display = [card.firstName, card.middleName, card.lastName]
+            .filter { !$0.isEmpty }.joined(separator: " ")
+        let name = !display.isEmpty ? display
+            : (!card.organization.isEmpty ? card.organization : card.nickname)
+        emit(VCardResponse(ok: true, name: name, vcard: data.base64EncodedString()),
+             maximum: maxVCardResponseBytes)
+        exit(0)
+    }
+
+    if request.operation == "update" {
+        guard let targetUid = request.targetUid, validId(targetUid), let card = request.card else {
+            throw failure("Contacts update request is incomplete", code: 26)
+        }
+        try validateCard(card)
+        _ = try exactContact(targetUid, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+        try withFreshStoreRetry("update contact") { session in
+            let save = CNSaveRequest()
+            save.update(try mutableCard(card, uid: targetUid, in: session))
+            try session.execute(save)
+        }
+        _ = try exactContact(targetUid, in: store,
+                             keys: [CNContactIdentifierKey as CNKeyDescriptor])
+        emit(Response(ok: true, availableCount: nil, deletedCount: nil,
+                      updated: true, error: nil, names: nil))
+        exit(0)
+    }
+
+    if request.operation == "counts" {
+        guard let identifiers = request.personUids else {
+            throw failure("Contacts mutation card list is missing", code: 13)
+        }
+        try validateIds(identifiers, maximum: 8)
+        let keys: [CNKeyDescriptor] = [
+            CNContactIdentifierKey as CNKeyDescriptor,
+            CNContactPhoneNumbersKey as CNKeyDescriptor,
+            CNContactEmailAddressesKey as CNKeyDescriptor,
+            CNContactUrlAddressesKey as CNKeyDescriptor,
+            CNContactPostalAddressesKey as CNKeyDescriptor
+        ]
+        let contacts = try exactContacts(identifiers, in: store, keys: keys)
+        guard contacts.count == identifiers.count else {
+            throw failure("A selected Contacts source card no longer exists", code: 9)
+        }
+        emit(Response(ok: true, availableCount: nil, deletedCount: nil,
+                      updated: nil, error: nil, names: nil,
+                      counts: contacts.map { CardCounts(
+                          uid: $0.identifier,
+                          phones: $0.phoneNumbers.count,
+                          emails: $0.emailAddresses.count,
+                          urls: $0.urlAddresses.count,
+                          addresses: $0.postalAddresses.count) }),
+             maximum: 8192)
+        exit(0)
+    }
+
+    if request.operation == "available" || request.operation == "delete" {
+        guard let identifiers = request.personUids else {
+            throw failure("Contacts mutation card list is missing", code: 13)
+        }
+        try validateIds(identifiers)
+        let contacts = try exactContacts(
+            identifiers, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor]
+        )
+        guard contacts.count == identifiers.count else {
+            throw failure("A selected Contacts source card no longer exists", code: 9)
+        }
+        if request.operation == "available" {
+            emit(Response(ok: true, availableCount: contacts.count, deletedCount: nil,
+                          updated: nil, error: nil, names: nil))
+            exit(0)
+        }
+        let save = CNSaveRequest()
+        for contact in contacts {
+            guard let mutable = contact.mutableCopy() as? CNMutableContact else {
+                throw failure("Contacts returned a read-only card", code: 14)
+            }
+            save.delete(mutable)
+        }
+        mutationStage = "delete sources"
+        try store.execute(save)
+        try requireMissing(identifiers, in: store)
+        emit(Response(ok: true, availableCount: nil, deletedCount: contacts.count,
+                      updated: nil, error: nil, names: nil))
+        exit(0)
+    }
+
+    guard let targetUid = request.targetUid, validId(targetUid),
+          let sourceUids = request.sourceUids, let card = request.card else {
+        throw failure("Contacts consolidation request is incomplete", code: 15)
+    }
+    try validateIds(sourceUids)
+    guard !sourceUids.contains(targetUid) else {
+        throw failure("Contacts consolidation target is also a source", code: 16)
+    }
+    try validateCard(card)
+    let target = try exactContact(targetUid, in: store,
+                                  keys: [CNContactIdentifierKey as CNKeyDescriptor])
+    let sources = try sourceUids.map {
+        try exactContact($0, in: store, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+    }
+    let targetContainer = try containerIdentifier(for: target, in: store)
+    let sourceContainers = try sources.map { try containerIdentifier(for: $0, in: store) }
+    if sourceContainers.allSatisfy({ $0 == targetContainer }) {
+        // One atomic request: survivor update and source deletes together. A
+        // retry refetches everything in its fresh session and deletes only the
+        // sources still present — a "failed" save can turn out to have
+        // committed; requireMissing below stays the authoritative check.
+        try withFreshStoreRetry("save same-account merge") { session in
+            let save = CNSaveRequest()
+            save.update(try mutableCard(card, uid: targetUid, in: session))
+            let present = try exactContacts(
+                sourceUids, in: session, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+            for source in present {
+                guard let mutable = source.mutableCopy() as? CNMutableContact else {
+                    throw failure("Contacts returned a read-only source card", code: 18)
+                }
+                save.delete(mutable)
+            }
+            try session.execute(save)
+        }
+    } else {
+        // Contacts can reject a single CNSaveRequest that spans account-backed
+        // persistent stores. Save the complete survivor first so no source data
+        // is lost, then delete sources in one request per backing container.
+        try withFreshStoreRetry("update survivor") { session in
+            let update = CNSaveRequest()
+            update.update(try mutableCard(card, uid: targetUid, in: session))
+            try session.execute(update)
+        }
+
+        // Saving the survivor can cause Contacts to rebuild its unified-contact
+        // graph. Objects fetched before that save may then retain stale backing-
+        // store relationships and fail with Cocoa 134092 when deleted, so every
+        // attempt refetches the source cards by their pinned identifiers in its
+        // own fresh session. The fetch is lenient — an earlier partial attempt
+        // may already have removed some sources; requireMissing below stays the
+        // authoritative check that every one is gone.
+        try withFreshStoreRetry("delete sources") { session in
+            let present = try exactContacts(
+                sourceUids, in: session, keys: [CNContactIdentifierKey as CNKeyDescriptor])
+            var grouped: [String: [CNContact]] = [:]
+            for source in present {
+                let container = try containerIdentifier(for: source, in: session)
+                grouped[container, default: []].append(source)
+            }
+            for contacts in grouped.values {
+                let deletion = CNSaveRequest()
+                for source in contacts {
+                    guard let mutable = source.mutableCopy() as? CNMutableContact else {
+                        throw failure("Contacts returned a read-only source card", code: 18)
+                    }
+                    deletion.delete(mutable)
+                }
+                try session.execute(deletion)
+            }
+        }
+    }
+    _ = try exactContact(targetUid, in: store,
+                         keys: [CNContactIdentifierKey as CNKeyDescriptor])
+    try requireMissing(sourceUids, in: store)
+    emit(Response(ok: true, availableCount: nil, deletedCount: sources.count,
+                  updated: true, error: nil, names: nil))
+} catch {
+    emit(Response(ok: false, availableCount: nil, deletedCount: nil,
+                  updated: nil, error: safeMessage(error, stage: mutationStage), names: nil,
+                  stage: mutationStage.isEmpty ? nil : mutationStage))
+    exit(1)
+}

--- a/bridge/mac/contact-link.applescript
+++ b/bridge/mac/contact-link.applescript
@@ -1,0 +1,98 @@
+-- Blip's narrowly scoped Contacts UI handoff.
+--
+-- Contacts exposes multi-card selection to AppleScript, but no link command.
+-- This helper selects exact, revalidated card ids and either reports the one
+-- Apple-provided link/merge menu action or clicks it after Blip's separate
+-- confirmation. It accepts only a fixed mode and card ids supplied by the
+-- owner-controlled Python bridge.
+
+on jsonError(messageText)
+  set cleaned to my oneLine(messageText)
+  return "{\"ok\":false,\"error\":\"" & cleaned & "\"}"
+end jsonError
+
+on oneLine(valueText)
+  set sourceText to valueText as text
+  set AppleScript's text item delimiters to {return, linefeed, tab, "\"", "\\"}
+  set pieces to text items of sourceText
+  set AppleScript's text item delimiters to " "
+  set joined to pieces as text
+  set AppleScript's text item delimiters to ""
+  if (count joined) > 160 then set joined to text 1 thru 160 of joined
+  return joined
+end oneLine
+
+on trimSpaces(valueText)
+  set resultText to valueText as text
+  repeat while resultText begins with " "
+    if (count resultText) = 1 then return ""
+    set resultText to text 2 thru -1 of resultText
+  end repeat
+  repeat while resultText ends with " "
+    if (count resultText) = 1 then return ""
+    set resultText to text 1 thru -2 of resultText
+  end repeat
+  return resultText
+end trimSpaces
+
+on run argv
+  try
+    if (count argv) < 3 or (count argv) > 10 then return my jsonError("invalid card selection")
+    set operation to item 1 of argv
+    if operation is not "prepare" and operation is not "link" then return my jsonError("invalid link operation")
+    set firstCardIndex to 2
+    set expectedAction to ""
+    if operation is "link" then
+      if (count argv) < 4 then return my jsonError("invalid card selection")
+      set expectedAction to item 2 of argv
+      if expectedAction is not "Link Selected Cards" and expectedAction is not "Merge Selected Cards" and expectedAction is not "Merge and Link Selected Cards" then return my jsonError("invalid expected link action")
+      set firstCardIndex to 3
+    end if
+
+    tell application "Contacts"
+      if unsaved then return my jsonError("Contacts has unsaved changes; finish or discard them first")
+      set selectedCards to {}
+      repeat with itemNumber from firstCardIndex to count argv
+        set personId to item itemNumber of argv
+        if not (exists person id personId) then return my jsonError("an exact Contacts card is unavailable")
+        set end of selectedCards to person id personId
+      end repeat
+      set selection to selectedCards
+      activate
+      delay 0.4
+      if (count selection) is not ((count argv) - firstCardIndex + 1) then return my jsonError("Contacts did not select every requested card")
+    end tell
+
+    tell application "System Events"
+      if UI elements enabled is false then return my jsonError("Accessibility is required for linking Contacts cards")
+      tell process "Contacts"
+        set cardMenu to menu 1 of menu bar item "Card" of menu bar 1
+        set actionItem to missing value
+        set actionName to ""
+        repeat with candidateItem in every menu item of cardMenu
+          try
+            set candidateName to my trimSpaces(name of candidateItem)
+            if candidateName is "Link Selected Cards" or candidateName is "Merge Selected Cards" or candidateName is "Merge and Link Selected Cards" then
+              set actionItem to candidateItem
+              set actionName to candidateName
+              exit repeat
+            end if
+          end try
+        end repeat
+        if actionItem is missing value then return my jsonError("Contacts does not expose a link or merge action")
+        if enabled of actionItem is false then
+          return "{\"ok\":true,\"ready\":false,\"action\":\"" & actionName & "\"}"
+        end if
+        if operation is "prepare" then
+          return "{\"ok\":true,\"ready\":true,\"action\":\"" & actionName & "\"}"
+        end if
+        if actionName is not expectedAction then return my jsonError("Contacts link action changed; review the cards again")
+        click actionItem
+      end tell
+    end tell
+    delay 0.8
+    return "{\"ok\":true,\"linked\":true,\"action\":\"" & actionName & "\"}"
+  on error messageText
+    return my jsonError(messageText)
+  end try
+end run

--- a/bridge/mac/contact-repair.js
+++ b/bridge/mac/contact-repair.js
@@ -1,18 +1,20 @@
 #!/usr/bin/osascript -l JavaScript
 /*
- * Read-only Contacts availability check for Blip.
+ * Supported Contacts.app mutation boundary for Blip.
  *
  * The Python bridge sends one bounded JSON request on stdin. Raw Contacts
- * identifiers never appear in argv, and this helper emits a small JSON
- * result only. Its single operation answers which person ids the object
- * layer can actually address — raw per-account databases can retain
- * inactive cache rows. It mutates nothing.
+ * identifiers and field values never appear in argv, and this helper emits a
+ * small JSON result only. It deliberately refuses to save while Contacts has
+ * unrelated unsaved changes.
  */
 ObjC.import("Foundation");
 
 const MAX_INPUT_BYTES = 48 * 1024;
 const MAX_OUTPUT_BYTES = 48 * 1024;
+const MAX_FIELDS = 8;
 const MAX_PERSON_IDS = 64;
+const MAX_COMPARE_CARDS = 8;
+const MAX_VALUES_PER_KIND = 16;
 const UNSAFE = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g;
 
 function boundedString(value, label, maximum) {
@@ -21,6 +23,15 @@ function boundedString(value, label, maximum) {
   const cleaned = value.replace(UNSAFE, " ").replace(/\s+/g, " ").trim();
   if (!cleaned) throw new Error(label + " is invalid");
   return cleaned;
+}
+
+function normalizePhone(value) {
+  const digits = boundedString(value, "phone value", 320).replace(/\D/g, "");
+  return digits.length >= 10 ? digits.slice(-10) : digits;
+}
+
+function normalizeEmail(value) {
+  return boundedString(value, "email value", 320).toLowerCase();
 }
 
 function readRequest() {
@@ -36,35 +47,571 @@ function readRequest() {
 }
 
 function normalizeRequest(value) {
-  if (value.operation !== "available") throw new Error("repair operation is invalid");
-  if (!Array.isArray(value.personUids) || value.personUids.length < 1
-      || value.personUids.length > MAX_PERSON_IDS)
-    throw new Error("person id list is invalid");
-  const seen = {};
-  const personUids = value.personUids.map(function(uid) {
-    const normalized = boundedString(uid, "person id", 200);
-    if (seen[normalized]) throw new Error("person id list contains a duplicate");
-    seen[normalized] = true;
-    return normalized;
+  const operation = value.operation === "available" || value.operation === "describe"
+    || value.operation === "inspect" || value.operation === "remove"
+    || value.operation === "undo" || value.operation === "edit"
+    || value.operation === "delete" || value.operation === "restore"
+    || value.operation === "consolidate" || value.operation === "undo-consolidate"
+    || value.operation === "discard-unsaved" || value.operation === "delete-fallback"
+    ? value.operation : "";
+  if (!operation) throw new Error("repair operation is invalid");
+  if (operation === "discard-unsaved") return { operation: operation };
+  if (operation === "available" || operation === "delete-fallback") {
+    if (!Array.isArray(value.personUids) || value.personUids.length < 1
+        || value.personUids.length > MAX_PERSON_IDS)
+      throw new Error("person id list is invalid");
+    const seen = {};
+    const personUids = value.personUids.map(function(uid) {
+      const normalized = boundedString(uid, "person id", 200);
+      if (seen[normalized]) throw new Error("person id list contains a duplicate");
+      seen[normalized] = true;
+      return normalized;
+    });
+    return { operation: operation, personUids: personUids };
+  }
+  if (operation === "describe") {
+    if (!Array.isArray(value.personUids) || value.personUids.length < 1
+        || value.personUids.length > MAX_COMPARE_CARDS)
+      throw new Error("comparison card list is invalid");
+    const seen = {};
+    const personUids = value.personUids.map(function(uid) {
+      const normalized = boundedString(uid, "person id", 200);
+      if (seen[normalized]) throw new Error("comparison card list contains a duplicate");
+      seen[normalized] = true;
+      return normalized;
+    });
+    return { operation: operation, personUids: personUids };
+  }
+  if (operation === "restore") {
+    return { operation: operation, card: normalizeCard(value.card, false) };
+  }
+  if (operation === "undo-consolidate") {
+    const targetUid = boundedString(value.targetUid, "target person id", 200);
+    if (!Array.isArray(value.restoreCards) || value.restoreCards.length < 1
+        || value.restoreCards.length >= MAX_COMPARE_CARDS)
+      throw new Error("restore card list is invalid");
+    return {
+      operation: operation,
+      targetUid: targetUid,
+      expectedCard: normalizeCard(value.expectedCard, true),
+      card: normalizeCard(value.card, false),
+      restoreCards: value.restoreCards.map(function(card) { return normalizeCard(card, false); })
+    };
+  }
+  if (operation === "consolidate") {
+    const targetUid = boundedString(value.targetUid, "target person id", 200);
+    if (!Array.isArray(value.sourceUids) || value.sourceUids.length < 1
+        || value.sourceUids.length >= MAX_COMPARE_CARDS)
+      throw new Error("source person id list is invalid");
+    if (!Array.isArray(value.expectedCards)
+        || value.expectedCards.length !== value.sourceUids.length + 1)
+      throw new Error("expected card list is invalid");
+    const sourceUids = value.sourceUids.map(function(uid) {
+      const normalized = boundedString(uid, "source person id", 200);
+      if (normalized === targetUid) throw new Error("target cannot also be a source card");
+      return normalized;
+    });
+    if (new Set(sourceUids).size !== sourceUids.length)
+      throw new Error("source person id list contains a duplicate");
+    const request = {
+      operation: operation,
+      targetUid: targetUid,
+      sourceUids: sourceUids,
+      expectedCards: value.expectedCards.map(function(card) { return normalizeCard(card, true); }),
+      card: normalizeCard(value.card, false)
+    };
+    return request;
+  }
+  if (operation === "edit" || operation === "delete") {
+    const request = {
+      operation: operation,
+      personUid: boundedString(value.personUid, "person id", 200),
+      expectedCard: normalizeCard(value.expectedCard, true)
+    };
+    if (operation === "edit") request.card = normalizeCard(value.card, false);
+    return request;
+  }
+  const uid = boundedString(value.personUid, "person id", 200);
+  const kind = value.kind === "phone" || value.kind === "email" ? value.kind : "";
+  if (!kind) throw new Error("repair kind is invalid");
+  const key = boundedString(value.key, "handle key", 320);
+  const request = { operation: operation, personUid: uid, kind: kind, key: key, fields: [] };
+  if (operation === "remove" || operation === "undo") {
+    if (!Array.isArray(value.fields) || value.fields.length < 1 || value.fields.length > MAX_FIELDS)
+      throw new Error("repair field list is invalid");
+    request.fields = value.fields.map(function(field) {
+      if (!field || typeof field !== "object" || Array.isArray(field))
+        throw new Error("repair field is invalid");
+      return {
+        id: operation === "remove" ? boundedString(field.id, "field id", 200) : "",
+        value: boundedString(field.value, "field value", 320),
+        label: typeof field.label === "string"
+          ? field.label.replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 80) : ""
+      };
+    });
+  }
+  return request;
+}
+
+function peopleForId(contacts, uid) {
+  const people = contacts.people.whose({ id: uid })();
+  if (!Array.isArray(people) || people.length !== 1)
+    throw new Error("the exact Contacts card is unavailable");
+  return people[0];
+}
+
+function normalizedValue(kind, value) {
+  return kind === "email" ? normalizeEmail(value) : normalizePhone(value);
+}
+
+function matchingFields(person, kind, key) {
+  const entries = kind === "email" ? person.emails() : person.phones();
+  const matches = [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    let value;
+    try { value = boundedString(entry.value(), "field value", 320); }
+    catch (_) { continue; }
+    if (normalizedValue(kind, value) !== key) continue;
+    const id = boundedString(entry.id(), "field id", 200);
+    let label = "";
+    try {
+      const rawLabel = entry.label();
+      if (typeof rawLabel === "string")
+        label = rawLabel.replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 80);
+    } catch (_) { /* labels are optional */ }
+    matches.push({ specifier: entry, id: id, value: value, label: label });
+    if (matches.length > MAX_FIELDS) throw new Error("too many matching fields on this card");
+  }
+  return matches;
+}
+
+function publicFields(fields) {
+  return fields.map(function(field) {
+    return { id: field.id, value: field.value, label: field.label };
   });
-  return { operation: "available", personUids: personUids };
+}
+
+function optionalString(value, label, maximum) {
+  if (value === null || value === undefined) return "";
+  if (typeof value !== "string") throw new Error(label + " is invalid");
+  if (value.length > maximum) throw new Error(label + " is too long");
+  return value.replace(UNSAFE, " ").replace(/\s+/g, " ").trim();
+}
+
+function normalizeLabeledInput(value, label) {
+  if (!Array.isArray(value) || value.length > MAX_VALUES_PER_KIND)
+    throw new Error(label + " list is invalid");
+  return value.map(function(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry))
+      throw new Error(label + " is invalid");
+    const item = {
+      label: optionalString(entry.label, label + " label", 80),
+      value: optionalString(entry.value, label + " value", 320)
+    };
+    if (!item.value) throw new Error(label + " value is empty");
+    return item;
+  });
+}
+
+function normalizeAddressInput(value) {
+  if (!Array.isArray(value) || value.length > MAX_VALUES_PER_KIND)
+    throw new Error("address list is invalid");
+  return value.map(function(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry))
+      throw new Error("address is invalid");
+    const address = {
+      label: optionalString(entry.label, "address label", 80),
+      street: optionalString(entry.street, "street", 320),
+      city: optionalString(entry.city, "city", 320),
+      state: optionalString(entry.state, "state", 320),
+      postalCode: optionalString(entry.postalCode, "postal code", 80),
+      country: optionalString(entry.country, "country", 160),
+      countryCode: optionalString(entry.countryCode, "country code", 8)
+    };
+    if (!address.street && !address.city && !address.state && !address.postalCode && !address.country)
+      throw new Error("address is empty");
+    return address;
+  });
+}
+
+function normalizeCard(value, includeDisplayName) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error("contact card is invalid");
+  const birthday = optionalString(value.birthday, "birthday", 10);
+  if (birthday && !/^(?:\d{4}\-|--)\d{2}\-\d{2}$/.test(birthday))
+    throw new Error("birthday is invalid");
+  const card = {
+    firstName: optionalString(value.firstName, "first name", 160),
+    middleName: optionalString(value.middleName, "middle name", 160),
+    lastName: optionalString(value.lastName, "last name", 160),
+    nickname: optionalString(value.nickname, "nickname", 160),
+    organization: optionalString(value.organization, "organization", 320),
+    department: optionalString(value.department, "department", 320),
+    jobTitle: optionalString(value.jobTitle, "job title", 320),
+    birthday: birthday,
+    note: optionalString(value.note, "note", 1000),
+    phones: normalizeLabeledInput(value.phones, "phone"),
+    emails: normalizeLabeledInput(value.emails, "email"),
+    urls: normalizeLabeledInput(value.urls, "URL"),
+    addresses: normalizeAddressInput(value.addresses)
+  };
+  if (!card.firstName && !card.lastName && !card.nickname && !card.organization)
+    throw new Error("contact card needs a name, nickname, or organization");
+  if (includeDisplayName)
+    card.displayName = optionalString(value.displayName, "display name", 160);
+  return card;
+}
+
+function personString(person, property, label, maximum) {
+  try { return optionalString(person[property](), label, maximum); }
+  catch (error) {
+    if (String(error).indexOf("is too long") >= 0) throw error;
+    return "";
+  }
+}
+
+function labeledValues(person, property, label) {
+  const entries = person[property]();
+  if (!Array.isArray(entries) || entries.length > MAX_VALUES_PER_KIND)
+    throw new Error("too many " + label + " values on one card");
+  return entries.map(function(entry) {
+    const value = optionalString(entry.value(), label + " value", 320);
+    let entryLabel = "";
+    try { entryLabel = optionalString(entry.label(), label + " label", 80); }
+    catch (_) { entryLabel = ""; }
+    return { label: entryLabel, value: value };
+  }).filter(function(entry) { return entry.value !== ""; });
+}
+
+function addressValues(person) {
+  const entries = person.addresses();
+  if (!Array.isArray(entries) || entries.length > MAX_VALUES_PER_KIND)
+    throw new Error("too many address values on one card");
+  return entries.map(function(entry) {
+    function piece(property, label) {
+      try { return optionalString(entry[property](), label, 320); }
+      catch (_) { return ""; }
+    }
+    return {
+      label: piece("label", "address label"),
+      street: piece("street", "street"),
+      city: piece("city", "city"),
+      state: piece("state", "state"),
+      postalCode: piece("zip", "postal code"),
+      country: piece("country", "country"),
+      countryCode: piece("countryCode", "country code")
+    };
+  }).filter(function(entry) {
+    return entry.street || entry.city || entry.state || entry.postalCode || entry.country;
+  });
+}
+
+function birthDateValue(person) {
+  let value;
+  try { value = person.birthDate(); } catch (_) { return ""; }
+  if (value === null || value === undefined) return "";
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return "";
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getFullYear();
+  return year < 1800 ? "--" + month + "-" + day : String(year).padStart(4, "0") + "-" + month + "-" + day;
+}
+
+function describePerson(person) {
+  return {
+    displayName: personString(person, "name", "display name", 160),
+    firstName: personString(person, "firstName", "first name", 160),
+    middleName: personString(person, "middleName", "middle name", 160),
+    lastName: personString(person, "lastName", "last name", 160),
+    nickname: personString(person, "nickname", "nickname", 160),
+    organization: personString(person, "organization", "organization", 320),
+    department: personString(person, "department", "department", 320),
+    jobTitle: personString(person, "jobTitle", "job title", 320),
+    birthday: birthDateValue(person),
+    note: personString(person, "note", "note", 1000),
+    phones: labeledValues(person, "phones", "phone"),
+    emails: labeledValues(person, "emails", "email"),
+    urls: labeledValues(person, "urls", "URL"),
+    addresses: addressValues(person)
+  };
+}
+
+function sameCard(person, expected) {
+  const actual = describePerson(person);
+  const keys = ["displayName", "firstName", "middleName", "lastName", "nickname",
+    "organization", "department", "jobTitle", "birthday", "note", "phones",
+    "emails", "urls", "addresses"];
+  for (let i = 0; i < keys.length; i++) {
+    if (JSON.stringify(actual[keys[i]]) !== JSON.stringify(expected[keys[i]])) return false;
+  }
+  return true;
+}
+
+function removeAll(contacts, person, property) {
+  // The remove-from-person Apple event errors with "Message not understood"
+  // on current macOS (verified live 2026-09-03); deleting the entry
+  // specifier is the pattern that works.
+  const entries = person[property]();
+  for (let i = entries.length - 1; i >= 0; i--)
+    contacts.delete(entries[i]);
+}
+
+// When every existing entry survives the edit, return just the additions so
+// setCard can skip the removal pass entirely — removing a damaged stored row
+// fails ("Message not understood") where additions still work, and existing
+// entries keep their stable field ids. Returns null when anything is removed
+// or relabeled, which forces the full replace path.
+function addedEntries(existing, desired) {
+  const pool = existing.map(function(entry) { return entry.label + "\u0000" + entry.value; });
+  const added = [];
+  for (let i = 0; i < desired.length; i++) {
+    const key = desired[i].label + "\u0000" + desired[i].value;
+    const at = pool.indexOf(key);
+    if (at >= 0) pool.splice(at, 1);
+    else added.push(desired[i]);
+  }
+  return pool.length === 0 ? added : null;
+}
+
+function sameCollection(actual, desired) {
+  return JSON.stringify(actual) === JSON.stringify(desired);
+}
+
+function birthdayDate(value) {
+  if (!value) return null;
+  const yearless = value.slice(0, 2) === "--";
+  const year = yearless ? 1604 : Number(value.slice(0, 4));
+  const month = Number(value.slice(yearless ? 2 : 5, yearless ? 4 : 7));
+  const day = Number(value.slice(yearless ? 5 : 8, yearless ? 7 : 10));
+  const date = new Date(year, month - 1, day, 12, 0, 0);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day)
+    throw new Error("birthday is invalid");
+  return date;
+}
+
+function cardStep(label, action) {
+  try {
+    action();
+  } catch (error) {
+    const detail = String(error && error.message ? error.message : error)
+      .replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 120);
+    throw new Error("Contacts could not update " + label + (detail ? ": " + detail : ""));
+  }
+}
+
+function setCard(contacts, person, card) {
+  const scalar = ["firstName", "middleName", "lastName", "nickname", "organization",
+    "department", "jobTitle", "note"];
+  for (let i = 0; i < scalar.length; i++) {
+    const property = scalar[i];
+    cardStep(property, function() { person[property].set(card[property]); });
+  }
+  cardStep("birthday", function() { person.birthDate.set(birthdayDate(card.birthday)); });
+  // Preserve collection objects (and their stable field ids) when an edit
+  // changes only a scalar such as middle name. When replacement is needed,
+  // remove the concrete specifiers returned by Contacts; calling `.at()` on
+  // the property function produces a malformed Apple event on current macOS.
+  const existingPhones = labeledValues(person, "phones", "phone");
+  const existingEmails = labeledValues(person, "emails", "email");
+  const phonesChanged = !sameCollection(existingPhones, card.phones);
+  const emailsChanged = !sameCollection(existingEmails, card.emails);
+  const urlsChanged = !sameCollection(labeledValues(person, "urls", "URL"), card.urls);
+  const addressesChanged = !sameCollection(addressValues(person), card.addresses);
+  const phonesAdded = phonesChanged ? addedEntries(existingPhones, card.phones) : [];
+  const emailsAdded = emailsChanged ? addedEntries(existingEmails, card.emails) : [];
+  if (phonesChanged && phonesAdded === null)
+    cardStep("phone numbers", function() { removeAll(contacts, person, "phones"); });
+  if (emailsChanged && emailsAdded === null)
+    cardStep("email addresses", function() { removeAll(contacts, person, "emails"); });
+  if (urlsChanged)
+    cardStep("websites", function() { removeAll(contacts, person, "urls"); });
+  if (addressesChanged)
+    cardStep("postal addresses", function() { removeAll(contacts, person, "addresses"); });
+  const phonesToWrite = phonesAdded === null ? card.phones : phonesAdded;
+  const emailsToWrite = emailsAdded === null ? card.emails : emailsAdded;
+  for (let i = 0; phonesChanged && i < phonesToWrite.length; i++) {
+    const field = phonesToWrite[i];
+    cardStep("phone number " + String(i + 1), function() { addField(contacts, person, "phone", field); });
+  }
+  for (let i = 0; emailsChanged && i < emailsToWrite.length; i++) {
+    const field = emailsToWrite[i];
+    cardStep("email address " + String(i + 1), function() { addField(contacts, person, "email", field); });
+  }
+  for (let i = 0; urlsChanged && i < card.urls.length; i++) {
+    const field = card.urls[i];
+    cardStep("website " + String(i + 1), function() {
+      const properties = { value: field.value };
+      if (field.label) properties.label = field.label;
+      person.urls.push(contacts.Url(properties));
+    });
+  }
+  for (let i = 0; addressesChanged && i < card.addresses.length; i++) {
+    const source = card.addresses[i];
+    cardStep("postal address " + String(i + 1), function() {
+      const properties = { street: source.street, city: source.city, state: source.state,
+        zip: source.postalCode, country: source.country, countryCode: source.countryCode };
+      if (source.label) properties.label = source.label;
+      person.addresses.push(contacts.Address(properties));
+    });
+  }
+}
+
+function createPerson(contacts, card) {
+  const person = contacts.Person({ firstName: card.firstName });
+  contacts.people.push(person);
+  setCard(contacts, person, card);
+  return person;
+}
+
+function sameFieldSet(actual, expected) {
+  if (actual.length !== expected.length) return false;
+  const left = actual.map(function(field) { return field.id; }).sort();
+  const right = expected.map(function(field) { return field.id; }).sort();
+  for (let i = 0; i < left.length; i++) if (left[i] !== right[i]) return false;
+  return true;
+}
+
+function addField(contacts, person, kind, field) {
+  const properties = { value: field.value };
+  if (field.label) properties.label = field.label;
+  const entry = kind === "email" ? contacts.Email(properties) : contacts.Phone(properties);
+  // The add-to-person Apple event errors with "No error. (0)" on
+  // current macOS; pushing onto the person's own collection is the pattern
+  // that works (verified live 2026-09-03, macOS 15.5).
+  person[kind === "email" ? "emails" : "phones"].push(entry);
 }
 
 function perform(request) {
-  // The object layer exposes only cards that Contacts can actually address;
-  // raw per-account databases can retain inactive cache rows.
-  ObjC.import("AddressBook");
-  const book = $.ABAddressBook.sharedAddressBook;
-  const available = request.personUids.filter(function(uid) {
-    try {
-      const person = book.recordForUniqueId($(uid));
-      const value = ObjC.unwrap(person);
-      return value !== undefined && value !== null;
-    } catch (_) {
-      return false;
+  if (request.operation === "available") {
+    // The object layer exposes only cards that Contacts can actually address;
+    // raw per-account databases can retain inactive cache rows.
+    ObjC.import("AddressBook");
+    const book = $.ABAddressBook.sharedAddressBook;
+    const available = request.personUids.filter(function(uid) {
+      try {
+        const person = book.recordForUniqueId($(uid));
+        const value = ObjC.unwrap(person);
+        return value !== undefined && value !== null;
+      } catch (_) {
+        return false;
+      }
+    });
+    return { ok: true, available: available };
+  }
+  const Contacts = Application("Contacts");
+  if (request.operation === "discard-unsaved") {
+    if (!Contacts.running() || !Contacts.unsaved())
+      return { ok: true, discarded: false };
+    // This is reachable only from Blip's explicit destructive confirmation.
+    // `saving: "no"` closes Contacts without committing its in-memory edit.
+    Contacts.quit({ saving: "no" });
+    return { ok: true, discarded: true };
+  }
+  if (request.operation === "describe") {
+    const cards = request.personUids.map(function(uid) {
+      return describePerson(peopleForId(Contacts, uid));
+    });
+    return { ok: true, cards: cards };
+  }
+  if (request.operation === "restore") {
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    const restored = createPerson(Contacts, request.card);
+    Contacts.save();
+    return { ok: true, restored: true, card: describePerson(restored) };
+  }
+  if (request.operation === "undo-consolidate") {
+    const target = peopleForId(Contacts, request.targetUid);
+    if (!sameCard(target, request.expectedCard))
+      throw new Error("the merged card changed; refresh before undoing");
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    setCard(Contacts, target, request.card);
+    for (let i = 0; i < request.restoreCards.length; i++) createPerson(Contacts, request.restoreCards[i]);
+    Contacts.save();
+    return { ok: true, restored: true, card: describePerson(target),
+      sourceCount: request.restoreCards.length };
+  }
+  if (request.operation === "delete-fallback") {
+    // CNContactStore deletion faults with Cocoa 134092 when a card holds a
+    // damaged stored row; Contacts.app itself can still remove it (verified
+    // live 2026-09-03). Native deletion stays the primary path — the caller
+    // reaches this only after it failed on exact, already-confirmed uids.
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    const doomed = request.personUids.map(function(uid) { return peopleForId(Contacts, uid); });
+    for (let i = 0; i < doomed.length; i++) Contacts.delete(doomed[i]);
+    Contacts.save();
+    return { ok: true, deletedCount: doomed.length };
+  }
+  if (request.operation === "consolidate") {
+    const people = [peopleForId(Contacts, request.targetUid)].concat(
+      request.sourceUids.map(function(uid) { return peopleForId(Contacts, uid); })
+    );
+    for (let i = 0; i < people.length; i++) {
+      if (!sameCard(people[i], request.expectedCards[i]))
+        throw new Error("a selected card changed; refresh before merging");
     }
-  });
-  return { ok: true, available: available };
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    return { ok: true, readyToConsolidate: true, sourceCount: request.sourceUids.length };
+  }
+  if (request.operation === "edit" || request.operation === "delete") {
+    const editable = peopleForId(Contacts, request.personUid);
+    if (!sameCard(editable, request.expectedCard))
+      throw new Error("the selected card changed; refresh before saving");
+    if (Contacts.unsaved())
+      throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+    if (request.operation === "delete") {
+      return { ok: true, readyToDelete: true };
+    }
+    const before = describePerson(editable);
+    try { setCard(Contacts, editable, request.card); Contacts.save(); }
+    catch (error) {
+      try { setCard(Contacts, editable, before); Contacts.save(); } catch (_) { /* original error wins */ }
+      throw error;
+    }
+    return { ok: true, edited: true, card: describePerson(editable) };
+  }
+  const person = peopleForId(Contacts, request.personUid);
+  const current = matchingFields(person, request.kind, request.key);
+
+  if (request.operation === "inspect") {
+    if (current.length < 1) throw new Error("this handle is no longer on the selected card");
+    return { ok: true, fieldCount: current.length, fields: publicFields(current) };
+  }
+
+  if (Contacts.unsaved())
+    throw new Error("Contacts has unsaved changes; finish or discard them on the Mac first");
+
+  if (request.operation === "remove") {
+    if (!sameFieldSet(current, request.fields))
+      throw new Error("the selected card changed; review it again before removing anything");
+    // delete-the-specifier: the remove-from-person event is broken on
+    // current macOS ("Message not understood")
+    for (let i = current.length - 1; i >= 0; i--)
+      Contacts.delete(current[i].specifier);
+    try {
+      Contacts.save();
+    } catch (error) {
+      for (let i = 0; i < request.fields.length; i++) addField(Contacts, person, request.kind, request.fields[i]);
+      try { Contacts.save(); } catch (_) { /* preserve the original failure */ }
+      throw error;
+    }
+    if (matchingFields(person, request.kind, request.key).length !== 0)
+      throw new Error("Contacts did not remove the selected handle");
+    return { ok: true, removed: true, fieldCount: current.length };
+  }
+
+  if (current.length > 0)
+    return { ok: true, restored: true, alreadyPresent: true, fieldCount: current.length };
+  for (let i = 0; i < request.fields.length; i++) addField(Contacts, person, request.kind, request.fields[i]);
+  Contacts.save();
+  const restored = matchingFields(person, request.kind, request.key);
+  if (restored.length < 1) throw new Error("Contacts did not restore the selected handle");
+  return { ok: true, restored: true, alreadyPresent: false, fieldCount: restored.length };
 }
 
 function run() {
@@ -77,7 +624,7 @@ function run() {
   } catch (error) {
     const message = String(error && error.message ? error.message : error)
       .replace(UNSAFE, " ").replace(/\s+/g, " ").trim().slice(0, 180)
-      || "Contacts availability check failed";
+      || "Contacts repair failed";
     return JSON.stringify({ ok: false, error: message });
   }
 }

--- a/bridge/mac/contacts
+++ b/bridge/mac/contacts
@@ -11,10 +11,9 @@ Subcommands:
   find <query> [N], substring search across name/org/phone/email
   lookup <phone-or-email>, resolve to a contact (best-effort match);
                                 exit 0 + name on stdout, exit 1 if no match
-  resolve, bounded JSON identity resolver over stdin. Read-only:
-                                candidate lookup, a store fingerprint, a bulk
-                                handle audit, and opening one matching card
-                                in Contacts.app
+  resolve, bounded JSON identity resolver over stdin. Supports candidate
+                                lookup, opening one matching card, and an
+                                explicitly gated field-only repair with undo
   dump [--json], full dump of every contact
   sources, list configured Contacts sources
 
@@ -37,6 +36,7 @@ import json
 import os
 import plistlib
 import re
+import secrets
 import selectors
 import sqlite3
 import stat
@@ -64,9 +64,20 @@ MAX_REPAIR_FIELDS = 8
 MAX_AUDIT_HANDLES = 200
 MAX_REPAIR_INPUT_BYTES = 48 * 1024
 MAX_REPAIR_PROCESS_BYTES = 48 * 1024
+MAX_VCARD_BYTES = 2 * 1024 * 1024
+MAX_VCARD_RESPONSE_BYTES = 3 * 1024 * 1024
+MAX_UNDO_BYTES = 48 * 1024
 REPAIR_TIMEOUT_SECONDS = 25
+WRITE_GATE = os.path.expanduser("~/.blip/contact-writes-enabled")
+UNDO_DIR = os.path.expanduser("~/.blip/contact-undo")
+UNDO_FILE = "latest.json"
+UNDO_TTL_SECONDS = 7 * 24 * 60 * 60
 _UNSAFE_TEXT = re.compile(r"[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]")
 _CONTACT_TOKEN = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_REVISION = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_PLAN_HASH = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_UNDO_TOKEN = re.compile(r"undo:[0-9a-f]{32}\Z")
+_PERSON_UID = re.compile(r"[A-Za-z0-9._:-]{1,200}\Z")
 
 _ACCOUNTS_DB = os.path.expanduser("~/Library/Accounts/Accounts4.sqlite")
 
@@ -529,6 +540,219 @@ def selected_card(handle: object, token: object) -> tuple[str, str, dict, dict, 
     raise ValueError("the selected contact card is no longer a candidate")
 
 
+def selected_candidate(handle: object, token: object) -> tuple[str, str, dict, list[dict]]:
+    """Freshly resolve one candidate token and its ordered active cards."""
+    token_text = clean_text(token, 80)
+    if not _CONTACT_TOKEN.fullmatch(token_text):
+        raise ValueError("the selected contact token is invalid")
+    original, candidates, by_name = contact_candidates(handle)
+    _, key, _ = normalize_resolve_handle(original)
+    candidate = next((item for item in candidates if item["token"] == token_text), None)
+    if candidate is None:
+        raise ValueError("the selected contact is no longer a candidate")
+    # contact_candidates already ordered these to match candidate["cards"]
+    # (largest account first); re-sorting here would de-align the two lists
+    # that are consumed positionally together.
+    records = list(by_name[candidate["name"].casefold()])
+    if len(records) != candidate["recordCount"]:
+        raise RuntimeError("Contacts returned inconsistent candidate cards")
+    return original, key, candidate, records
+
+
+def selected_candidate_pair(
+    handle: object, token: object, other_token: object,
+) -> tuple[str, str, dict, list[dict]]:
+    """Explicitly combine TWO named candidates into one merge scope.
+
+    A person can appear under two names on one handle (a married-name change
+    is the common case). Cross-name consolidation is available only when the
+    caller presents BOTH owner tokens — nothing is ever guessed — and the
+    combined cards are renumbered over the union so account numbers stay
+    unique. Everything downstream (revisions, plan hash, undo receipt) works
+    on exact card tokens and is name-agnostic.
+    """
+    other_text = clean_text(other_token, 80)
+    if not _CONTACT_TOKEN.fullmatch(other_text):
+        raise ValueError("the other contact token is invalid")
+    original, key, candidate, records = selected_candidate(handle, token)
+    if candidate["token"] == other_text:
+        raise ValueError("the other person must be a different candidate")
+    _, _, other, other_records = selected_candidate(handle, other_text)
+    paired = []
+    for cand, recs in ((candidate, records), (other, other_records)):
+        for index, record in enumerate(recs):
+            paired.append((record, dict(cand["cards"][index])))
+    # The union follows the same global account order as every other view
+    # (largest store first), not selected-person-first; the stable sort keeps
+    # each person's internal card order within a source.
+    rank = {source_identifier(path): position
+            for position, path in enumerate(bounded_source_dbs())}
+    paired.sort(key=lambda item: rank.get(item[0]["source"], len(rank)))
+    combined_sources: dict[str, int] = {}
+    for record, _ in paired:
+        combined_sources.setdefault(record["source"], len(combined_sources) + 1)
+    cards = []
+    ordered_records = []
+    for record, card in paired:
+        card["accountNumber"] = combined_sources[record["source"]]
+        cards.append(card)
+        ordered_records.append(record)
+    combined = dict(candidate)
+    combined["recordCount"] = len(ordered_records)
+    combined["sourceCount"] = len(combined_sources)
+    combined["cards"] = cards
+    return original, key, combined, ordered_records
+
+
+def selected_candidate_from_unique_handle(
+    handle: object,
+) -> tuple[str, str, dict, list[dict]]:
+    """Resolve only when one person owns the handle; never guess for vCard export."""
+    original, candidates, by_name = contact_candidates(handle)
+    if not candidates:
+        raise ValueError("no Mac contact matches this conversation")
+    if len(candidates) != 1:
+        raise ValueError("more than one person matches this handle; use Edit contact to choose one")
+    _, key, _ = normalize_resolve_handle(original)
+    candidate = candidates[0]
+    records = list(by_name[candidate["name"].casefold()])
+    if len(records) != candidate["recordCount"]:
+        raise RuntimeError("Contacts returned inconsistent candidate cards")
+    return original, key, candidate, records
+
+
+def write_gate_enabled() -> bool:
+    """The restricted SSH key gains write authority only through this Mac-local gate."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(WRITE_GATE, flags)
+    except OSError:
+        return False
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_size > 64:
+            return False
+        if info.st_mode & 0o077:
+            return False
+        data = os.read(fd, 65)
+        return data == b"enabled-v1\n"
+    finally:
+        os.close(fd)
+
+
+def require_write_gate() -> None:
+    if not write_gate_enabled():
+        raise PermissionError(
+            "Mac contact writes are disabled; enable Blip's owner-only contact-writes gate first"
+        )
+
+
+def private_directory(path: str) -> int:
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    info = os.fstat(fd)
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid():
+        os.close(fd)
+        raise RuntimeError("contact undo directory is unsafe")
+    if info.st_mode & 0o077:
+        os.fchmod(fd, 0o700)
+    return fd
+
+
+def write_undo_receipt(receipt: dict) -> str:
+    token = "undo:" + secrets.token_hex(16)
+    value = {"version": 1, "token": token, "created": int(time.time()), **receipt}
+    data = (json.dumps(value, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+    if len(data) > MAX_UNDO_BYTES:
+        raise RuntimeError("contact undo receipt is too large")
+    directory = private_directory(UNDO_DIR)
+    temp = ".latest." + secrets.token_hex(8)
+    fd = -1
+    published = False
+    try:
+        fd = os.open(
+            temp,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=directory,
+        )
+        offset = 0
+        while offset < len(data):
+            offset += os.write(fd, data[offset:])
+        os.fchmod(fd, 0o600)
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        try:
+            target = os.stat(UNDO_FILE, dir_fd=directory, follow_symlinks=False)
+            if not stat.S_ISREG(target.st_mode) or target.st_uid != os.getuid():
+                raise RuntimeError("contact undo receipt target is unsafe")
+        except FileNotFoundError:
+            pass
+        os.replace(temp, UNDO_FILE, src_dir_fd=directory, dst_dir_fd=directory)
+        published = True
+        os.fsync(directory)
+        return token
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if not published:
+            try:
+                os.unlink(temp, dir_fd=directory)
+            except OSError:
+                pass
+        os.close(directory)
+
+
+def read_undo_receipt(token: object) -> dict:
+    token_text = clean_text(token, 40)
+    if not _UNDO_TOKEN.fullmatch(token_text):
+        raise ValueError("undo token is invalid")
+    directory = private_directory(UNDO_DIR)
+    fd = -1
+    try:
+        fd = os.open(
+            UNDO_FILE,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=directory,
+        )
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_size > MAX_UNDO_BYTES:
+            raise RuntimeError("contact undo receipt is unsafe")
+        if info.st_mode & 0o077:
+            raise RuntimeError("contact undo receipt permissions are unsafe")
+        raw = os.read(fd, MAX_UNDO_BYTES + 1)
+        if len(raw) > MAX_UNDO_BYTES:
+            raise RuntimeError("contact undo receipt is too large")
+        try:
+            value = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise RuntimeError("contact undo receipt is invalid")
+        if not isinstance(value, dict) or value.get("version") != 1 or value.get("token") != token_text:
+            raise ValueError("this undo action is no longer available")
+        created = value.get("created")
+        if not isinstance(created, int) or time.time() - created > UNDO_TTL_SECONDS:
+            raise ValueError("this contact undo action has expired")
+        return value
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        os.close(directory)
+
+
+def clear_undo_receipt(token: str) -> None:
+    # Re-read through the pinned descriptor before deleting so an old UI token
+    # cannot remove a newer receipt.
+    read_undo_receipt(token)
+    directory = private_directory(UNDO_DIR)
+    try:
+        os.unlink(UNDO_FILE, dir_fd=directory)
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
 def run_bounded_process(
     argv: list[str], payload: bytes, output_limit: int = MAX_REPAIR_PROCESS_BYTES,
 ) -> tuple[int, bytes, bytes]:
@@ -603,6 +827,136 @@ def run_contact_repair(request: dict) -> dict:
     return response
 
 
+class NativeMutationError(RuntimeError):
+    """A contact-delete failure carrying the machine-readable stage, so the
+    caller can pick a recovery path without parsing the human message."""
+
+    def __init__(self, message: str, stage: str = ""):
+        super().__init__(message)
+        self.stage = stage
+
+
+def run_native_contact_mutation(
+    request: dict, output_limit: int = MAX_REPAIR_PROCESS_BYTES,
+) -> dict:
+    helper = os.path.join(os.path.dirname(os.path.realpath(__file__)), "contact-delete")
+    # install.sh skips compiling the helper when swiftc is absent; say so
+    # plainly instead of surfacing a stat traceback.
+    try:
+        info = os.lstat(helper)
+    except FileNotFoundError:
+        raise RuntimeError(
+            "the compiled Contacts helper is not installed — install Xcode "
+            "Command Line Tools on the Mac and re-run bridge/mac/install.sh"
+        ) from None
+    if (not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode)
+            or info.st_uid != os.getuid() or info.st_mode & 0o022):
+        raise RuntimeError("Contacts deletion helper is unsafe")
+    payload = json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(payload) > MAX_REPAIR_INPUT_BYTES:
+        raise RuntimeError("Contacts deletion request is too large")
+    code, stdout, stderr = run_bounded_process([helper], payload, output_limit=output_limit)
+    try:
+        response = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        message = clean_text(stderr.decode("utf-8", "replace"), 180)
+        raise RuntimeError(message or "Contacts deletion returned invalid data")
+    if code != 0 or not isinstance(response, dict) or response.get("ok") is not True:
+        message = (clean_text(response.get("error") if isinstance(response, dict) else "", 180)
+                   or "Contacts deletion failed")
+        stage = clean_text(response.get("stage") if isinstance(response, dict) else "", 40)
+        raise NativeMutationError(message, stage)
+    return response
+
+
+def run_contact_delete(person_uids: list[str]) -> dict:
+    if (not 1 <= len(person_uids) <= 7 or len(set(person_uids)) != len(person_uids)
+            or any(not _PERSON_UID.fullmatch(uid) for uid in person_uids)):
+        raise RuntimeError("Contacts deletion card list is invalid")
+    response = run_native_contact_mutation({
+        "operation": "delete", "personUids": person_uids,
+    })
+    if response.get("deletedCount") != len(person_uids):
+        raise RuntimeError("Contacts did not confirm every source-card deletion")
+    return response
+
+
+def run_contact_update(target_uid: str, draft: dict) -> dict:
+    if not _PERSON_UID.fullmatch(target_uid):
+        raise RuntimeError("Contacts update card id is invalid")
+    response = run_native_contact_mutation({
+        "operation": "update", "targetUid": target_uid,
+        "card": validated_card_draft(draft),
+    })
+    if response.get("updated") is not True:
+        raise RuntimeError("Contacts did not confirm the card update")
+    return response
+
+
+def run_contact_consolidation(target_uid: str, source_uids: list[str], draft: dict) -> dict:
+    if (not _PERSON_UID.fullmatch(target_uid) or not 1 <= len(source_uids) <= 7
+            or len(set(source_uids)) != len(source_uids) or target_uid in source_uids
+            or any(not _PERSON_UID.fullmatch(uid) for uid in source_uids)):
+        raise RuntimeError("Contacts consolidation card list is invalid")
+    response = run_native_contact_mutation({
+        "operation": "consolidate", "targetUid": target_uid,
+        "sourceUids": source_uids, "card": validated_card_draft(draft),
+    })
+    if response.get("updated") is not True or response.get("deletedCount") != len(source_uids):
+        raise RuntimeError("Contacts did not confirm the card consolidation")
+    return response
+
+
+def merged_contact_draft(details: list[dict]) -> dict:
+    """Build one deterministic export card without mutating any source card."""
+    if not details:
+        raise RuntimeError("Contacts returned no card details")
+    result = card_draft(details[0])
+    scalar_keys = (
+        "firstName", "middleName", "lastName", "nickname", "organization",
+        "department", "jobTitle", "birthday",
+    )
+    for key in scalar_keys:
+        if result[key]:
+            continue
+        result[key] = next((detail[key] for detail in details if detail[key]), "")
+    # Notes are deliberately target-only, matching consolidation semantics.
+    for key in ("phones", "emails", "urls", "addresses"):
+        combined = []
+        seen = set()
+        for detail in details:
+            for item in detail[key]:
+                if key == "addresses":
+                    identity = tuple(str(item.get(field, "")).casefold() for field in (
+                        "street", "city", "state", "postalCode", "country", "countryCode",
+                    ))
+                else:
+                    identity = str(item.get("value", "")).casefold()
+                empty_identity = not any(identity) if isinstance(identity, tuple) else not identity
+                if empty_identity:
+                    continue
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                combined.append(item)
+        result[key] = combined
+    return validated_card_draft(result)
+
+
+def contact_vcard(handle: object) -> dict:
+    original, _, candidate, records = selected_candidate_from_unique_handle(handle)
+    details = describe_records(records)
+    draft = merged_contact_draft(details)
+    response = run_native_contact_mutation({
+        "operation": "vcard", "targetUid": records[0]["uid"], "card": draft,
+    }, MAX_VCARD_RESPONSE_BYTES)
+    encoded = response.get("vcard")
+    name = clean_text(response.get("name") or candidate["name"], MAX_NAME_CHARS)
+    if not isinstance(encoded, str) or not encoded or len(encoded) > MAX_VCARD_RESPONSE_BYTES:
+        raise RuntimeError("Contacts returned an invalid vCard")
+    return {"handle": original, "name": name, "vcard": encoded}
+
+
 def active_record_uids(records: list[dict]) -> set[str]:
     """Cards addressable through Contacts, excluding inactive account caches."""
     uids = list(dict.fromkeys(clean_text(record.get("uid"), 200) for record in records))
@@ -622,9 +976,777 @@ def active_record_uids(records: list[dict]) -> set[str]:
     return accepted
 
 
+def optional_contact_text(value: object, label: str, maximum: int) -> str:
+    if not isinstance(value, str) or len(value) > maximum:
+        raise RuntimeError(f"Contacts returned an invalid {label}")
+    return clean_text(value, maximum)
+
+
+def validated_labeled_values(value: object, label: str) -> list[dict]:
+    if not isinstance(value, list) or len(value) > 16:
+        raise RuntimeError(f"Contacts returned an invalid {label} list")
+    result = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise RuntimeError(f"Contacts returned an invalid {label}")
+        item_value = optional_contact_text(item.get("value"), f"{label} value", 320)
+        item_label = optional_contact_text(item.get("label"), f"{label} label", 80)
+        if not item_value:
+            raise RuntimeError(f"Contacts returned an empty {label}")
+        result.append({"label": item_label, "value": item_value})
+    return result
+
+
+def validated_addresses(value: object) -> list[dict]:
+    if not isinstance(value, list) or len(value) > 16:
+        raise RuntimeError("Contacts returned an invalid address list")
+    limits = {
+        "label": 80, "street": 320, "city": 320, "state": 320,
+        "postalCode": 80, "country": 160, "countryCode": 8,
+    }
+    result = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise RuntimeError("Contacts returned an invalid address")
+        address = {
+            key: optional_contact_text(item.get(key), f"address {key}", maximum)
+            for key, maximum in limits.items()
+        }
+        if not any(address[key] for key in limits if key != "label"):
+            raise RuntimeError("Contacts returned an empty address")
+        result.append(address)
+    return result
+
+
+def validated_card_detail(value: object) -> dict:
+    if not isinstance(value, dict):
+        raise RuntimeError("Contacts returned an invalid card detail")
+    scalar_limits = {
+        "displayName": 160, "firstName": 160, "middleName": 160,
+        "lastName": 160, "nickname": 160, "organization": 320,
+        "department": 320, "jobTitle": 320, "birthday": 10, "note": 1000,
+    }
+    detail = {
+        key: optional_contact_text(value.get(key), key, maximum)
+        for key, maximum in scalar_limits.items()
+    }
+    if detail["birthday"] and not re.fullmatch(r"(?:[0-9]{4}-|--)[0-9]{2}-[0-9]{2}", detail["birthday"]):
+        raise RuntimeError("Contacts returned an invalid birthday")
+    detail["phones"] = validated_labeled_values(value.get("phones"), "phone")
+    detail["emails"] = validated_labeled_values(value.get("emails"), "email")
+    detail["urls"] = validated_labeled_values(value.get("urls"), "URL")
+    detail["addresses"] = validated_addresses(value.get("addresses"))
+    return detail
+
+
+def card_draft(detail: dict) -> dict:
+    """The writable subset of a described card; displayName is Contacts-derived."""
+    return {key: value for key, value in detail.items() if key != "displayName"}
+
+
+def validated_card_draft(value: object) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError("contact card draft is invalid")
+    # Reuse the strict detail validator with a derived-only placeholder.
+    draft = card_draft(validated_card_detail({"displayName": "", **value}))
+    if not any(draft[key] for key in ("firstName", "lastName", "nickname", "organization")):
+        raise ValueError("contact card needs a name, nickname, or organization")
+    return draft
+
+
+def card_revision(detail: dict) -> str:
+    payload = json.dumps(detail, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(
+        b"blip-contact-revision-v1\0" + payload.encode("utf-8")
+    ).hexdigest()
+
+
+def require_revision(value: object) -> str:
+    revision = clean_text(value, 80)
+    if not _REVISION.fullmatch(revision):
+        raise ValueError("contact card revision is invalid")
+    return revision
+
+
+def require_plan_hash(value: object) -> str:
+    plan = clean_text(value, 80)
+    if not _PLAN_HASH.fullmatch(plan):
+        raise ValueError("contact mutation plan is invalid")
+    return plan
+
+
+def mutation_plan_hash(action: str, value: dict) -> str:
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(
+        b"blip-contact-mutation-v1\0" + action.encode("ascii") + b"\0" + payload.encode("utf-8")
+    ).hexdigest()
+
+
+def native_collection_counts(person_uids: list[str]) -> dict[str, tuple[int, int, int, int]]:
+    """Fresh CNContactStore collection sizes per card — the authority the
+    Contacts.app describe view is checked against."""
+    response = run_native_contact_mutation({"operation": "counts", "personUids": person_uids})
+    raw = response.get("counts")
+    if not isinstance(raw, list) or len(raw) != len(person_uids):
+        raise RuntimeError("Contacts returned invalid card counts")
+    result: dict[str, tuple[int, int, int, int]] = {}
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise RuntimeError("Contacts returned invalid card counts")
+        uid = clean_text(entry.get("uid"), 200)
+        sizes = tuple(entry.get(key) for key in ("phones", "emails", "urls", "addresses"))
+        if uid == "" or not all(isinstance(size, int) and 0 <= size <= 64 for size in sizes):
+            raise RuntimeError("Contacts returned invalid card counts")
+        result[uid] = sizes  # type: ignore[assignment]
+    return result
+
+
+def describe_records(records: list[dict]) -> list[dict]:
+    """Describe cards via Contacts.app, cross-checked against CNContactStore.
+
+    The app process is long-lived and its person objects go STALE after
+    external store mutations — right after a merge it can report a card's
+    collections as empty while the scalars still read (seen live 2026-09-03;
+    an editor seeded from that view would draft field deletions). Retry the
+    describe until the app's collection sizes agree with the store, and fail
+    honestly if the view never settles.
+    """
+    if not 1 <= len(records) <= 8:
+        raise ValueError("card details require between one and eight active cards")
+    uids = [record["uid"] for record in records]
+    expected = native_collection_counts(uids)
+    details: list[dict] = []
+    for attempt in range(6):
+        if attempt:
+            time.sleep(0.5)
+        result = run_contact_repair({"operation": "describe", "personUids": uids})
+        raw_cards = result.get("cards")
+        if not isinstance(raw_cards, list) or len(raw_cards) != len(records):
+            raise RuntimeError("Contacts returned an invalid card description")
+        details = [validated_card_detail(raw) for raw in raw_cards]
+        if all(
+            (len(detail["phones"]), len(detail["emails"]),
+             len(detail["urls"]), len(detail["addresses"])) == expected.get(uid)
+            for uid, detail in zip(uids, details)
+        ):
+            return details
+    raise RuntimeError(
+        "Contacts.app is showing stale card data; give it a moment and try again")
+
+
+def same_card_content(left: dict, right: dict) -> bool:
+    """Field-for-field draft equality that ignores collection ORDER.
+
+    The native writer reuses a card's existing rows and appends additions, so
+    a merged card legitimately reads back with the same values in a different
+    sequence than the reviewed draft listed them (seen live 2026-09-03: a
+    two-email merge applied perfectly and still failed the byte-identical
+    check). The reviewed plan's contract is the content, not the sequence.
+    """
+    def canonical(detail: dict) -> dict:
+        result = {key: value for key, value in detail.items() if key != "displayName"}
+        for key in ("phones", "emails", "urls", "addresses"):
+            result[key] = sorted(
+                detail.get(key) or [],
+                key=lambda item: json.dumps(item, sort_keys=True, ensure_ascii=False),
+            )
+        return result
+    return canonical(left) == canonical(right)
+
+
+def settled_card_detail(uid: str, draft: dict) -> dict:
+    """Read a just-saved card back, tolerating Contacts.app's stale view.
+
+    Saves go through CNContactStore, but describe goes through Contacts.app,
+    whose in-memory people refresh asynchronously — an immediate read-back can
+    still show the pre-save card (verified live: a merged card that "failed"
+    verification matched the draft exactly one poll later). Poll briefly for
+    the saved draft; return the last view so the caller's equality check still
+    decides.
+    """
+    detail = None
+    last_error: Exception | None = None
+    for attempt in range(10):
+        if attempt:
+            time.sleep(0.6)
+        try:
+            detail = validated_card_detail(describe_records([{"uid": uid}])[0])
+        except (RuntimeError, ValueError) as error:
+            last_error = error
+            continue
+        if same_card_content(card_draft(detail), draft):
+            return detail
+    if detail is None:
+        raise last_error if last_error is not None else RuntimeError(
+            "Contacts returned no card details")
+    return detail
+
+
+def owned_card(
+    handle: object, owner_token: object, token: object
+) -> tuple[str, str, dict, list[dict], dict, int, int]:
+    """Resolve a card only within the selected person's current active source cards."""
+    original, key, candidate, records = selected_candidate(handle, owner_token)
+    token_text = clean_text(token, 80)
+    if not _CONTACT_TOKEN.fullmatch(token_text):
+        raise ValueError("the selected card token is invalid")
+    for index, record in enumerate(records):
+        if card_token(key, record["source"], record["uid"]) == token_text:
+            return (
+                original, key, candidate, records, record, index + 1,
+                candidate["cards"][index]["accountNumber"],
+            )
+    raise ValueError("the selected card is no longer part of this contact")
+
+
+def changed_card_fields(before: dict, after: dict) -> list[str]:
+    labels = {
+        "firstName": "first name", "middleName": "middle name", "lastName": "last name",
+        "nickname": "nickname", "organization": "organization", "department": "department",
+        "jobTitle": "job title", "birthday": "birthday", "note": "notes",
+        "phones": "phone numbers", "emails": "email addresses", "urls": "websites",
+        "addresses": "postal addresses",
+    }
+    return [labels[key] for key in labels if before.get(key) != after.get(key)]
+
+
+def contact_collections_changed(before: dict, after: dict) -> bool:
+    return any(before.get(key) != after.get(key) for key in (
+        "phones", "emails", "urls", "addresses",
+    ))
+
+
+def mutation_metadata(
+    action: str, original: str, candidate: dict, card_number: int, account_number: int,
+    source_name: str, changed: list[str], plan_hash: str, source_count: int = 0,
+) -> dict:
+    return {
+        "action": action, "handle": original, "name": candidate["name"],
+        "cardNumber": card_number, "cardCount": candidate["recordCount"],
+        "accountNumber": account_number, "sourceName": source_name,
+        "sourceCardCount": source_count,
+        "changedFields": changed, "planHash": plan_hash,
+        "writeEnabled": write_gate_enabled(),
+    }
+
+
+def compare_candidate(handle: object, owner_token: object,
+                      other_owner_token: object = None) -> dict:
+    if other_owner_token:
+        original, key, candidate, records = selected_candidate_pair(
+            handle, owner_token, other_owner_token)
+    else:
+        original, key, candidate, records = selected_candidate(handle, owner_token)
+    if not 1 <= len(records) <= 8:
+        raise ValueError("contact management requires between one and eight active cards")
+    details = describe_records(records)
+    cards = []
+    for index, (record, detail) in enumerate(zip(records, details)):
+        cards.append({
+            "token": card_token(key, record["source"], record["uid"]),
+            "revision": card_revision(detail),
+            "cardNumber": index + 1,
+            "accountNumber": candidate["cards"][index]["accountNumber"],
+            "sourceName": candidate["cards"][index]["sourceName"],
+            "hasPhoto": record["photo"],
+            **detail,
+        })
+    return {
+        "handle": original, "name": candidate["name"], "cardCount": len(cards),
+        "sourceCount": candidate["sourceCount"], "writeEnabled": write_gate_enabled(),
+        "cards": cards,
+    }
+
+
+def prepare_card_edit(
+    handle: object, owner_token: object, token: object, revision: object, draft_value: object
+) -> tuple[dict, dict]:
+    original, _, candidate, _, record, number, account = owned_card(handle, owner_token, token)
+    before = describe_records([record])[0]
+    expected = require_revision(revision)
+    if card_revision(before) != expected:
+        raise ValueError("this card changed on the Mac; refresh before saving")
+    draft = validated_card_draft(draft_value)
+    changed = changed_card_fields(card_draft(before), draft)
+    if not changed:
+        raise ValueError("this draft does not change the contact card")
+    public_plan = {
+        "token": clean_text(token, 80), "revision": expected, "card": draft,
+    }
+    plan_hash = mutation_plan_hash("edit", public_plan)
+    preview = mutation_metadata(
+        "edit", original, candidate, number, account,
+        candidate["cards"][number - 1]["sourceName"], changed, plan_hash,
+    )
+    private = {
+        "personUid": record["uid"], "before": before, "after": draft,
+        "handle": original, "name": candidate["name"], "cardToken": clean_text(token, 80),
+        "planHash": plan_hash,
+    }
+    return preview, private
+
+
+def apply_card_edit(
+    handle: object, owner_token: object, token: object, revision: object,
+    draft_value: object, expected_plan: object,
+) -> dict:
+    require_write_gate()
+    preview, private = prepare_card_edit(handle, owner_token, token, revision, draft_value)
+    if preview["planHash"] != require_plan_hash(expected_plan):
+        raise ValueError("the contact edit changed; preview it again before saving")
+    native_update = contact_collections_changed(private["before"], private["after"])
+    if native_update and private["before"]["note"] != private["after"]["note"]:
+        raise ValueError(
+            "save contact notes separately from phone, email, website, or address changes"
+        )
+    undo_token = write_undo_receipt({"action": "edit", **private})
+    if native_update:
+        run_contact_update(private["personUid"], private["after"])
+        after = settled_card_detail(private["personUid"], private["after"])
+    else:
+        result = run_contact_repair({
+            "operation": "edit", "personUid": private["personUid"],
+            "expectedCard": private["before"], "card": private["after"],
+        })
+        if result.get("edited") is not True:
+            raise RuntimeError("Contacts did not confirm the card edit")
+        after = validated_card_detail(result.get("card"))
+    if not same_card_content(card_draft(after), private["after"]):
+        raise RuntimeError("Contacts changed the contact card while saving it")
+    return {
+        **preview, "applied": True, "undoToken": undo_token,
+        "revision": card_revision(after), "displayName": after["displayName"],
+    }
+
+
+def prepare_card_delete(
+    handle: object, owner_token: object, token: object, revision: object
+) -> tuple[dict, dict]:
+    original, _, candidate, _, record, number, account = owned_card(handle, owner_token, token)
+    before = describe_records([record])[0]
+    expected = require_revision(revision)
+    if card_revision(before) != expected:
+        raise ValueError("this card changed on the Mac; refresh before deleting")
+    public_plan = {"token": clean_text(token, 80), "revision": expected}
+    plan_hash = mutation_plan_hash("delete", public_plan)
+    preview = mutation_metadata(
+        "delete", original, candidate, number, account,
+        candidate["cards"][number - 1]["sourceName"], ["entire source card"], plan_hash,
+    )
+    private = {
+        "personUid": record["uid"], "before": before, "handle": original,
+        "name": candidate["name"], "cardToken": clean_text(token, 80), "planHash": plan_hash,
+    }
+    return preview, private
+
+
+def apply_card_delete(
+    handle: object, owner_token: object, token: object, revision: object, expected_plan: object
+) -> dict:
+    require_write_gate()
+    preview, private = prepare_card_delete(handle, owner_token, token, revision)
+    if preview["planHash"] != require_plan_hash(expected_plan):
+        raise ValueError("the contact deletion changed; preview it again")
+    result = run_contact_repair({
+        "operation": "delete", "personUid": private["personUid"],
+        "expectedCard": private["before"],
+    })
+    if result.get("readyToDelete") is not True:
+        raise RuntimeError("Contacts did not confirm the deletion preflight")
+    undo_token = write_undo_receipt({"action": "delete", **private})
+    run_contact_delete([private["personUid"]])
+    return {**preview, "applied": True, "undoToken": undo_token}
+
+
+def prepare_consolidation(
+    handle: object, owner_token: object, target_token: object,
+    revisions_value: object, draft_value: object, other_owner_token: object = None,
+) -> tuple[dict, dict]:
+    if other_owner_token:
+        original, key, candidate, records = selected_candidate_pair(
+            handle, owner_token, other_owner_token)
+    else:
+        original, key, candidate, records = selected_candidate(handle, owner_token)
+    if not 2 <= len(records) <= 8:
+        raise ValueError("consolidation requires between two and eight active cards")
+    if not isinstance(revisions_value, list) or len(revisions_value) != len(records):
+        raise ValueError("contact card revision list is invalid")
+    supplied = {}
+    for item in revisions_value:
+        if not isinstance(item, dict):
+            raise ValueError("contact card revision is invalid")
+        token = clean_text(item.get("token"), 80)
+        revision = require_revision(item.get("revision"))
+        if not _CONTACT_TOKEN.fullmatch(token) or token in supplied:
+            raise ValueError("contact card revision is invalid")
+        supplied[token] = revision
+    details = describe_records(records)
+    entries = []
+    for index, (record, detail) in enumerate(zip(records, details)):
+        token = card_token(key, record["source"], record["uid"])
+        if supplied.get(token) != card_revision(detail):
+            raise ValueError("a source card changed on the Mac; refresh before merging")
+        entries.append({"token": token, "record": record, "detail": detail, "index": index})
+    target_text = clean_text(target_token, 80)
+    target = next((entry for entry in entries if entry["token"] == target_text), None)
+    if target is None:
+        raise ValueError("the merge target is no longer part of this contact")
+    draft = validated_card_draft(draft_value)
+    changed = changed_card_fields(card_draft(target["detail"]), draft)
+    if not changed:
+        changed = ["source-card consolidation"]
+    public_plan = {
+        "targetToken": target_text,
+        "revisions": [{"token": entry["token"], "revision": supplied[entry["token"]]}
+                      for entry in entries],
+        "card": draft,
+    }
+    plan_hash = mutation_plan_hash("consolidate", public_plan)
+    preview = mutation_metadata(
+        "consolidate", original, candidate, target["index"] + 1,
+        candidate["cards"][target["index"]]["accountNumber"],
+        candidate["cards"][target["index"]]["sourceName"], changed, plan_hash,
+        len(entries) - 1,
+    )
+    sources = [entry for entry in entries if entry is not target]
+    private = {
+        "targetUid": target["record"]["uid"], "targetBefore": target["detail"],
+        "targetAfter": draft, "sources": [
+            {"personUid": entry["record"]["uid"], "card": entry["detail"]} for entry in sources
+        ],
+        "handle": original, "name": candidate["name"], "planHash": plan_hash,
+    }
+    return preview, private
+
+
+def recover_consolidation_via_contacts_app(private: dict, error: NativeMutationError) -> None:
+    """Finish an approved consolidation through Contacts.app when the native
+    store path faults.
+
+    CNContactStore fails with Cocoa 134092 ("Unhandled error occurred during
+    faulting") on cards holding a damaged stored row — persistently, for any
+    real write — while Contacts.app's own write path still succeeds (verified
+    live 2026-09-03 on two real synced cards). The plan being recovered is the
+    exact reviewed one: the survivor draft is revalidated against the card's
+    current state, and only the already-confirmed source uids are removed.
+    """
+    if error.stage not in ("update contact", "update survivor",
+                           "save same-account merge", "delete sources"):
+        raise error
+    if error.stage != "delete sources":
+        current = validated_card_detail(
+            describe_records([{"uid": private["targetUid"]}])[0])
+        if card_draft(current) != private["targetAfter"]:
+            edited = run_contact_repair({
+                "operation": "edit", "personUid": private["targetUid"],
+                "expectedCard": current, "card": private["targetAfter"],
+            })
+            if edited.get("edited") is not True:
+                raise error
+    remaining = [source["personUid"] for source in private["sources"]]
+    try:
+        run_contact_delete(remaining)
+        return
+    except RuntimeError:
+        pass
+    removed = run_contact_repair({
+        "operation": "delete-fallback", "personUids": remaining,
+    })
+    if removed.get("deletedCount") != len(remaining):
+        raise error
+
+
+def apply_consolidation(
+    handle: object, owner_token: object, target_token: object, revisions: object,
+    draft: object, expected_plan: object, other_owner_token: object = None,
+) -> dict:
+    require_write_gate()
+    preview, private = prepare_consolidation(
+        handle, owner_token, target_token, revisions, draft, other_owner_token,
+    )
+    if preview["planHash"] != require_plan_hash(expected_plan):
+        raise ValueError("the merge plan changed; preview it again")
+    if private["targetBefore"]["note"] != private["targetAfter"]["note"]:
+        raise ValueError(
+            "contact notes cannot be changed during consolidation; keep the target note, "
+            "then edit it after the merge"
+        )
+    result = run_contact_repair({
+        "operation": "consolidate", "targetUid": private["targetUid"],
+        "sourceUids": [source["personUid"] for source in private["sources"]],
+        "expectedCards": [private["targetBefore"]]
+            + [source["card"] for source in private["sources"]],
+        "card": private["targetAfter"],
+    })
+    if (result.get("readyToConsolidate") is not True
+            or result.get("sourceCount") != len(private["sources"])):
+        raise RuntimeError("Contacts did not confirm the consolidation preflight")
+    undo_token = write_undo_receipt({"action": "consolidate", **private})
+    # The native helper saves and verifies the survivor before deleting source
+    # cards. For cross-account merges it issues one deletion request per source
+    # container, avoiding the CNSaveRequest cross-store failure.
+    try:
+        run_contact_consolidation(
+            private["targetUid"],
+            [source["personUid"] for source in private["sources"]],
+            private["targetAfter"],
+        )
+    except NativeMutationError as error:
+        recover_consolidation_via_contacts_app(private, error)
+    updated_card = settled_card_detail(private["targetUid"], private["targetAfter"])
+    if not same_card_content(card_draft(updated_card), private["targetAfter"]):
+        raise RuntimeError("Contacts changed the merged card while saving it")
+    after = updated_card
+    return {
+        **preview, "applied": True, "undoToken": undo_token,
+        "revision": card_revision(after), "displayName": after["displayName"],
+    }
+
+
+def run_contact_link(operation: str, records: list[dict], expected_action: object = "") -> dict:
+    if operation not in ("prepare", "link"):
+        raise ValueError("invalid contact link operation")
+    allowed = ("Link Selected Cards", "Merge Selected Cards", "Merge and Link Selected Cards")
+    expected = clean_text(expected_action, 80)
+    if operation == "link" and expected not in allowed:
+        raise ValueError("the confirmed Contacts action is invalid")
+    if operation == "prepare" and expected:
+        raise ValueError("a link preview cannot include an expected action")
+    if not 2 <= len(records) <= 8:
+        raise ValueError("linking requires between two and eight active cards")
+    uids = [clean_text(record.get("uid"), 200) for record in records]
+    if any(not _PERSON_UID.fullmatch(uid) for uid in uids) or len(set(uids)) != len(uids):
+        raise RuntimeError("Contacts returned an unsafe card identifier")
+    script = os.path.join(os.path.dirname(os.path.realpath(__file__)), "contact-link.applescript")
+    info = os.lstat(script)
+    if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode) or info.st_uid != os.getuid():
+        raise RuntimeError("Contacts link helper is unsafe")
+    argv = ["/usr/bin/osascript", script, operation]
+    if operation == "link":
+        argv.append(expected)
+    code, stdout, stderr = run_bounded_process([*argv, *uids], b"")
+    try:
+        result = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        message = clean_text(stderr.decode("utf-8", "replace"), 180)
+        raise RuntimeError(message or "Contacts link helper returned invalid data")
+    if code != 0 or not isinstance(result, dict) or result.get("ok") is not True:
+        raise RuntimeError(clean_text(result.get("error") if isinstance(result, dict) else "", 180)
+                           or "Contacts could not prepare these cards")
+    return result
+
+
+def link_candidate(
+    handle: object, owner_token: object, apply: bool, expected_action: object = ""
+) -> dict:
+    if apply:
+        require_write_gate()
+    original, _, candidate, records = selected_candidate(handle, owner_token)
+    result = run_contact_link(
+        "link" if apply else "prepare", records, expected_action if apply else ""
+    )
+    action = clean_text(result.get("action"), 80)
+    allowed = ("Link Selected Cards", "Merge Selected Cards", "Merge and Link Selected Cards")
+    if action not in allowed:
+        raise RuntimeError("Contacts returned an invalid link action")
+    if apply and action != clean_text(expected_action, 80):
+        raise RuntimeError("Contacts link action changed; review the cards again")
+    if apply and result.get("linked") is not True:
+        raise RuntimeError("Contacts did not confirm the link action")
+    if not apply and not isinstance(result.get("ready"), bool):
+        raise RuntimeError("Contacts returned an invalid link preview")
+    return {
+        "handle": original, "name": candidate["name"], "cardCount": len(records),
+        "sourceCount": candidate["sourceCount"], "writeEnabled": write_gate_enabled(),
+        "action": action,
+        **({"linked": True} if apply else {"ready": result["ready"]}),
+    }
+
+
+def validated_repair_fields(value: object, kind: str, key: str) -> list[dict]:
+    if not isinstance(value, list) or not 1 <= len(value) <= MAX_REPAIR_FIELDS:
+        raise RuntimeError("Contacts returned an invalid matching-field list")
+    fields = []
+    seen = set()
+    for raw in value:
+        if not isinstance(raw, dict):
+            raise RuntimeError("Contacts returned an invalid matching field")
+        field_id = clean_text(raw.get("id"), 200)
+        field_value = clean_text(raw.get("value"), 320)
+        label = clean_text(raw.get("label"), 80)
+        if not field_id or field_id in seen or not field_value:
+            raise RuntimeError("Contacts returned an invalid matching field")
+        normalized = normalize_email(field_value) if kind == "email" else normalize_phone(field_value)
+        if normalized != key:
+            raise RuntimeError("Contacts returned a different field value")
+        seen.add(field_id)
+        fields.append({"id": field_id, "value": field_value, "label": label})
+    return fields
+
+
+def inspect_repair(handle: object, token: object, owner_token: object) -> tuple[dict, dict, list[dict]]:
+    original, key, candidate, record, card_number, account_number = selected_card(handle, token)
+    owner_text = clean_text(owner_token, 80)
+    if not _CONTACT_TOKEN.fullmatch(owner_text):
+        raise ValueError("the selected owner token is invalid")
+    _, candidates, _ = contact_candidates(handle)
+    owner = next((option for option in candidates if option["token"] == owner_text), None)
+    if owner is None:
+        raise ValueError("the selected correct contact is no longer a candidate")
+    if owner["token"] == candidate["token"]:
+        raise ValueError("refusing to remove a handle from the selected correct contact")
+    kind = record.get("kind")
+    if kind not in ("phone", "email"):
+        raise RuntimeError("the selected card has no repairable field")
+    result = run_contact_repair({
+        "operation": "inspect", "personUid": record["uid"], "kind": kind, "key": key,
+    })
+    fields = validated_repair_fields(result.get("fields"), kind, key)
+    preview = {
+        "handle": original,
+        "name": candidate["name"],
+        "kind": kind,
+        "fieldCount": len(fields),
+        "labels": [field["label"] for field in fields],
+        "cardNumber": card_number,
+        "cardCount": candidate["recordCount"],
+        "accountNumber": account_number,
+        "sourceName": candidate["cards"][card_number - 1]["sourceName"],
+        "writeEnabled": write_gate_enabled(),
+    }
+    private = {
+        "personUid": record["uid"], "key": key, "kind": kind, "fields": fields,
+        "name": candidate["name"], "handle": original, "source": record["source"],
+        "cardToken": card_token(key, record["source"], record["uid"]),
+    }
+    return preview, private, fields
+
+
+def remove_from_contact(handle: object, token: object, owner_token: object) -> dict:
+    require_write_gate()
+    preview, private, fields = inspect_repair(handle, token, owner_token)
+    if not preview["writeEnabled"]:
+        raise PermissionError("Mac contact writes are disabled")
+    undo_token = write_undo_receipt(private)
+    result = run_contact_repair({
+        "operation": "remove",
+        "personUid": private["personUid"],
+        "kind": private["kind"],
+        "key": private["key"],
+        "fields": fields,
+    })
+    if result.get("removed") is not True or result.get("fieldCount") != len(fields):
+        raise RuntimeError("Contacts did not confirm the removal")
+    return {**preview, "removed": True, "undoToken": undo_token}
+
+
+def undo_contact_removal(token: object) -> dict:
+    require_write_gate()
+    receipt = read_undo_receipt(token)
+    action = clean_text(receipt.get("action"), 40)
+    if action == "edit":
+        before = validated_card_detail(receipt.get("before"))
+        after_draft = validated_card_draft(receipt.get("after"))
+        # The saved response's display name is derived from the applied draft.
+        current = describe_records([{"uid": clean_text(receipt.get("personUid"), 200)}])[0]
+        if card_draft(current) != after_draft:
+            raise ValueError("this card changed after the Blip edit; undo was not applied")
+        result = run_contact_repair({
+            "operation": "edit", "personUid": clean_text(receipt.get("personUid"), 200),
+            "expectedCard": current, "card": card_draft(before),
+        })
+        if result.get("edited") is not True:
+            raise RuntimeError("Contacts did not confirm the edit undo")
+        clear_undo_receipt(receipt["token"])
+        return {
+            "restored": True, "alreadyPresent": False, "action": "edit",
+            "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+            "name": clean_text(receipt.get("name"), MAX_NAME_CHARS), "cardCount": 1,
+            "fieldCount": max(1, len(changed_card_fields(after_draft, card_draft(before)))),
+        }
+    if action == "delete":
+        before = validated_card_detail(receipt.get("before"))
+        result = run_contact_repair({"operation": "restore", "card": card_draft(before)})
+        if result.get("restored") is not True:
+            raise RuntimeError("Contacts did not confirm the deleted-card restore")
+        clear_undo_receipt(receipt["token"])
+        return {
+            "restored": True, "alreadyPresent": False, "action": "delete",
+            "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+            "name": clean_text(receipt.get("name"), MAX_NAME_CHARS), "cardCount": 1,
+            "fieldCount": 1,
+        }
+    if action == "consolidate":
+        target_before = validated_card_detail(receipt.get("targetBefore"))
+        target_after = validated_card_draft(receipt.get("targetAfter"))
+        raw_sources = receipt.get("sources")
+        if not isinstance(raw_sources, list) or not 1 <= len(raw_sources) < 8:
+            raise RuntimeError("contact merge undo receipt is invalid")
+        restore_cards = []
+        for source in raw_sources:
+            if not isinstance(source, dict):
+                raise RuntimeError("contact merge undo receipt is invalid")
+            restore_cards.append(card_draft(validated_card_detail(source.get("card"))))
+        current = describe_records([{"uid": clean_text(receipt.get("targetUid"), 200)}])[0]
+        if card_draft(current) != target_after:
+            raise ValueError("the merged card changed after consolidation; undo was not applied")
+        result = run_contact_repair({
+            "operation": "undo-consolidate",
+            "targetUid": clean_text(receipt.get("targetUid"), 200),
+            "expectedCard": current, "card": card_draft(target_before),
+            "restoreCards": restore_cards,
+        })
+        if result.get("restored") is not True or result.get("sourceCount") != len(restore_cards):
+            raise RuntimeError("Contacts did not confirm the merge undo")
+        clear_undo_receipt(receipt["token"])
+        return {
+            "restored": True, "alreadyPresent": False, "action": "consolidate",
+            "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+            "name": clean_text(receipt.get("name"), MAX_NAME_CHARS),
+            "cardCount": len(restore_cards) + 1, "fieldCount": 1,
+        }
+    kind = receipt.get("kind")
+    key = clean_text(receipt.get("key"), 320)
+    fields = validated_repair_fields(receipt.get("fields"), kind, key)
+    result = run_contact_repair({
+        "operation": "undo",
+        "personUid": clean_text(receipt.get("personUid"), 200),
+        "kind": kind,
+        "key": key,
+        "fields": fields,
+    })
+    if result.get("restored") is not True:
+        raise RuntimeError("Contacts did not confirm the restore")
+    field_count = result.get("fieldCount")
+    if not isinstance(field_count, int) or not 1 <= field_count <= MAX_REPAIR_FIELDS:
+        raise RuntimeError("Contacts returned an invalid restored-field count")
+    clear_undo_receipt(receipt["token"])
+    return {
+        "restored": True,
+        "alreadyPresent": result.get("alreadyPresent") is True,
+        "action": "field-removal",
+        "handle": clean_text(receipt.get("handle"), MAX_HANDLE_CHARS),
+        "name": clean_text(receipt.get("name"), MAX_NAME_CHARS),
+        "cardCount": 1,
+        "fieldCount": field_count,
+    }
+
+
 def _cmd_resolve(args):
     request = read_resolve_request()
     operation = request.get("operation")
+    if operation == "discard-unsaved":
+        require_write_gate()
+        result = run_contact_repair({"operation": "discard-unsaved"})
+        discarded = result.get("discarded")
+        if not isinstance(discarded, bool):
+            raise RuntimeError("Contacts returned an invalid unsaved-change result")
+        emit_resolve({"ok": True, "discarded": discarded})
+        return
+    if operation == "vcard":
+        result = contact_vcard(request.get("handle"))
+        emit_resolve({"ok": True, **result}, MAX_VCARD_RESPONSE_BYTES)
+        return
     if operation == "candidates":
         original, candidates, _ = contact_candidates(request.get("handle"))
         emit_resolve({
@@ -665,8 +1787,84 @@ def _cmd_resolve(args):
             "sourceName": selected["cards"][selected_card_number - 1]["sourceName"],
         })
         return
+    if operation == "compare":
+        result = compare_candidate(request.get("handle"), request.get("ownerToken"),
+                                   request.get("otherOwnerToken"))
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "edit-prepare":
+        preview, _ = prepare_card_edit(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"), request.get("card"),
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "edit":
+        result = apply_card_edit(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"), request.get("card"), request.get("planHash"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "delete-prepare":
+        preview, _ = prepare_card_delete(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"),
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "delete":
+        result = apply_card_delete(
+            request.get("handle"), request.get("ownerToken"), request.get("token"),
+            request.get("revision"), request.get("planHash"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "merge-prepare":
+        preview, _ = prepare_consolidation(
+            request.get("handle"), request.get("ownerToken"), request.get("targetToken"),
+            request.get("revisions"), request.get("card"), request.get("otherOwnerToken"),
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "merge":
+        result = apply_consolidation(
+            request.get("handle"), request.get("ownerToken"), request.get("targetToken"),
+            request.get("revisions"), request.get("card"), request.get("planHash"),
+            request.get("otherOwnerToken"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "link-prepare":
+        result = link_candidate(request.get("handle"), request.get("ownerToken"), False)
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "link":
+        result = link_candidate(
+            request.get("handle"), request.get("ownerToken"), True,
+            request.get("expectedAction"),
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "inspect":
+        preview, _, _ = inspect_repair(
+            request.get("handle"), request.get("token"), request.get("ownerToken")
+        )
+        emit_resolve({"ok": True, "preview": preview})
+        return
+    if operation == "remove":
+        result = remove_from_contact(
+            request.get("handle"), request.get("token"), request.get("ownerToken")
+        )
+        emit_resolve({"ok": True, **result})
+        return
+    if operation == "undo":
+        result = undo_contact_removal(request.get("undoToken"))
+        emit_resolve({"ok": True, **result})
+        return
     raise ValueError(
-        "operation must be candidates, fingerprint, audit, or open"
+        "operation must be discard-unsaved, vcard, candidates, audit, open, compare, edit-prepare, edit, delete-prepare, "
+        "delete, merge-prepare, merge, link-prepare, link, inspect, remove, or undo"
     )
 
 

--- a/bridge/mac/contacts_test.py
+++ b/bridge/mac/contacts_test.py
@@ -28,6 +28,66 @@ class Stdin:
 
 
 class ContactResolverTests(unittest.TestCase):
+    def test_card_deletion_uses_the_current_contacts_framework(self):
+        script_helper = os.path.join(os.path.dirname(__file__), "contact-repair.js")
+        native_helper = os.path.join(os.path.dirname(__file__), "contact-delete.swift")
+        with open(script_helper, "r", encoding="utf-8") as stream:
+            script_source = stream.read()
+        with open(native_helper, "r", encoding="utf-8") as stream:
+            native_source = stream.read()
+        self.assertNotIn("removeRecord(", script_source)
+        # Contacts.delete() covers the person delete-fallback AND field
+        # removal — the remove-from-person Apple event is broken on current
+        # macOS ("Message not understood"), deleting the specifier works.
+        self.assertNotIn("contacts.remove(", script_source)
+        self.assertNotIn("Contacts.remove(", script_source)
+        self.assertGreaterEqual(script_source.count("delete("), 3)
+        self.assertIn('request.operation === "delete-fallback"', script_source)
+        self.assertIn('value.operation === "delete-fallback"', script_source)
+        # the add-to-person Apple event errors with "No error. (0)" on current
+        # macOS; the push pattern is the one that works
+        self.assertIn('person[kind === "email" ? "emails" : "phones"].push(entry)', script_source)
+        # add-only edits keep existing entries (and their damaged rows) untouched
+        self.assertIn("function addedEntries", script_source)
+        self.assertIn("CNSaveRequest()", native_source)
+        self.assertIn("save.delete(mutable)", native_source)
+        self.assertIn("request.unifyResults = false", native_source)
+        self.assertIn("grouped[container, default: []]", native_source)
+        # every save stage retries transient Cocoa 134092 against a FRESH
+        # store session, refetching by pinned identifier each attempt
+        self.assertIn("func withFreshStoreRetry", native_source)
+        self.assertIn("try body(CNContactStore())", native_source)
+        self.assertIn("nsError.code == 134092", native_source)
+        self.assertIn('withFreshStoreRetry("update survivor")', native_source)
+        self.assertIn('withFreshStoreRetry("delete sources")', native_source)
+        self.assertIn('withFreshStoreRetry("save same-account merge")', native_source)
+        self.assertIn("Contacts saved the merged contact but could not delete", native_source)
+        # unchanged label+value rows are REUSED, never rebuilt: replacing a value
+        # forces contactsd to fault the old row out, and one damaged stored row
+        # then fails the whole save with Cocoa 134092. Contacts.app's scripting
+        # layer also reports unlabeled values under default kind names, which
+        # must normalize back to nil instead of becoming literal custom labels.
+        self.assertIn("func reuseLabeled", native_source)
+        self.assertIn("func normalizedLabel", native_source)
+        self.assertIn('kindDefaults: ["Email"]', native_source)
+        self.assertIn('kindDefaults: ["Phone"]', native_source)
+        # residual failures name their stage and code so reports are diagnosable
+        self.assertIn("(stage: \\(stage), code \\(nsError.code))", native_source)
+
+    def test_native_deletion_uses_fixed_argv_and_private_stdin(self):
+        completed = (0, b'{"deletedCount":2,"ok":true}', b"")
+        file_info = os.stat_result((stat.S_IFREG | 0o700, 0, 0, 1, os.getuid(), 0, 1, 0, 0, 0))
+        with mock.patch.object(contacts.os, "lstat", return_value=file_info), mock.patch.object(
+            contacts, "run_bounded_process", return_value=completed,
+        ) as run:
+            result = contacts.run_contact_delete(["person-1", "person-2"])
+        argv, payload = run.call_args.args
+        self.assertEqual(len(argv), 1)
+        self.assertTrue(argv[0].endswith("contact-delete"))
+        self.assertNotIn(b"person-1", " ".join(argv).encode())
+        self.assertIn(b"person-1", payload)
+        self.assertEqual(result["deletedCount"], 2)
+
     def test_handle_normalization(self):
         self.assertEqual(contacts.normalize_resolve_handle("+1 (555) 010-0001")[1], "5550100001")
         self.assertEqual(contacts.normalize_resolve_handle("Person@Example.COM")[1], "person@example.com")
@@ -226,6 +286,56 @@ class ContactResolverTests(unittest.TestCase):
                 contacts._cmd_resolve(None)
         run.assert_not_called()
 
+    def test_discard_unsaved_requires_gate_and_reports_only_confirmation(self):
+        with mock.patch.object(
+            contacts, "read_resolve_request",
+            return_value={"operation": "discard-unsaved"},
+        ), mock.patch.object(contacts, "require_write_gate") as gate, mock.patch.object(
+            contacts, "run_contact_repair",
+            return_value={"ok": True, "discarded": True},
+        ) as repair:
+            output = io.StringIO()
+            with redirect_stdout(output):
+                contacts._cmd_resolve(None)
+        gate.assert_called_once_with()
+        repair.assert_called_once_with({"operation": "discard-unsaved"})
+        self.assertEqual(json.loads(output.getvalue()), {"ok": True, "discarded": True})
+
+    def test_write_gate_requires_an_owner_only_regular_file(self):
+        with tempfile.TemporaryDirectory() as root, mock.patch.object(
+            contacts, "WRITE_GATE", os.path.join(root, "gate")
+        ):
+            self.assertFalse(contacts.write_gate_enabled())
+            with open(contacts.WRITE_GATE, "wb") as stream:
+                stream.write(b"enabled-v1\n")
+            os.chmod(contacts.WRITE_GATE, 0o600)
+            self.assertTrue(contacts.write_gate_enabled())
+            os.chmod(contacts.WRITE_GATE, 0o644)
+            self.assertFalse(contacts.write_gate_enabled())
+            os.unlink(contacts.WRITE_GATE)
+            os.symlink(__file__, contacts.WRITE_GATE)
+            self.assertFalse(contacts.write_gate_enabled())
+
+    def test_undo_receipt_is_private_bounded_and_token_pinned(self):
+        receipt = {
+            "personUid": "person-1", "key": "5550100001", "kind": "phone",
+            "fields": [{"id": "field-1", "value": "+15550100001", "label": "mobile"}],
+            "name": "Alex Rivera", "handle": "+15550100001", "source": "source-1",
+            "cardToken": "sha256:" + "a" * 64,
+        }
+        with tempfile.TemporaryDirectory() as root, mock.patch.object(
+            contacts, "UNDO_DIR", os.path.join(root, "undo")
+        ):
+            token = contacts.write_undo_receipt(receipt)
+            self.assertRegex(token, r"^undo:[0-9a-f]{32}$")
+            self.assertEqual(contacts.read_undo_receipt(token)["personUid"], "person-1")
+            self.assertEqual(os.stat(contacts.UNDO_DIR).st_mode & 0o777, 0o700)
+            self.assertEqual(os.stat(os.path.join(contacts.UNDO_DIR, contacts.UNDO_FILE)).st_mode & 0o777, 0o600)
+            with self.assertRaisesRegex(ValueError, "no longer available"):
+                contacts.read_undo_receipt("undo:" + "f" * 32)
+            contacts.clear_undo_receipt(token)
+            self.assertFalse(os.path.exists(os.path.join(contacts.UNDO_DIR, contacts.UNDO_FILE)))
+
     def test_automation_output_cap_kills_a_producer_before_timeout(self):
         started = time.monotonic()
         producer = (
@@ -237,6 +347,444 @@ class ContactResolverTests(unittest.TestCase):
             contacts.run_bounded_process([sys.executable, "-c", producer], b"{}")
         self.assertLess(time.monotonic() - started, 2)
 
+    def test_comparison_validates_details_and_keeps_raw_ids_private(self):
+        key = "5550100001"
+        candidate = {
+            "token": contacts.resolve_token(key, "Alex Rivera"),
+            "name": "Alex Rivera", "recordCount": 2, "sourceCount": 2,
+            "hasPhoto": True,
+            "cards": [
+                {"token": "sha256:" + "b" * 64, "accountNumber": 1,
+                 "sourceName": "iCloud", "hasPhoto": True},
+                {"token": "sha256:" + "c" * 64, "accountNumber": 2,
+                 "sourceName": "Google", "hasPhoto": False},
+            ],
+        }
+        records = [
+            {"uid": "private-person-one", "source": "source-one", "photo": True},
+            {"uid": "private-person-two", "source": "source-two", "photo": False},
+        ]
+        detail = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "Example",
+            "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+            "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+            "emails": [], "urls": [], "addresses": [],
+        }
+        with mock.patch.object(
+            contacts, "selected_candidate",
+            return_value=("+15550100001", key, candidate, records),
+        ), mock.patch.object(
+            contacts, "run_contact_repair", return_value={"ok": True, "cards": [detail, detail]},
+        ), mock.patch.object(
+            contacts, "native_collection_counts",
+            side_effect=lambda uids: {uid: (1, 0, 0, 0) for uid in uids},
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            result = contacts.compare_candidate("+15550100001", candidate["token"])
+        self.assertEqual(result["cardCount"], 2)
+        self.assertEqual(result["sourceCount"], 2)
+        self.assertEqual(result["cards"][0]["accountNumber"], 1)
+        self.assertEqual(result["cards"][0]["sourceName"], "iCloud")
+        self.assertRegex(result["cards"][0]["token"], r"^sha256:[0-9a-f]{64}$")
+        self.assertRegex(result["cards"][0]["revision"], r"^sha256:[0-9a-f]{64}$")
+        serialized = json.dumps(result)
+        self.assertNotIn("private-person-one", serialized)
+        self.assertNotIn("private-person-two", serialized)
+        self.assertNotIn("source-one", serialized)
+
+        hostile = dict(detail)
+        hostile["phones"] = [{"label": "x", "value": "1"}] * 17
+        with self.assertRaisesRegex(RuntimeError, "phone list"):
+            contacts.validated_card_detail(hostile)
+
+    def test_link_helper_uses_fixed_argv_and_refuses_unsafe_card_ids(self):
+        records = [{"uid": "person-1"}, {"uid": "person_2"}]
+        completed = (0, b'{"ok":true,"ready":true,"action":"Link Selected Cards"}', b"")
+        with mock.patch.object(
+            contacts, "run_bounded_process", return_value=completed,
+        ) as run:
+            result = contacts.run_contact_link("prepare", records)
+        argv, payload = run.call_args.args
+        self.assertEqual(argv[0], "/usr/bin/osascript")
+        self.assertTrue(argv[1].endswith("contact-link.applescript"))
+        self.assertEqual(argv[2:], ["prepare", "person-1", "person_2"])
+        self.assertEqual(payload, b"")
+        self.assertTrue(result["ready"])
+
+        with mock.patch.object(contacts, "run_bounded_process") as run:
+            with self.assertRaisesRegex(RuntimeError, "unsafe card identifier"):
+                contacts.run_contact_link("prepare", [{"uid": "safe"}, {"uid": "bad/value"}])
+        run.assert_not_called()
+
+    def test_link_apply_requires_gate_and_preserves_apple_action(self):
+        candidate = {
+            "name": "Alex Rivera", "sourceCount": 2,
+        }
+        selected = (
+            "+15550100001", "5550100001", candidate,
+            [{"uid": "person-1"}, {"uid": "person-2"}],
+        )
+        with mock.patch.object(
+            contacts, "selected_candidate", return_value=selected,
+        ), mock.patch.object(
+            contacts, "run_contact_link",
+            return_value={"ok": True, "ready": False, "action": "Merge Selected Cards"},
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            preview = contacts.link_candidate("+15550100001", "sha256:" + "a" * 64, False)
+        self.assertFalse(preview["ready"])
+        self.assertEqual(preview["action"], "Merge Selected Cards")
+
+        with mock.patch.object(contacts, "require_write_gate", side_effect=PermissionError("disabled")):
+            with self.assertRaisesRegex(PermissionError, "disabled"):
+                contacts.link_candidate(
+                    "+15550100001", "sha256:" + "a" * 64, True,
+                    "Merge Selected Cards",
+                )
+
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "selected_candidate", return_value=selected,
+        ), mock.patch.object(
+            contacts, "run_contact_link",
+            return_value={"ok": True, "linked": True, "action": "Link Selected Cards"},
+        ):
+            with self.assertRaisesRegex(RuntimeError, "action changed"):
+                contacts.link_candidate(
+                    "+15550100001", "sha256:" + "a" * 64, True,
+                    "Merge Selected Cards",
+                )
+
+    def test_remove_revalidates_fields_and_saves_undo_before_automation(self):
+        preview = {
+            "handle": "+15550100001", "name": "Pat Rivera", "kind": "phone",
+            "fieldCount": 1, "labels": ["mobile"], "cardNumber": 1,
+            "cardCount": 1, "accountNumber": 1, "sourceName": "iCloud",
+            "writeEnabled": True,
+        }
+        private = {
+            "personUid": "person-1", "key": "5550100001", "kind": "phone",
+            "fields": [{"id": "field-1", "value": "+15550100001", "label": "mobile"}],
+            "name": "Pat Rivera", "handle": "+15550100001", "source": "source-1",
+            "cardToken": "sha256:" + "a" * 64,
+        }
+        events = []
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "inspect_repair", return_value=(preview, private, private["fields"])
+        ), mock.patch.object(
+            contacts, "write_undo_receipt", side_effect=lambda value: events.append("receipt") or "undo:" + "b" * 32
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=lambda value: events.append("automation") or {"ok": True, "removed": True, "fieldCount": 1},
+        ):
+            result = contacts.remove_from_contact(
+                "+15550100001", private["cardToken"], "sha256:" + "c" * 64
+            )
+        self.assertEqual(events, ["receipt", "automation"])
+        self.assertTrue(result["removed"])
+        self.assertRegex(result["undoToken"], r"^undo:")
+
+    def test_inspect_refuses_the_saved_correct_contact(self):
+        key = "5550100001"
+        correct = {
+            "token": contacts.resolve_token(key, "Alex Rivera"),
+            "name": "Alex Rivera", "recordCount": 1, "sourceCount": 1,
+            "hasPhoto": False, "cards": [],
+        }
+        wrong = {
+            "token": contacts.resolve_token(key, "Pat Rivera"),
+            "name": "Pat Rivera", "recordCount": 1, "sourceCount": 1,
+            "hasPhoto": False, "cards": [],
+        }
+        record = {
+            "name": "Alex Rivera", "uid": "person-1", "source": "source-1",
+            "kind": "phone", "modified": 0, "photo": False,
+        }
+        with mock.patch.object(
+            contacts, "selected_card",
+            return_value=("+15550100001", key, correct, record, 1, 1),
+        ), mock.patch.object(
+            contacts, "contact_candidates",
+            return_value=("+15550100001", [correct, wrong], {}),
+        ), mock.patch.object(contacts, "run_contact_repair") as repair:
+            with self.assertRaisesRegex(ValueError, "selected correct contact"):
+                contacts.inspect_repair(
+                    "+15550100001", "sha256:" + "a" * 64, correct["token"]
+                )
+        repair.assert_not_called()
+
+    def test_card_edit_requires_revision_preview_and_writes_receipt_before_apply(self):
+        detail = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [{"label": "mobile", "value": "+15550100001"}],
+            "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft({**detail, "nickname": "Lex"})
+        token = "sha256:" + "b" * 64
+        owner = "sha256:" + "a" * 64
+        candidate = {
+            "name": "Alex Rivera", "recordCount": 1, "sourceCount": 1,
+            "cards": [{"accountNumber": 1, "sourceName": "iCloud"}],
+        }
+        selected = (
+            "+15550100001", "5550100001", candidate,
+            [{"uid": "person-1", "source": "source-1"}],
+            {"uid": "person-1", "source": "source-1"}, 1, 1,
+        )
+        events = []
+        edited = {**detail, "nickname": "Lex"}
+        with mock.patch.object(contacts, "owned_card", return_value=selected), mock.patch.object(
+            contacts, "describe_records", return_value=[detail]
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            preview, _ = contacts.prepare_card_edit(
+                "+15550100001", owner, token, contacts.card_revision(detail), draft
+            )
+        self.assertEqual(preview["changedFields"], ["nickname"])
+        self.assertRegex(preview["planHash"], r"^sha256:[0-9a-f]{64}$")
+
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_card_edit", return_value=(preview, {
+                "personUid": "person-1", "before": detail, "after": draft,
+                "handle": "+15550100001", "name": "Alex Rivera", "cardToken": token,
+                "planHash": preview["planHash"],
+            })
+        ), mock.patch.object(
+            contacts, "write_undo_receipt",
+            side_effect=lambda value: events.append("receipt") or "undo:" + "c" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=lambda value: events.append("automation") or {
+                "ok": True, "edited": True, "card": edited,
+            },
+        ):
+            result = contacts.apply_card_edit(
+                "+15550100001", owner, token, contacts.card_revision(detail), draft,
+                preview["planHash"],
+            )
+        self.assertEqual(events, ["receipt", "automation"])
+        self.assertTrue(result["applied"])
+
+    def test_card_collection_edit_uses_native_contacts_update(self):
+        before = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [{"label": "mobile", "value": "+15550100001"}],
+            "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft({
+            **before, "phones": [{"label": "mobile", "value": "+15550100002"}],
+        })
+        after = {**before, **draft}
+        plan = "sha256:" + "d" * 64
+        preview = {"planHash": plan, "changedFields": ["phone numbers"]}
+        private = {
+            "personUid": "person-1", "before": before, "after": draft,
+            "handle": "+15550100001", "name": "Alex Rivera",
+            "cardToken": "sha256:" + "b" * 64, "planHash": plan,
+        }
+        events = []
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_card_edit", return_value=(preview, private),
+        ), mock.patch.object(
+            contacts, "write_undo_receipt",
+            side_effect=lambda value: events.append("receipt") or "undo:" + "c" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_update",
+            side_effect=lambda uid, card: events.append("native") or {"updated": True},
+        ), mock.patch.object(contacts, "describe_records", return_value=[after]), mock.patch.object(
+            contacts, "run_contact_repair",
+        ) as automation:
+            result = contacts.apply_card_edit(
+                "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                contacts.card_revision(before), draft, plan,
+            )
+        self.assertEqual(events, ["receipt", "native"])
+        automation.assert_not_called()
+        self.assertTrue(result["applied"])
+
+    def test_consolidation_plan_pins_every_card_and_keeps_raw_ids_private(self):
+        base = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [], "emails": [], "urls": [], "addresses": [],
+        }
+        other = {**base, "emails": [{"label": "home", "value": "alex@example.com"}]}
+        key = "5550100001"
+        records = [
+            {"uid": "private-1", "source": "source-1"},
+            {"uid": "private-2", "source": "source-2"},
+        ]
+        tokens = [contacts.card_token(key, record["source"], record["uid"]) for record in records]
+        candidate = {
+            "name": "Alex Rivera", "recordCount": 2, "sourceCount": 2,
+            "cards": [{"accountNumber": 1, "sourceName": "iCloud"},
+                      {"accountNumber": 2, "sourceName": "Google"}],
+        }
+        revisions = [
+            {"token": tokens[0], "revision": contacts.card_revision(base)},
+            {"token": tokens[1], "revision": contacts.card_revision(other)},
+        ]
+        with mock.patch.object(
+            contacts, "selected_candidate",
+            return_value=("+15550100001", key, candidate, records),
+        ), mock.patch.object(
+            contacts, "describe_records", return_value=[base, other],
+        ), mock.patch.object(contacts, "write_gate_enabled", return_value=True):
+            preview, private = contacts.prepare_consolidation(
+                "+15550100001", "sha256:" + "a" * 64, tokens[0], revisions,
+                contacts.card_draft(other),
+            )
+        self.assertEqual(preview["action"], "consolidate")
+        self.assertEqual(preview["sourceCardCount"], 1)
+        self.assertNotIn("private-1", json.dumps(preview))
+        self.assertEqual(private["targetUid"], "private-1")
+
+        changed = [dict(item) for item in revisions]
+        changed[1]["revision"] = "sha256:" + "f" * 64
+        with mock.patch.object(
+            contacts, "selected_candidate",
+            return_value=("+15550100001", key, candidate, records),
+        ), mock.patch.object(contacts, "describe_records", return_value=[base, other]):
+            with self.assertRaisesRegex(ValueError, "source card changed"):
+                contacts.prepare_consolidation(
+                    "+15550100001", "sha256:" + "a" * 64, tokens[0], changed,
+                    contacts.card_draft(other),
+                )
+
+    def test_consolidation_preflights_then_updates_and_deletes(self):
+        before = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [], "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft({
+            **before, "emails": [{"label": "home", "value": "alex@example.com"}],
+        })
+        after = {**before, **draft}
+        plan = "sha256:" + "d" * 64
+        preview = {
+            "action": "consolidate", "handle": "+15550100001", "name": "Alex Rivera",
+            "cardNumber": 1, "cardCount": 2, "accountNumber": 1, "sourceName": "iCloud",
+            "sourceCardCount": 1, "changedFields": ["email addresses"],
+            "planHash": plan, "writeEnabled": True,
+        }
+        private = {
+            "targetUid": "person-1", "targetBefore": before, "targetAfter": draft,
+            "sources": [{"personUid": "person-2", "card": before}],
+            "handle": "+15550100001", "name": "Alex Rivera", "planHash": plan,
+        }
+        events = []
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_consolidation", return_value=(preview, private),
+        ), mock.patch.object(
+            contacts, "describe_records", return_value=[after],
+        ), mock.patch.object(
+            contacts, "write_undo_receipt",
+            side_effect=lambda value: events.append("receipt") or "undo:" + "e" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=lambda value: events.append(value["operation"]) or {
+                "ok": True, "readyToConsolidate": True, "sourceCount": 1,
+            },
+        ), mock.patch.object(
+            contacts, "run_contact_consolidation",
+            side_effect=lambda target, sources, card: events.append("native") or {
+                "ok": True, "updated": True, "deletedCount": len(sources),
+            },
+        ) as consolidate:
+            result = contacts.apply_consolidation(
+                "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                [], draft, plan,
+            )
+        self.assertEqual(events, ["consolidate", "receipt", "native"])
+        consolidate.assert_called_once_with("person-1", ["person-2"], draft)
+        self.assertTrue(result["applied"])
+
+    def test_consolidation_never_deletes_a_source_when_survivor_save_fails(self):
+        before = {
+            "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+            "lastName": "Rivera", "nickname": "", "organization": "",
+            "department": "", "jobTitle": "", "birthday": "", "note": "",
+            "phones": [], "emails": [], "urls": [], "addresses": [],
+        }
+        draft = contacts.card_draft(before)
+        plan = "sha256:" + "d" * 64
+        preview = {
+            "action": "consolidate", "handle": "+15550100001", "name": "Alex Rivera",
+            "cardNumber": 1, "cardCount": 2, "accountNumber": 1, "sourceName": "iCloud",
+            "sourceCardCount": 1, "changedFields": ["source-card consolidation"],
+            "planHash": plan, "writeEnabled": True,
+        }
+        private = {
+            "targetUid": "person-1", "targetBefore": before, "targetAfter": draft,
+            "sources": [{"personUid": "person-2", "card": before}],
+            "handle": "+15550100001", "name": "Alex Rivera", "planHash": plan,
+        }
+        with mock.patch.object(contacts, "require_write_gate"), mock.patch.object(
+            contacts, "prepare_consolidation", return_value=(preview, private),
+        ), mock.patch.object(
+            contacts, "write_undo_receipt", return_value="undo:" + "e" * 32,
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            return_value={"ok": True, "readyToConsolidate": True, "sourceCount": 1},
+        ), mock.patch.object(
+            contacts, "run_contact_consolidation", side_effect=RuntimeError("native save failed"),
+        ), mock.patch.object(contacts, "run_contact_delete") as delete:
+            with self.assertRaisesRegex(RuntimeError, "native save failed"):
+                contacts.apply_consolidation(
+                    "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                    [], draft, plan,
+                )
+        delete.assert_not_called()
+
+
+
+class CrossNameMergeTests(unittest.TestCase):
+    def fake_candidates(self):
+        gray = {"token": "sha256:" + "a" * 64, "name": "Julia Gray", "recordCount": 1,
+                "sourceCount": 1, "hasPhoto": True,
+                "cards": [{"token": "sha256:" + "1" * 64, "accountNumber": 1,
+                           "sourceName": "iCloud", "hasPhoto": True, "matchCount": 1}]}
+        kinney = {"token": "sha256:" + "b" * 64, "name": "Julia Kinney", "recordCount": 1,
+                  "sourceCount": 1, "hasPhoto": True,
+                  "cards": [{"token": "sha256:" + "2" * 64, "accountNumber": 1,
+                             "sourceName": "Gmail", "hasPhoto": True, "matchCount": 1}]}
+        by_name = {
+            "julia gray": [{"uid": "uid-gray", "source": "s-icloud", "photo": True,
+                            "modified": 2, "name": "Julia Gray"}],
+            "julia kinney": [{"uid": "uid-kinney", "source": "s-gmail", "photo": True,
+                              "modified": 1, "name": "Julia Kinney"}],
+        }
+        return ("+15550100001", [gray, kinney], by_name)
+
+    def test_pair_combines_both_people_in_global_account_order(self):
+        # the union follows the same largest-store-first account order as
+        # every other view — NOT selected-person-first
+        stores = ["/AB/Sources/s-gmail/AddressBook-v22.abcddb",
+                  "/AB/Sources/s-icloud/AddressBook-v22.abcddb"]
+        with mock.patch.object(contacts, "contact_candidates", return_value=self.fake_candidates()), \
+             mock.patch.object(contacts, "bounded_source_dbs", return_value=stores), \
+             mock.patch.object(contacts, "normalize_resolve_handle",
+                               return_value=("+15550100001", "5550100001", False)):
+            _, _, combined, records = contacts.selected_candidate_pair(
+                "+15550100001", "sha256:" + "a" * 64, "sha256:" + "b" * 64)
+        self.assertEqual(combined["recordCount"], 2)
+        self.assertEqual(combined["sourceCount"], 2)
+        # gmail (the bigger store) leads even though iCloud's person was selected
+        self.assertEqual([r["uid"] for r in records], ["uid-kinney", "uid-gray"])
+        self.assertEqual([c["sourceName"] for c in combined["cards"]], ["Gmail", "iCloud"])
+        self.assertEqual([c["accountNumber"] for c in combined["cards"]], [1, 2])
+
+    def test_pair_requires_two_distinct_candidates(self):
+        with mock.patch.object(contacts, "contact_candidates", return_value=self.fake_candidates()), \
+             mock.patch.object(contacts, "normalize_resolve_handle",
+                               return_value=("+15550100001", "5550100001", False)):
+            with self.assertRaises(ValueError):
+                contacts.selected_candidate_pair(
+                    "+15550100001", "sha256:" + "a" * 64, "sha256:" + "a" * 64)
 
 
 class SourceOrderTests(unittest.TestCase):
@@ -262,6 +810,170 @@ class SourceOrderTests(unittest.TestCase):
             "/AB/Sources/ccc/AddressBook-v22.abcddb",
             "/AB/Sources/aaa/AddressBook-v22.abcddb",
         ])
+
+
+class CardContentComparisonTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "Example",
+        "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [{"label": "Email", "value": "a@example.invalid"},
+                   {"label": "Email", "value": "b@example.invalid"}],
+        "urls": [], "addresses": [],
+    }
+
+    def test_collection_order_never_fails_verification(self):
+        # the writer reuses existing rows and appends additions, so a merged
+        # card can read back with the same values in a different sequence
+        draft = contacts.card_draft(self.DETAIL)
+        reordered = dict(draft, emails=list(reversed(draft["emails"])))
+        self.assertTrue(contacts.same_card_content(reordered, draft))
+
+    def test_changed_values_still_fail_verification(self):
+        draft = contacts.card_draft(self.DETAIL)
+        changed = dict(draft, emails=[{"label": "Email", "value": "c@example.invalid"},
+                                      {"label": "Email", "value": "b@example.invalid"}])
+        self.assertFalse(contacts.same_card_content(changed, draft))
+        renamed = dict(draft, organization="Someone Else")
+        self.assertFalse(contacts.same_card_content(renamed, draft))
+
+
+class ConsolidationRecoveryTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "Example",
+        "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [], "urls": [], "addresses": [],
+    }
+
+    def private(self):
+        after = dict(contacts.card_draft(self.DETAIL), organization="Merged Org")
+        return {
+            "targetUid": "uid-target", "targetAfter": after,
+            "sources": [{"personUid": "uid-source"}],
+        }
+
+    def test_native_failures_carry_their_stage(self):
+        completed = (1, b'{"ok":false,"error":"boom","stage":"update survivor"}', b"")
+        file_info = os.stat_result((stat.S_IFREG | 0o700, 0, 0, 1, os.getuid(), 0, 1, 0, 0, 0))
+        with mock.patch.object(contacts.os, "lstat", return_value=file_info), mock.patch.object(
+            contacts, "run_bounded_process", return_value=completed,
+        ):
+            with self.assertRaises(contacts.NativeMutationError) as caught:
+                contacts.run_native_contact_mutation({"operation": "consolidate"})
+        self.assertEqual(caught.exception.stage, "update survivor")
+
+    def test_survivor_fault_recovers_through_contacts_app_edit(self):
+        private = self.private()
+        error = contacts.NativeMutationError("boom", "update survivor")
+        with mock.patch.object(
+            contacts, "describe_records", return_value=[self.DETAIL],
+        ), mock.patch.object(
+            contacts, "run_contact_repair", return_value={"ok": True, "edited": True},
+        ) as repair, mock.patch.object(contacts, "run_contact_delete") as delete:
+            contacts.recover_consolidation_via_contacts_app(private, error)
+        self.assertEqual(repair.call_args.args[0]["operation"], "edit")
+        self.assertEqual(repair.call_args.args[0]["card"], private["targetAfter"])
+        delete.assert_called_once_with(["uid-source"])
+
+    def test_delete_fault_falls_back_to_contacts_app_deletion(self):
+        private = self.private()
+        error = contacts.NativeMutationError("boom", "delete sources")
+        with mock.patch.object(
+            contacts, "run_contact_delete", side_effect=RuntimeError("still faulting"),
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            return_value={"ok": True, "deletedCount": 1},
+        ) as repair:
+            contacts.recover_consolidation_via_contacts_app(private, error)
+        self.assertEqual(repair.call_args.args[0]["operation"], "delete-fallback")
+        self.assertEqual(repair.call_args.args[0]["personUids"], ["uid-source"])
+
+    def test_unknown_stage_is_never_recovered(self):
+        error = contacts.NativeMutationError("boom", "")
+        with self.assertRaises(contacts.NativeMutationError):
+            contacts.recover_consolidation_via_contacts_app(self.private(), error)
+
+
+class StaleDescribeGuardTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "", "department": "",
+        "jobTitle": "", "birthday": "", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [], "urls": [], "addresses": [],
+    }
+
+    def test_stale_app_view_retries_until_counts_agree(self):
+        # first describe returns a stale empty-collection view; the retry sees
+        # the real card
+        stale = dict(self.DETAIL, phones=[])
+        with mock.patch.object(
+            contacts, "native_collection_counts", return_value={"uid-1": (1, 0, 0, 0)},
+        ), mock.patch.object(
+            contacts, "run_contact_repair",
+            side_effect=[{"ok": True, "cards": [stale]}, {"ok": True, "cards": [self.DETAIL]}],
+        ) as described, mock.patch.object(contacts.time, "sleep"):
+            details = contacts.describe_records([{"uid": "uid-1"}])
+        self.assertEqual(len(details[0]["phones"]), 1)
+        self.assertEqual(described.call_count, 2)
+
+    def test_persistently_stale_view_fails_honestly(self):
+        stale = dict(self.DETAIL, phones=[])
+        with mock.patch.object(
+            contacts, "native_collection_counts", return_value={"uid-1": (1, 0, 0, 0)},
+        ), mock.patch.object(
+            contacts, "run_contact_repair", return_value={"ok": True, "cards": [stale]},
+        ), mock.patch.object(contacts.time, "sleep"):
+            with self.assertRaises(RuntimeError) as caught:
+                contacts.describe_records([{"uid": "uid-1"}])
+        self.assertIn("stale card data", str(caught.exception))
+
+
+class SettledReadbackTests(unittest.TestCase):
+    DETAIL = {
+        "displayName": "Alex Rivera", "firstName": "Alex", "middleName": "",
+        "lastName": "Rivera", "nickname": "", "organization": "Example",
+        "department": "", "jobTitle": "", "birthday": "--09-02", "note": "",
+        "phones": [{"label": "mobile", "value": "+1 555 010 0001"}],
+        "emails": [], "urls": [], "addresses": [],
+    }
+
+    def test_readback_polls_past_contacts_stale_view(self):
+        # Saves go through CNContactStore; describe goes through Contacts.app,
+        # whose view refreshes asynchronously. The first read returns the
+        # pre-save card, the second the saved one — no error, no false
+        # "Contacts changed the card" report.
+        stale = dict(self.DETAIL, organization="Old Org")
+        draft = contacts.card_draft(self.DETAIL)
+        with mock.patch.object(
+            contacts, "describe_records", side_effect=[[stale], [self.DETAIL]],
+        ) as described, mock.patch.object(contacts.time, "sleep") as slept:
+            result = contacts.settled_card_detail("uid-one", draft)
+        self.assertEqual(contacts.card_draft(result), draft)
+        self.assertEqual(described.call_count, 2)
+        slept.assert_called_once()
+
+    def test_readback_returns_last_view_when_the_card_really_changed(self):
+        changed = dict(self.DETAIL, organization="Someone Else Edited")
+        draft = contacts.card_draft(self.DETAIL)
+        with mock.patch.object(
+            contacts, "describe_records", return_value=[changed],
+        ) as described, mock.patch.object(contacts.time, "sleep"):
+            result = contacts.settled_card_detail("uid-one", draft)
+        self.assertNotEqual(contacts.card_draft(result), draft)
+        self.assertEqual(described.call_count, 10)
+
+    def test_readback_tolerates_transient_describe_failures(self):
+        draft = contacts.card_draft(self.DETAIL)
+        with mock.patch.object(
+            contacts, "describe_records",
+            side_effect=[RuntimeError("app view lagging"), [self.DETAIL]],
+        ), mock.patch.object(contacts.time, "sleep"):
+            result = contacts.settled_card_detail("uid-one", draft)
+        self.assertEqual(contacts.card_draft(result), draft)
 
 
 if __name__ == "__main__":

--- a/bridge/mac/install.sh
+++ b/bridge/mac/install.sh
@@ -5,7 +5,9 @@
 # What it does:
 #   1. copies the bridge tools into ~/.blip/bin (imsg, imsg-send, imsg-read, contacts,
 #      tcc-check, blip-check) — read-only sqlite over chat.db, AppleScript
-#      send, Contacts — plus blip-dispatch, the forced-command gate that
+#      send, Contacts — plus the static contact-repair.js Automation helper,
+#      the compiled contact-mutation helper that uses Apple's current Contacts framework,
+#      the scoped contact-link.applescript UI handoff, and blip-dispatch, the forced-command gate that
 #      confines Blip's dedicated ssh key to exactly those tools;
 #   2. makes sure Remote Login (sshd) is on, since Blip talks over ssh;
 #   3. explains the two TCC grants that cannot be scripted:
@@ -22,13 +24,30 @@ dest="$HOME/.blip/bin"
 # denial (#36, Astra #11).
 check=1; for a in "$@"; do [[ $a == --no-check ]] && check=0; done
 mkdir -p "$dest"
-for t in imsg imsg-send imsg-read contacts contact-repair.js tcc-check blip-check blip-dispatch calling_codes.py; do
+for t in imsg imsg-send imsg-read contacts contact-repair.js contact-link.applescript tcc-check blip-check blip-dispatch calling_codes.py; do
   if [[ -f "$here/$t" ]]; then
     install -m 0755 "$here/$t" "$dest/$t"
   else
     echo "install.sh: missing $here/$t" >&2; exit 1
   fi
 done
+
+# The compiled Contacts helper powers contact WRITES, compare, and vCard
+# export. Reading iMessage needs none of it, so a machine without the
+# Command Line Tools still gets a complete install — those features simply
+# stay unavailable until swiftc exists and this installer is re-run.
+if xcrun --find swiftc >/dev/null 2>&1; then
+  delete_tmp="$dest/.contact-delete.new"
+  xcrun swiftc -O -framework Contacts "$here/contact-delete.swift" -o "$delete_tmp"
+  chmod 0755 "$delete_tmp"
+  mv -f "$delete_tmp" "$dest/contact-delete"
+else
+  rm -f "$dest/contact-delete"
+  echo "install.sh: swiftc not found — skipping the compiled Contacts helper." >&2
+  echo "  Messaging works fully; contact writes, card compare, and vCard export" >&2
+  echo "  stay unavailable until Xcode Command Line Tools are installed and this" >&2
+  echo "  installer is re-run." >&2
+fi
 echo "✓ bridge tools installed to $dest"
 
 # /usr/bin/python3 ALWAYS exists on macOS — as a Command Line Tools stub that
@@ -55,6 +74,20 @@ Two permissions must be granted by hand (macOS will not let a script do it):
   2. Automation → Messages: the first send from an ssh session pops a prompt on
      THIS Mac's screen: "sshd-keygen-wrapper wants to control Messages" — click
      Allow once. (blip-setup triggers this with a dry-run-free self-send.)
+
+Optional contact comparison, editing, deletion, consolidation, repair, and linking need Automation →
+Contacts for sshd-keygen-wrapper. Blip requests it only when you explicitly
+open those tools; contact writes additionally require both contact_writes=on
+on Linux and the owner-only ~/.blip/contact-writes-enabled gate on this Mac.
+
+Blip previews and revision-pins each card mutation. It writes an owner-only
+undo receipt before saving through Contacts.app and Apple's Contacts framework;
+it never writes Contacts' private SQLite databases directly.
+
+Linking or merging exact cards from Blip additionally uses System Events and
+requires sshd-keygen-wrapper under Privacy & Security → Accessibility. Blip
+first selects the revalidated cards and shows a separate confirmation; it
+invokes only Contacts' enabled Link/Merge Selected Cards menu item.
 
 Then check:
 EOF

--- a/contact-management.test.ts
+++ b/contact-management.test.ts
@@ -520,3 +520,30 @@ describe("Mac candidate boundary", () => {
   });
 });
 
+
+describe("contact workspace CLI", () => {
+  test("removed name preferences cannot create a local display override", () => {
+    const { root } = fixture();
+    for (const operation of ["choose", "custom", "clear"]) {
+      const result = spawnSync(process.execPath, ["contact-management.ts", operation], {
+        cwd: import.meta.dir,
+        env: { ...process.env, HOME: root },
+        input: JSON.stringify({ handle: "+15551234567", name: "Example", token }),
+        encoding: "utf8", timeout: 1500,
+      });
+      expect(result.status).toBe(1);
+      expect(JSON.parse(result.stdout).ok).toBe(false);
+      expect(existsSync(join(root, ".config", "blip", "identities.json"))).toBe(false);
+    }
+  });
+
+  test("oversized streaming input is rejected before a native request", () => {
+    const { root } = fixture();
+    const result = spawnSync(process.execPath, ["contact-management.ts", "edit"], {
+      cwd: import.meta.dir, env: { ...process.env, HOME: root },
+      input: "x".repeat(MAX_IDENTITY_REQUEST_BYTES + 1), encoding: "utf8", timeout: 1500,
+    });
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout).error).toContain("too large");
+  });
+});

--- a/contact-management.test.ts
+++ b/contact-management.test.ts
@@ -1,0 +1,522 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  auditContactsOnMac,
+  contactWritesEnabled,
+  contactMutationOnMac,
+  exportContactVCard,
+  identityKey,
+  MAX_BRIDGE_CONFIG_BYTES,
+  MAX_IDENTITY_REQUEST_BYTES,
+  normalizeBridgeCandidates,
+  normalizeContactComparison,
+  normalizeContactAudit,
+  normalizeContactDraft,
+  normalizeRepairPreview,
+  readBoundedBridgeConfig,
+  resolveOnMac,
+} from "./contact-management";
+
+const roots: string[] = [];
+function fixture(): { root: string; path: string } {
+  const root = mkdtempSync(join(tmpdir(), "blip-contact-management-"));
+  roots.push(root);
+  return { root, path: join(root, "blip", "bridge.conf") };
+}
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+const token = "sha256:" + "a".repeat(64);
+const cardToken = (character: string) => "sha256:" + character.repeat(64);
+describe("contact-write opt-in", () => {
+  test("is disabled by default and accepts only an explicit on value", () => {
+    const { root } = fixture();
+    const path = join(root, "blip", "bridge.conf");
+    mkdirSync(join(root, "blip"), { recursive: true, mode: 0o700 });
+    writeFileSync(path, "host=mac\ncontact_writes=off\n");
+    expect(contactWritesEnabled(path)).toBe(false);
+    writeFileSync(path, "contact_writes='on'\n");
+    expect(contactWritesEnabled(path)).toBe(true);
+    writeFileSync(path, "contact_writes=on\ncontact_writes=off\n");
+    expect(contactWritesEnabled(path)).toBe(false);
+  });
+
+  test("fails closed for oversized, symlinked, and group-writable config", () => {
+    const first = fixture();
+    const path = join(first.root, "blip", "bridge.conf");
+    mkdirSync(join(first.root, "blip"), { recursive: true, mode: 0o700 });
+    writeFileSync(path, Buffer.alloc(MAX_BRIDGE_CONFIG_BYTES + 1, 0x20));
+    expect(contactWritesEnabled(path)).toBe(false);
+    expect(() => readBoundedBridgeConfig(path)).toThrow("too large");
+    writeFileSync(path, "contact_writes=on\n");
+    chmodSync(path, 0o622);
+    expect(contactWritesEnabled(path)).toBe(false);
+
+    const second = fixture();
+    const target = join(second.root, "target.conf");
+    const link = join(second.root, "blip", "bridge.conf");
+    mkdirSync(join(second.root, "blip"), { recursive: true, mode: 0o700 });
+    writeFileSync(target, "contact_writes=on\n");
+    symlinkSync(target, link);
+    expect(contactWritesEnabled(link)).toBe(false);
+  });
+});
+
+describe("Mac candidate boundary", () => {
+  test("validates a bounded candidate response", () => {
+    const cards = [
+      { token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: true, matchCount: 1 },
+      { token: cardToken("c"), accountNumber: 2, sourceName: "Google", hasPhoto: false, matchCount: 1 },
+      { token: cardToken("d"), accountNumber: 2, sourceName: "Google", hasPhoto: false, matchCount: 1 },
+    ];
+    expect(normalizeBridgeCandidates({
+      ok: true,
+      handle: "+15550100001",
+      candidates: [{
+        token, name: "Alex Rivera", recordCount: 3, sourceCount: 2, hasPhoto: true, cards,
+      }],
+    }, "+15550100001")).toEqual([
+      { token, name: "Alex Rivera", recordCount: 3, sourceCount: 2, hasPhoto: true, cards },
+    ]);
+  });
+
+  test("rejects wrong handles, oversized lists, and hostile fields", () => {
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100002", candidates: [] }, "+15550100001"))
+      .toThrow("different handle");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: Array(9).fill({
+      token, name: "Alex", recordCount: 1, sourceCount: 1, hasPhoto: false,
+    }) }, "+15550100001")).toThrow("too many");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: [{
+      token: "bad", name: "<b>unsafe</b>", recordCount: 1, sourceCount: 1, hasPhoto: false,
+    }] }, "+15550100001")).toThrow("token");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: [{
+      token, name: "Alex", recordCount: 2, sourceCount: 1, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    }] }, "+15550100001")).toThrow("source-card list");
+    expect(() => normalizeBridgeCandidates({ ok: true, handle: "+15550100001", candidates: [{
+      token, name: "Alex", recordCount: 1, sourceCount: 2, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    }] }, "+15550100001")).toThrow("account metadata");
+  });
+
+  test("the handle travels through stdin, never argv", () => {
+    let capturedArgs: string[] = [];
+    let capturedInput = "";
+    const runner = ((_command: string, args: string[], options: any) => {
+      capturedArgs = args;
+      capturedInput = options.input;
+      return {
+        status: 0,
+        signal: null,
+        output: [],
+        pid: 1,
+        stdout: JSON.stringify({
+          ok: true,
+          handle: "+15550100001",
+          candidates: [{
+            token, name: "Alex Rivera", recordCount: 1, sourceCount: 1, hasPhoto: false,
+            cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+          }],
+        }),
+        stderr: "",
+        error: undefined,
+      };
+    }) as any;
+    const result = resolveOnMac("candidates", "+15550100001", undefined, runner);
+    expect(capturedArgs).toEqual(["--json", "resolve"]);
+    expect(capturedArgs.join(" ")).not.toContain("15550100001");
+    expect(JSON.parse(capturedInput).handle).toBe("+15550100001");
+    expect(result.candidates?.[0]?.name).toBe("Alex Rivera");
+  });
+
+  test("contact audit classifies a bounded handle batch through one bridge call", () => {
+    let capturedInput = "";
+    const single = {
+      token, name: "Alex Rivera", recordCount: 1, sourceCount: 1, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    };
+    const duplicate = {
+      token: cardToken("c"), name: "Pat Rivera", recordCount: 2, sourceCount: 2, hasPhoto: false,
+      cards: [
+        { token: cardToken("d"), accountNumber: 1, sourceName: "Gmail", hasPhoto: false },
+        { token: cardToken("e"), accountNumber: 2, sourceName: "iCloud", hasPhoto: false },
+      ],
+    };
+    const runner = ((_command: string, args: string[], options: any) => {
+      capturedInput = options.input;
+      return {
+        status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({
+          ok: true, handleCount: 3, noMatchCount: 1,
+          singleCards: [{ handle: "+15550100001", candidates: [single] }],
+          duplicates: [{ handle: "+15550100002", candidates: [duplicate] }],
+          conflicts: [],
+        }),
+      };
+    }) as any;
+    const savedHome = process.env.HOME;
+    process.env.HOME = mkdtempSync(join(tmpdir(), "blip-audit-test-"));
+    try {
+      const result = auditContactsOnMac(
+        ["+15550100001", "+15550100002", "+15550100003"], runner,
+      );
+      expect(result.cached).toBe(false);
+      expect(result.audit.noMatchCount).toBe(1);
+      expect(result.audit.singleCards[0]?.candidates[0]?.name).toBe("Alex Rivera");
+      expect(result.audit.duplicates[0]?.candidates[0]?.recordCount).toBe(2);
+      expect(JSON.parse(capturedInput)).toEqual({
+        operation: "audit", handles: ["+15550100001", "+15550100002", "+15550100003"],
+      });
+    } finally {
+      process.env.HOME = savedHome;
+    }
+  });
+
+  test("an unchanged store fingerprint reuses the cached scan without re-scanning", () => {
+    const savedHome = process.env.HOME;
+    process.env.HOME = mkdtempSync(join(tmpdir(), "blip-audit-cache-"));
+    const fingerprint = "sha256:" + "9".repeat(64);
+    const operations: string[] = [];
+    const runner = ((_command: string, _args: string[], options: any) => {
+      const request = JSON.parse(options.input);
+      operations.push(request.operation);
+      if (request.operation === "fingerprint")
+        return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+          stdout: JSON.stringify({ ok: true, fingerprint }) };
+      return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({
+          ok: true, fingerprint, handleCount: 1, noMatchCount: 1,
+          singleCards: [], duplicates: [], conflicts: [],
+        }) };
+    }) as any;
+    try {
+      const first = auditContactsOnMac(["+15550100001"], runner);
+      expect(first.cached).toBe(false);
+      const second = auditContactsOnMac(["+15550100001"], runner);
+      expect(second.cached).toBe(true);
+      expect(second.audit.noMatchCount).toBe(1);
+      // the second call only paid one cheap fingerprint round-trip
+      expect(operations).toEqual(["audit", "fingerprint"]);
+      // a different conversation set never reuses the cache
+      const third = auditContactsOnMac(["+15550100002"], runner);
+      expect(third.cached).toBe(false);
+      expect(operations).toEqual(["audit", "fingerprint", "audit"]);
+    } finally {
+      process.env.HOME = savedHome;
+    }
+  });
+
+  test("contact audit rejects inconsistent totals and category shapes", () => {
+    const single = {
+      token, name: "Alex Rivera", recordCount: 1, sourceCount: 1, hasPhoto: false,
+      cards: [{ token: cardToken("b"), accountNumber: 1, sourceName: "iCloud", hasPhoto: false }],
+    };
+    const base = {
+      handleCount: 1, noMatchCount: 0,
+      singleCards: [{ handle: "+15550100001", candidates: [single] }],
+      duplicates: [], conflicts: [],
+    };
+    expect(() => normalizeContactAudit({ ...base, noMatchCount: 1 }, 1)).toThrow("totals");
+    expect(() => normalizeContactAudit({
+      ...base, singleCards: [], duplicates: [{ handle: "+15550100001", candidates: [single] }],
+    }, 1)).toThrow("duplicate-card");
+    expect(() => auditContactsOnMac(["+15550100001", "5550100001"])).toThrow("duplicate handle");
+    const wrongHandleRunner = (() => ({
+      status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+      stdout: JSON.stringify({
+        ok: true, handleCount: 1, noMatchCount: 0,
+        singleCards: [{ handle: "+15550199999", candidates: [single] }],
+        duplicates: [], conflicts: [],
+      }),
+    })) as any;
+    expect(() => auditContactsOnMac(["+15550100001"], wrongHandleRunner)).toThrow("unrequested");
+  });
+
+  test("exact-card open keeps its token on stdin and validates card metadata", () => {
+    let capturedInput = "";
+    const exactToken = cardToken("e");
+    const runner = ((_command: string, args: string[], options: any) => {
+      capturedInput = options.input;
+      return {
+        status: 0,
+        signal: null,
+        output: [],
+        pid: 1,
+        stdout: JSON.stringify({
+          ok: true, opened: true, name: "Alex Rivera",
+          cardNumber: 2, cardCount: 3, accountNumber: 1, sourceName: "iCloud",
+        }),
+        stderr: "",
+        error: undefined,
+      };
+    }) as any;
+    expect(resolveOnMac("open", "+15550100001", exactToken, runner)).toEqual({
+      handle: "+15550100001", opened: true, name: "Alex Rivera",
+      cardNumber: 2, cardCount: 3, accountNumber: 1, sourceName: "iCloud",
+    });
+    expect(JSON.parse(capturedInput)).toEqual({
+      operation: "open", handle: "+15550100001", token: exactToken,
+    });
+  });
+
+  test("vCard export stays on stdin and creates a real owner-only .vcf file", () => {
+    let bridgeInput = "";
+    const runtime = fixture().root;
+    const card = Buffer.from(
+      "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alex Rivera\r\nEND:VCARD\r\n",
+      "utf8",
+    );
+    const runner = ((_command: string, args: string[], options: any) => {
+      expect(args).toEqual(["--json", "resolve"]);
+      bridgeInput = options.input;
+      return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({ ok: true, name: "Alex Rivera", vcard: card.toString("base64") }) };
+    }) as any;
+    const result = exportContactVCard("+15550100001", runner, runtime);
+    expect(result).toEqual({
+      handle: "+15550100001", name: "Alex Rivera", bytes: card.length,
+      fileName: "Alex Rivera.vcf",
+      fileUri: expect.stringContaining("/Alex%20Rivera.vcf"),
+    });
+    expect(JSON.parse(bridgeInput)).toEqual({
+      operation: "vcard", handle: "+15550100001",
+    });
+    const copiedPath = decodeURIComponent(new URL(result.fileUri).pathname);
+    expect(readFileSync(copiedPath)).toEqual(card);
+    expect(lstatSync(copiedPath).mode & 0o077).toBe(0);
+  });
+
+  test("discard-unsaved sends no contact identifier and validates the result", () => {
+    let bridgeInput = "";
+    const runner = ((_command: string, args: string[], options: any) => {
+      expect(args).toEqual(["--json", "resolve"]);
+      bridgeInput = options.input;
+      return { status: 0, signal: null, output: [], pid: 1, stderr: "", error: undefined,
+        stdout: JSON.stringify({ ok: true, discarded: true }) };
+    }) as any;
+    expect(resolveOnMac("discard-unsaved", undefined, undefined, runner))
+      .toEqual({ discarded: true });
+    expect(JSON.parse(bridgeInput)).toEqual({ operation: "discard-unsaved" });
+  });
+
+  test("validates repair previews and rejects inconsistent metadata", () => {
+    const preview = {
+      handle: "+15550100001", name: "Pat Rivera", kind: "phone",
+      fieldCount: 1, labels: ["mobile"], cardNumber: 1, cardCount: 2,
+      accountNumber: 1, sourceName: "iCloud", writeEnabled: true,
+    };
+    expect(normalizeRepairPreview(preview, "5550100001")).toEqual(preview);
+    expect(() => normalizeRepairPreview({ ...preview, labels: [] }, preview.handle))
+      .toThrow("field-label");
+    expect(() => normalizeRepairPreview({ ...preview, cardNumber: 3 }, preview.handle))
+      .toThrow("inconsistent card");
+    expect(() => normalizeRepairPreview({ ...preview, name: "x".repeat(161) }, preview.handle))
+      .toThrow("too long");
+  });
+
+  test("validates bounded contact-card comparisons", () => {
+    const comparison = {
+      handle: "+15550100001", name: "Alex Rivera", cardCount: 2,
+      sourceCount: 2, writeEnabled: true,
+      cards: [1, 2].map((number) => ({
+        token: cardToken(number === 1 ? "b" : "c"), revision: cardToken(number === 1 ? "d" : "e"), cardNumber: number,
+        accountNumber: number, sourceName: number === 1 ? "iCloud" : "Google",
+        hasPhoto: number === 1,
+        displayName: "Alex Rivera", firstName: "Alex", middleName: "", lastName: "Rivera",
+        nickname: "", organization: "Example", department: "", jobTitle: "",
+        birthday: "--09-02", note: "",
+        phones: [{ label: "mobile", value: "+1 555 010 0001" }],
+        emails: number === 1 ? [{ label: "home", value: "alex@example.com" }] : [],
+        urls: [], addresses: number === 2 ? [{ label: "home", street: "1 Main St",
+          city: "Madison", state: "WI", postalCode: "53703", country: "US",
+          countryCode: "US" }] : [],
+      })),
+    };
+    expect(normalizeContactComparison(comparison, "5550100001")).toEqual(comparison);
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      comparison.cards[0], { ...comparison.cards[1], token: comparison.cards[0]!.token },
+    ] }, comparison.handle)).toThrow("duplicate comparison card");
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      comparison.cards[0], { ...comparison.cards[1], cardNumber: 3 },
+    ] }, comparison.handle)).toThrow("card numbers");
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      { ...comparison.cards[0], phones: Array(17).fill({ label: "x", value: "1" }) },
+      comparison.cards[1],
+    ] }, comparison.handle)).toThrow("phone list");
+    expect(() => normalizeContactComparison({ ...comparison, cards: [
+      { ...comparison.cards[0], note: "x".repeat(1001) }, comparison.cards[1],
+    ] }, comparison.handle)).toThrow("note");
+  });
+
+  test("comparison and link operations stay on stdin and validate Apple actions", () => {
+    const comparison = {
+      handle: "+15550100001", name: "Alex Rivera", cardCount: 2,
+      sourceCount: 2, writeEnabled: true,
+      cards: [1, 2].map((number) => ({
+        token: cardToken(number === 1 ? "b" : "c"), revision: cardToken(number === 1 ? "d" : "e"), cardNumber: number,
+        accountNumber: number, sourceName: number === 1 ? "iCloud" : "Google",
+        hasPhoto: false, displayName: "Alex Rivera",
+        firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "",
+        organization: "", department: "", jobTitle: "", birthday: "", note: "",
+        phones: [], emails: [], urls: [], addresses: [],
+      })),
+    };
+    const captured: Array<{ args: string[]; input: string }> = [];
+    const responses = [
+      { ok: true, ...comparison },
+      { ok: true, handle: comparison.handle, name: comparison.name, cardCount: 2,
+        sourceCount: 2, writeEnabled: true, ready: true, action: "Link Selected Cards" },
+      { ok: true, handle: comparison.handle, name: comparison.name, cardCount: 2,
+        sourceCount: 2, writeEnabled: true, linked: true, action: "Link Selected Cards" },
+    ];
+    const runner = ((_command: string, args: string[], options: any) => {
+      captured.push({ args, input: options.input });
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify(responses.shift()), stderr: "", error: undefined };
+    }) as any;
+    expect(resolveOnMac("compare", comparison.handle, token, runner).comparison?.cardCount).toBe(2);
+    expect(resolveOnMac("link-prepare", comparison.handle, token, runner).linkPreview?.ready).toBe(true);
+    expect(resolveOnMac(
+      "link", comparison.handle, token, runner, undefined, "Link Selected Cards",
+    ).linkResult?.linked).toBe(true);
+    expect(captured.every(({ args }) => args.join(" ").includes("15550100001") === false)).toBe(true);
+    expect(captured.map(({ input }) => JSON.parse(input))).toEqual([
+      { operation: "compare", handle: comparison.handle, ownerToken: token },
+      { operation: "link-prepare", handle: comparison.handle, ownerToken: token },
+      { operation: "link", handle: comparison.handle, ownerToken: token,
+        expectedAction: "Link Selected Cards" },
+    ]);
+    const badRunner = (() => ({ status: 0, signal: null, output: [], pid: 1,
+      stdout: JSON.stringify({ ...responses[0], ok: true, handle: comparison.handle,
+        name: comparison.name, cardCount: 2, sourceCount: 2, writeEnabled: true,
+        ready: true, action: "Delete Cards" }), stderr: "", error: undefined })) as any;
+    expect(() => resolveOnMac("link-prepare", comparison.handle, token, badRunner))
+      .toThrow("invalid link action");
+    expect(() => resolveOnMac(
+      "link", comparison.handle, token, runner, undefined, "Delete Cards",
+    )).toThrow("confirmed Contacts action");
+  });
+
+  test("contact edits are bounded, revision-pinned, previewed, and confirmed", () => {
+    const exactToken = cardToken("b");
+    const revision = cardToken("c");
+    const planHash = cardToken("d");
+    const draft = normalizeContactDraft({
+      firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "Lex",
+      organization: "Example", department: "", jobTitle: "", birthday: "--09-02",
+      note: "", phones: [{ label: "mobile", value: "+1 555 010 0001" }],
+      emails: [], urls: [], addresses: [],
+    });
+    const metadata = {
+      action: "edit", handle: "+15550100001", name: "Alex Rivera", cardNumber: 1,
+      cardCount: 2, accountNumber: 1, sourceName: "iCloud", sourceCardCount: 0,
+      changedFields: ["nickname"], planHash, writeEnabled: true,
+    };
+    const captured: string[] = [];
+    const responses = [
+      { ok: true, preview: metadata },
+      { ok: true, ...metadata, applied: true, undoToken: "undo:" + "f".repeat(32),
+        revision: cardToken("e"), displayName: "Alex Rivera" },
+    ];
+    const runner = ((_command: string, args: string[], options: any) => {
+      expect(args).toEqual(["--json", "resolve"]);
+      captured.push(options.input);
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify(responses.shift()), stderr: "", error: undefined };
+    }) as any;
+    const input = { handle: metadata.handle, ownerToken: token, token: exactToken, revision, card: draft };
+    expect(contactMutationOnMac("edit-prepare", input, runner).preview?.action).toBe("edit");
+    expect(contactMutationOnMac("edit", { ...input, planHash }, runner).result?.applied).toBe(true);
+    expect(JSON.parse(captured[0]!)).toEqual({ operation: "edit-prepare", ...input });
+    expect(JSON.parse(captured[1]!)).toEqual({ operation: "edit", ...input, planHash });
+    expect(() => contactMutationOnMac("edit", { ...input, planHash: "sha256:bad" }, runner))
+      .toThrow("revision");
+  });
+
+  test("cross-name merge threads the second owner token and rejects a duplicate", () => {
+    const token = "sha256:" + "1".repeat(64);
+    const otherToken = "sha256:" + "2".repeat(64);
+    const captured: string[] = [];
+    const comparison = {
+      handle: "+15550100001", name: "Alex Rivera", cardCount: 2,
+      sourceCount: 2, writeEnabled: true,
+      cards: [1, 2].map((number) => ({
+        token: "sha256:" + String(number).repeat(63) + "a",
+        revision: "sha256:" + String(number).repeat(63) + "b", cardNumber: number,
+        accountNumber: number, sourceName: number === 1 ? "iCloud" : "Google",
+        hasPhoto: false, displayName: "Alex Rivera",
+        firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "",
+        organization: "", department: "", jobTitle: "", birthday: "", note: "",
+        phones: [], emails: [], urls: [], addresses: [],
+      })),
+    };
+    const runner = ((_command: string, _args: string[], options: any) => {
+      captured.push(options.input);
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify({ ok: true, ...comparison }), stderr: "", error: undefined };
+    }) as any;
+    resolveOnMac("compare", comparison.handle, token, runner, undefined, undefined, otherToken);
+    expect(JSON.parse(captured[0]!)).toEqual({
+      operation: "compare", handle: comparison.handle, ownerToken: token, otherOwnerToken: otherToken,
+    });
+    expect(() => resolveOnMac(
+      "compare", comparison.handle, token, runner, undefined, undefined, token,
+    )).toThrow("different candidate");
+    const draft = {
+      firstName: "Alex", middleName: "", lastName: "Rivera", nickname: "",
+      organization: "", department: "", jobTitle: "", birthday: "", note: "",
+      phones: [], emails: [], urls: [], addresses: [],
+    };
+    const revisions = comparison.cards.map((card) => ({ token: card.token, revision: card.revision }));
+    expect(() => contactMutationOnMac("merge-prepare", {
+      handle: comparison.handle, ownerToken: token, otherOwnerToken: token,
+      targetToken: comparison.cards[0]!.token, revisions, card: draft,
+    }, runner)).toThrow("different candidate");
+  });
+
+  test("inspect, removal, and undo keep contact data on stdin and validate receipts", () => {
+    const exactToken = cardToken("e");
+    const undoToken = "undo:" + "f".repeat(32);
+    const preview = {
+      handle: "+15550100001", name: "Pat Rivera", kind: "phone",
+      fieldCount: 1, labels: ["mobile"], cardNumber: 1, cardCount: 2,
+      accountNumber: 1, sourceName: "iCloud", writeEnabled: true,
+    };
+    const captured: Array<{ args: string[]; input: string }> = [];
+    const responses = [
+      { ok: true, preview },
+      { ok: true, ...preview, removed: true, undoToken },
+      { ok: true, restored: true, alreadyPresent: false, handle: preview.handle,
+        name: preview.name, action: "field-removal", cardCount: 1, fieldCount: 1 },
+    ];
+    const runner = ((_command: string, args: string[], options: any) => {
+      captured.push({ args, input: options.input });
+      return { status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify(responses.shift()), stderr: "", error: undefined };
+    }) as any;
+    expect(resolveOnMac("inspect", preview.handle, exactToken, runner, token).preview).toEqual(preview);
+    expect(resolveOnMac("remove", preview.handle, exactToken, runner, token).removal?.undoToken).toBe(undoToken);
+    expect(resolveOnMac("undo", undefined, undoToken, runner).undo?.restored).toBe(true);
+    expect(captured.every(({ args }) => args.join(" ").includes("15550100001") === false)).toBe(true);
+    expect(JSON.parse(captured[0]!.input)).toEqual({
+      operation: "inspect", handle: preview.handle, token: exactToken, ownerToken: token,
+    });
+    expect(JSON.parse(captured[2]!.input)).toEqual({ operation: "undo", undoToken });
+    expect(() => resolveOnMac("undo", undefined, "undo:bad", runner)).toThrow("undo token");
+  });
+});
+

--- a/contact-management.test.ts
+++ b/contact-management.test.ts
@@ -547,3 +547,13 @@ describe("contact workspace CLI", () => {
     expect(JSON.parse(result.stdout).error).toContain("too large");
   });
 });
+
+
+test("initial contact view skips only an unambiguous person, never writes", async () => {
+  const { initialContactToken } = await import("./contact-management");
+  const candidate = { token, name: "Sample Contact", recordCount: 2, sourceCount: 2,
+    hasPhoto: false, cards: [] };
+  expect(initialContactToken([])).toBe("");
+  expect(initialContactToken([candidate])).toBe(token);
+  expect(initialContactToken([candidate, { ...candidate, token: "sha256:" + "b".repeat(64) }])).toBe("");
+});

--- a/contact-management.ts
+++ b/contact-management.ts
@@ -1,0 +1,1319 @@
+// Bounded contact management. Local configuration is read only from bridge.conf.
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const MAX_IDENTITY_REQUEST_BYTES = 48 * 1024;
+export const MAX_IDENTITY_OUTPUT_BYTES = 48 * 1024;
+export const MAX_BRIDGE_OUTPUT_BYTES = 48 * 1024;
+export const MAX_VCARD_BYTES = 2 * 1024 * 1024;
+export const MAX_VCARD_RESPONSE_BYTES = 3 * 1024 * 1024;
+export const MAX_IDENTITY_CANDIDATES = 8;
+export const MAX_IDENTITY_CARDS = 64;
+export const MAX_REPAIR_FIELDS = 8;
+export const MAX_COMPARE_CARDS = 8;
+export const MAX_CARD_VALUES = 16;
+export const MAX_CONTACT_AUDIT_HANDLES = 200;
+export const MAX_BRIDGE_CONFIG_BYTES = 16 * 1024;
+export const MAX_HANDLE_CHARS = 320;
+export const MAX_NAME_CHARS = 160;
+
+export interface IdentityCandidate {
+  token: string;
+  name: string;
+  recordCount: number;
+  sourceCount: number;
+  hasPhoto: boolean;
+  cards: IdentitySourceCard[];
+}
+
+export interface IdentitySourceCard {
+  token: string;
+  accountNumber: number;
+  sourceName: string;
+  hasPhoto: boolean;
+  matchCount: number;
+}
+
+export interface ContactAuditEntry {
+  handle: string;
+  candidates: IdentityCandidate[];
+}
+
+export interface ContactAudit {
+  handleCount: number;
+  noMatchCount: number;
+  singleCards: ContactAuditEntry[];
+  duplicates: ContactAuditEntry[];
+  conflicts: ContactAuditEntry[];
+}
+
+export interface ContactRepairPreview {
+  handle: string;
+  name: string;
+  kind: "phone" | "email";
+  fieldCount: number;
+  labels: string[];
+  cardNumber: number;
+  cardCount: number;
+  accountNumber: number;
+  sourceName: string;
+  writeEnabled: boolean;
+}
+
+export interface ContactRemoval extends ContactRepairPreview {
+  removed: true;
+  undoToken: string;
+}
+
+export interface ContactUndo {
+  restored: true;
+  alreadyPresent: boolean;
+  action: "field-removal" | "edit" | "delete" | "consolidate";
+  handle: string;
+  name: string;
+  cardCount: number;
+  fieldCount: number;
+}
+
+export interface ContactLabeledValue {
+  label: string;
+  value: string;
+}
+
+export interface ContactAddress {
+  label: string;
+  street: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+  countryCode: string;
+}
+
+export interface ContactCardDetail {
+  token: string;
+  revision: string;
+  cardNumber: number;
+  accountNumber: number;
+  sourceName: string;
+  hasPhoto: boolean;
+  displayName: string;
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  nickname: string;
+  organization: string;
+  department: string;
+  jobTitle: string;
+  birthday: string;
+  note: string;
+  phones: ContactLabeledValue[];
+  emails: ContactLabeledValue[];
+  urls: ContactLabeledValue[];
+  addresses: ContactAddress[];
+}
+
+export type ContactCardDraft = Omit<
+  ContactCardDetail,
+  "token" | "revision" | "cardNumber" | "accountNumber" | "sourceName" | "hasPhoto" | "displayName"
+>;
+
+export interface ContactMutationPreview {
+  action: "edit" | "delete" | "consolidate";
+  handle: string;
+  name: string;
+  cardNumber: number;
+  cardCount: number;
+  accountNumber: number;
+  sourceName: string;
+  sourceCardCount: number;
+  changedFields: string[];
+  planHash: string;
+  writeEnabled: boolean;
+}
+
+export interface ContactMutationResult extends ContactMutationPreview {
+  applied: true;
+  undoToken: string;
+  revision?: string;
+  displayName?: string;
+}
+
+export interface ContactComparison {
+  handle: string;
+  name: string;
+  cardCount: number;
+  sourceCount: number;
+  writeEnabled: boolean;
+  cards: ContactCardDetail[];
+}
+
+export interface ContactLinkPreview {
+  handle: string;
+  name: string;
+  cardCount: number;
+  sourceCount: number;
+  writeEnabled: boolean;
+  action: "Link Selected Cards" | "Merge Selected Cards" | "Merge and Link Selected Cards";
+  ready: boolean;
+}
+
+export interface ContactLinkResult extends Omit<ContactLinkPreview, "ready"> {
+  linked: true;
+}
+
+const UNSAFE_TEXT = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g;
+const CONTACT_TOKEN = /^sha256:[0-9a-f]{64}$/;
+const CONTACT_REVISION = /^sha256:[0-9a-f]{64}$/;
+const UNDO_TOKEN = /^undo:[0-9a-f]{32}$/;
+
+function own(value: Record<string, unknown>, key: string): unknown {
+  return Object.prototype.hasOwnProperty.call(value, key) ? value[key] : undefined;
+}
+
+function boundedString(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  if (value.length > maximum) throw new Error(`${label} is too long`);
+  const text = value.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim();
+  if (!text) throw new Error(`${label} must not be empty`);
+  return text;
+}
+
+export function normalizeHandle(value: unknown): string {
+  const handle = boundedString(value, "handle", MAX_HANDLE_CHARS);
+  if (handle.includes("@")) {
+    const email = handle.toLowerCase();
+    if (email.length > 254 || !/^[^@\s]+@[^@\s]+$/.test(email))
+      throw new Error("handle is not a valid email address");
+    return handle;
+  }
+  if (!/^\+?[0-9][0-9 ()./-]{2,39}$/.test(handle))
+    throw new Error("handle is not a valid phone number");
+  const digits = handle.replace(/\D/g, "");
+  if (digits.length < 5) throw new Error("phone handle is too short");
+  return handle;
+}
+
+export function identityKey(value: unknown): string {
+  const handle = normalizeHandle(value);
+  if (handle.includes("@")) return `email:${handle.toLowerCase()}`;
+  const digits = handle.replace(/\D/g, "");
+  return `phone:${digits.length >= 10 ? digits.slice(-10) : digits}`;
+}
+
+export function normalizeIdentityName(value: unknown): string {
+  return boundedString(value, "name", MAX_NAME_CHARS);
+}
+
+function normalizeContactToken(value: unknown): string {
+  if (typeof value !== "string" || !CONTACT_TOKEN.test(value))
+    throw new Error("contact token is invalid");
+  return value;
+}
+
+function normalizeContactRevision(value: unknown): string {
+  if (typeof value !== "string" || !CONTACT_REVISION.test(value))
+    throw new Error("contact revision is invalid");
+  return value;
+}
+
+function currentUid(): number {
+  const uid = typeof process.getuid === "function" ? process.getuid() : -1;
+  if (uid < 0) throw new Error("cannot determine the current user");
+  return uid;
+}
+
+function openPinnedDirectory(path: string, create: boolean): number {
+  if (create) mkdirSync(path, { recursive: true, mode: 0o700 });
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+  );
+  const info = fstatSync(fd);
+  if (!info.isDirectory()) {
+    closeSync(fd);
+    throw new Error("identity directory is not a directory");
+  }
+  if (info.uid !== currentUid()) {
+    closeSync(fd);
+    throw new Error("identity directory is not owned by the current user");
+  }
+  if ((info.mode & 0o077) !== 0) fchmodSync(fd, 0o700);
+  return fd;
+}
+
+function pinnedPath(directoryFd: number, name: string): string {
+  return `/proc/self/fd/${directoryFd}/${name}`;
+}
+
+export function readBoundedBridgeConfig(path: string): string | null {
+  let directoryFd = -1;
+  let fileFd = -1;
+  try {
+    try { directoryFd = openPinnedDirectory(dirname(path), false); }
+    catch (error: any) {
+      if (error?.code === "ENOENT") return null;
+      throw error;
+    }
+    try {
+      fileFd = openSync(
+        pinnedPath(directoryFd, basename(path)),
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+    } catch (error: any) {
+      if (error?.code === "ENOENT") return null;
+      throw error;
+    }
+    const info = fstatSync(fileFd);
+    if (!info.isFile()) throw new Error("bridge.conf must be a regular file");
+    if (info.uid !== currentUid()) throw new Error("bridge.conf is not owned by the current user");
+    if ((info.mode & 0o022) !== 0) throw new Error("bridge.conf is writable by another user");
+    if (info.size > MAX_BRIDGE_CONFIG_BYTES) throw new Error("bridge.conf is too large");
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.alloc(Math.min(4096, MAX_BRIDGE_CONFIG_BYTES + 1 - total));
+      const count = readSync(fileFd, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > MAX_BRIDGE_CONFIG_BYTES) throw new Error("bridge.conf is too large");
+      chunks.push(chunk.subarray(0, count));
+    }
+    return Buffer.concat(chunks, total).toString("utf8");
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    if (directoryFd >= 0) closeSync(directoryFd);
+  }
+}
+
+export function bridgeConfigPath(): string {
+  const overridden = process.env.BLIP_BRIDGE_CONF;
+  if (overridden) {
+    if (!isAbsolute(overridden)) throw new Error("BLIP_BRIDGE_CONF must be absolute");
+    return overridden;
+  }
+  const home = process.env.HOME;
+  if (!home || !isAbsolute(home)) throw new Error("HOME must be an absolute path");
+  return join(home, ".config", "blip", "bridge.conf");
+}
+
+/** Fail closed: only an explicit, owner-controlled `contact_writes=on` enables UI writes. */
+export function contactWritesEnabled(path = bridgeConfigPath()): boolean {
+  let text: string | null;
+  try { text = readBoundedBridgeConfig(path); }
+  catch { return false; }
+  if (text === null) return false;
+  let enabled = false;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.replace(/#.*/, "").trim();
+    if (!line || !line.includes("=")) continue;
+    const split = line.indexOf("=");
+    if (line.slice(0, split).trim() !== "contact_writes") continue;
+    let value = line.slice(split + 1).trim().toLowerCase();
+    if ((value.startsWith('"') && value.endsWith('"'))
+        || (value.startsWith("'") && value.endsWith("'"))) value = value.slice(1, -1);
+    enabled = ["on", "true", "1", "yes"].includes(value);
+  }
+  return enabled;
+}
+
+function finiteInteger(value: unknown, label: string, low: number, high: number): number {
+  if (!Number.isInteger(value) || Number(value) < low || Number(value) > high)
+    throw new Error(`${label} is invalid`);
+  return Number(value);
+}
+
+function optionalLabel(value: unknown): string {
+  if (typeof value !== "string" || value.length > 80) throw new Error("contact label is invalid");
+  return value.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim();
+}
+
+function contactSourceName(value: unknown): string {
+  return boundedString(value, "contact source name", 120);
+}
+
+function normalizeUndoToken(value: unknown): string {
+  if (typeof value !== "string" || !UNDO_TOKEN.test(value)) throw new Error("undo token is invalid");
+  return value;
+}
+
+export function normalizeBridgeCandidates(value: unknown, requestedHandle: string): IdentityCandidate[] {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid response");
+  const response = value as Record<string, unknown>;
+  if (response.ok !== true) {
+    throw new Error(safeError(response.error || "Contacts could not resolve this handle"));
+  }
+  if (identityKey(response.handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  if (!Array.isArray(response.candidates) || response.candidates.length > MAX_IDENTITY_CANDIDATES)
+    throw new Error("Contacts returned too many candidates");
+  const seen = new Set<string>();
+  let cardCount = 0;
+  return response.candidates.map((raw: unknown) => {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+      throw new Error("Contacts returned an invalid candidate");
+    const candidate = raw as Record<string, unknown>;
+    const token = normalizeContactToken(candidate.token);
+    if (seen.has(token)) throw new Error("Contacts returned a duplicate candidate");
+    seen.add(token);
+    const recordCount = finiteInteger(candidate.recordCount, "record count", 1, MAX_IDENTITY_CARDS);
+    const sourceCount = finiteInteger(candidate.sourceCount, "source count", 1, MAX_IDENTITY_CARDS);
+    if (!Array.isArray(candidate.cards) || candidate.cards.length !== recordCount)
+      throw new Error("Contacts returned an invalid source-card list");
+    cardCount += candidate.cards.length;
+    if (cardCount > MAX_IDENTITY_CARDS) throw new Error("Contacts returned too many source cards");
+    const accounts = new Set<number>();
+    const cards = candidate.cards.map((rawCard: unknown): IdentitySourceCard => {
+      if (rawCard === null || typeof rawCard !== "object" || Array.isArray(rawCard))
+        throw new Error("Contacts returned an invalid source card");
+      const card = rawCard as Record<string, unknown>;
+      const cardToken = normalizeContactToken(card.token);
+      if (seen.has(cardToken)) throw new Error("Contacts returned a duplicate card token");
+      seen.add(cardToken);
+      const accountNumber = finiteInteger(
+        card.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+      );
+      const matchCount = finiteInteger(card.matchCount ?? 1, "matching field count", 1, MAX_REPAIR_FIELDS);
+      accounts.add(accountNumber);
+      return {
+        token: cardToken,
+        accountNumber,
+        sourceName: contactSourceName(card.sourceName),
+        hasPhoto: card.hasPhoto === true,
+        matchCount,
+      };
+    });
+    if (accounts.size !== sourceCount)
+      throw new Error("Contacts returned inconsistent account metadata");
+    return {
+      token,
+      name: normalizeIdentityName(candidate.name),
+      recordCount,
+      sourceCount,
+      hasPhoto: candidate.hasPhoto === true,
+      cards,
+    };
+  });
+}
+
+export function normalizeContactAudit(value: unknown, expectedHandleCount: number): ContactAudit {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid audit");
+  if (!Number.isInteger(expectedHandleCount) || expectedHandleCount < 1
+      || expectedHandleCount > MAX_CONTACT_AUDIT_HANDLES)
+    throw new Error("contact audit handle count is invalid");
+  const audit = value as Record<string, unknown>;
+  const handleCount = finiteInteger(
+    audit.handleCount, "audit handle count", 1, MAX_CONTACT_AUDIT_HANDLES,
+  );
+  if (handleCount !== expectedHandleCount)
+    throw new Error("Contacts returned an incomplete audit");
+  const noMatchCount = finiteInteger(
+    audit.noMatchCount, "audit no-match count", 0, MAX_CONTACT_AUDIT_HANDLES,
+  );
+  const seen = new Set<string>();
+  function entries(raw: unknown, kind: "single" | "duplicate" | "conflict"): ContactAuditEntry[] {
+    if (!Array.isArray(raw) || raw.length > MAX_CONTACT_AUDIT_HANDLES)
+      throw new Error("Contacts returned an invalid audit category");
+    return raw.map((item) => {
+      if (item === null || typeof item !== "object" || Array.isArray(item))
+        throw new Error("Contacts returned an invalid audit entry");
+      const entry = item as Record<string, unknown>;
+      const handle = normalizeHandle(entry.handle);
+      const key = identityKey(handle);
+      if (seen.has(key)) throw new Error("Contacts returned a duplicate audited handle");
+      seen.add(key);
+      const candidates = normalizeBridgeCandidates({
+        ok: true, handle, candidates: entry.candidates,
+      }, handle);
+      if (kind === "single" && (candidates.length !== 1 || candidates[0]!.recordCount !== 1))
+        throw new Error("Contacts returned an invalid single-card audit entry");
+      if (kind === "duplicate" && (candidates.length !== 1 || candidates[0]!.recordCount < 2))
+        throw new Error("Contacts returned an invalid duplicate-card audit entry");
+      if (kind === "conflict" && candidates.length < 2)
+        throw new Error("Contacts returned an invalid conflict audit entry");
+      return { handle, candidates };
+    });
+  }
+  const singleCards = entries(audit.singleCards, "single");
+  const duplicates = entries(audit.duplicates, "duplicate");
+  const conflicts = entries(audit.conflicts, "conflict");
+  if (noMatchCount + singleCards.length + duplicates.length + conflicts.length !== handleCount)
+    throw new Error("Contacts returned inconsistent audit totals");
+  return { handleCount, noMatchCount, singleCards, duplicates, conflicts };
+}
+
+export const MAX_AUDIT_CACHE_BYTES = 512 * 1024;
+const FINGERPRINT_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+export function auditCachePath(): string {
+  const home = process.env.HOME ?? homedir();
+  return join(home, ".local", "state", "blip", "audit-cache.json");
+}
+
+export function storeFingerprintOnMac(runner: Runner = spawnSync): string {
+  const home = process.env.HOME ?? homedir();
+  const result: SpawnSyncReturns<string> = runner(
+    join(home, "bin", "contacts"),
+    ["--json", "resolve"],
+    { encoding: "utf8", input: JSON.stringify({ operation: "fingerprint" }),
+      timeout: 15000, maxBuffer: MAX_BRIDGE_OUTPUT_BYTES },
+  );
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  let response: unknown;
+  try { response = JSON.parse(String(result.stdout || "")); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  const body = (response ?? {}) as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts fingerprint failed"));
+  if (typeof body.fingerprint !== "string" || !FINGERPRINT_PATTERN.test(body.fingerprint))
+    throw new Error("Contacts returned an invalid store fingerprint");
+  return body.fingerprint;
+}
+
+function handleSetFingerprint(handles: string[]): string {
+  const keys = handles.map(identityKey).sort();
+  return "sha256:" + createHash("sha256")
+    .update(`blip-audit-handles-v1\0${JSON.stringify(keys)}`).digest("hex");
+}
+
+type AuditCacheEntry = { storeFingerprint: string; handleFingerprint: string; audit: ContactAudit };
+
+export function readAuditCache(path = auditCachePath()): AuditCacheEntry | null {
+  let directoryFd = -1;
+  let fileFd = -1;
+  try {
+    try { directoryFd = openPinnedDirectory(dirname(path), false); }
+    catch (error: any) { if (error?.code === "ENOENT") return null; throw error; }
+    try {
+      fileFd = openSync(
+        pinnedPath(directoryFd, basename(path)),
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+    } catch (error: any) { if (error?.code === "ENOENT") return null; throw error; }
+    const info = fstatSync(fileFd);
+    if (!info.isFile() || info.uid !== currentUid() || info.size > MAX_AUDIT_CACHE_BYTES)
+      return null;
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.alloc(Math.min(4096, MAX_AUDIT_CACHE_BYTES + 1 - total));
+      const count = readSync(fileFd, chunk, 0, chunk.length, null);
+      if (count === 0) break;
+      total += count;
+      if (total > MAX_AUDIT_CACHE_BYTES) return null;
+      chunks.push(chunk.subarray(0, count));
+    }
+    let parsed: unknown;
+    try { parsed = JSON.parse(Buffer.concat(chunks, total).toString("utf8")); }
+    catch { return null; }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const entry = parsed as Record<string, unknown>;
+    if (typeof entry.storeFingerprint !== "string" || !FINGERPRINT_PATTERN.test(entry.storeFingerprint)
+        || typeof entry.handleFingerprint !== "string"
+        || !FINGERPRINT_PATTERN.test(entry.handleFingerprint)) return null;
+    const rawAudit = entry.audit as Record<string, unknown> | undefined;
+    const handleCount = Number(rawAudit?.handleCount);
+    if (!Number.isInteger(handleCount)) return null;
+    let audit: ContactAudit;
+    try { audit = normalizeContactAudit(entry.audit, handleCount); }
+    catch { return null; }
+    return { storeFingerprint: entry.storeFingerprint, handleFingerprint: entry.handleFingerprint, audit };
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    if (directoryFd >= 0) closeSync(directoryFd);
+  }
+}
+
+export function writeAuditCache(entry: AuditCacheEntry, path = auditCachePath()): void {
+  const serialized = `${JSON.stringify(entry)}
+`;
+  if (Buffer.byteLength(serialized) > MAX_AUDIT_CACHE_BYTES)
+    throw new Error("audit cache entry is too large");
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const directoryFd = openPinnedDirectory(dirname(path), true);
+  const name = basename(path);
+  const tempName = `.${name}.tmp.${process.pid}.${randomBytes(6).toString("hex")}`;
+  const tempPath = pinnedPath(directoryFd, tempName);
+  let tempFd = -1;
+  let renamed = false;
+  try {
+    tempFd = openSync(
+      tempPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    const bytes = Buffer.from(serialized, "utf8");
+    let offset = 0;
+    while (offset < bytes.length) offset += writeSync(tempFd, bytes, offset, bytes.length - offset);
+    fchmodSync(tempFd, 0o600);
+    fsyncSync(tempFd);
+    closeSync(tempFd);
+    tempFd = -1;
+    renameSync(tempPath, pinnedPath(directoryFd, name));
+    renamed = true;
+  } finally {
+    if (tempFd >= 0) closeSync(tempFd);
+    if (!renamed) { try { unlinkSync(tempPath); } catch { /* no temporary file */ } }
+    closeSync(directoryFd);
+  }
+}
+
+export function auditContactsOnMac(
+  value: unknown, runner: Runner = spawnSync,
+): { audit: ContactAudit; cached: boolean } {
+  if (!Array.isArray(value) || value.length < 1 || value.length > MAX_CONTACT_AUDIT_HANDLES)
+    throw new Error("contact audit handle list is invalid");
+  const seen = new Set<string>();
+  const handles = value.map((raw) => {
+    const handle = normalizeHandle(raw);
+    const key = identityKey(handle);
+    if (seen.has(key)) throw new Error("contact audit contains a duplicate handle");
+    seen.add(key);
+    return handle;
+  });
+  // Freshness short-circuit: when the conversation set matches the cached
+  // scan, one cheap fingerprint round-trip decides whether the Mac's
+  // Contacts stores changed at all â unchanged means the cached cleanup
+  // results are still exact, so skip the full scan.
+  const handleFingerprint = handleSetFingerprint(handles);
+  let cache: AuditCacheEntry | null = null;
+  try { cache = readAuditCache(); } catch { cache = null; }
+  if (cache && cache.handleFingerprint === handleFingerprint) {
+    try {
+      if (storeFingerprintOnMac(runner) === cache.storeFingerprint) {
+        const requested = new Set(handles.map(identityKey));
+        const entries = [...cache.audit.singleCards, ...cache.audit.duplicates, ...cache.audit.conflicts];
+        if (entries.every((entry) => requested.has(identityKey(entry.handle))))
+          return { audit: cache.audit, cached: true };
+      }
+    } catch { /* fingerprint unavailable â fall through to a full scan */ }
+  }
+  const home = process.env.HOME ?? homedir();
+  const result: SpawnSyncReturns<string> = runner(
+    join(home, "bin", "contacts"),
+    ["--json", "resolve"],
+    {
+      encoding: "utf8",
+      input: JSON.stringify({ operation: "audit", handles }),
+      timeout: 35000,
+      maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
+    },
+  );
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES)
+    throw new Error("Contacts returned too much data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid audit response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts audit failed"));
+  const audit = normalizeContactAudit(body, handles.length);
+  const requestedKeys = new Set(handles.map(identityKey));
+  for (const entry of [...audit.singleCards, ...audit.duplicates, ...audit.conflicts]) {
+    if (!requestedKeys.has(identityKey(entry.handle)))
+      throw new Error("Contacts returned an unrequested audited handle");
+  }
+  if (typeof body.fingerprint === "string" && FINGERPRINT_PATTERN.test(body.fingerprint)) {
+    try { writeAuditCache({ storeFingerprint: body.fingerprint, handleFingerprint, audit }); }
+    catch { /* caching is best-effort */ }
+  }
+  return { audit, cached: false };
+}
+
+type Runner = typeof spawnSync;
+
+export function normalizeRepairPreview(value: unknown, requestedHandle: string): ContactRepairPreview {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid repair preview");
+  const preview = value as Record<string, unknown>;
+  const handle = normalizeHandle(preview.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  const kind = preview.kind === "phone" || preview.kind === "email" ? preview.kind : null;
+  if (!kind) throw new Error("Contacts returned an invalid field kind");
+  const fieldCount = finiteInteger(preview.fieldCount, "matching field count", 1, MAX_REPAIR_FIELDS);
+  if (!Array.isArray(preview.labels) || preview.labels.length !== fieldCount)
+    throw new Error("Contacts returned an invalid field-label list");
+  const cardNumber = finiteInteger(preview.cardNumber, "card number", 1, MAX_IDENTITY_CARDS);
+  const cardCount = finiteInteger(preview.cardCount, "card count", 1, MAX_IDENTITY_CARDS);
+  if (cardNumber > cardCount) throw new Error("Contacts returned inconsistent card metadata");
+  return {
+    handle,
+    name: normalizeIdentityName(preview.name),
+    kind,
+    fieldCount,
+    labels: preview.labels.map(optionalLabel),
+    cardNumber,
+    cardCount,
+    accountNumber: finiteInteger(
+      preview.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+    ),
+    sourceName: contactSourceName(preview.sourceName),
+    writeEnabled: preview.writeEnabled === true,
+  };
+}
+
+function contactText(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== "string" || value.length > maximum)
+    throw new Error(`Contacts returned an invalid ${label}`);
+  return value.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim();
+}
+
+function normalizeLabeledValues(value: unknown, label: string): ContactLabeledValue[] {
+  if (!Array.isArray(value) || value.length > MAX_CARD_VALUES)
+    throw new Error(`Contacts returned an invalid ${label} list`);
+  return value.map((raw) => {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+      throw new Error(`Contacts returned an invalid ${label}`);
+    const item = raw as Record<string, unknown>;
+    const itemValue = contactText(item.value, `${label} value`, 320);
+    if (!itemValue) throw new Error(`Contacts returned an empty ${label}`);
+    return { label: contactText(item.label, `${label} label`, 80), value: itemValue };
+  });
+}
+
+function normalizeAddresses(value: unknown): ContactAddress[] {
+  if (!Array.isArray(value) || value.length > MAX_CARD_VALUES)
+    throw new Error("Contacts returned an invalid address list");
+  return value.map((raw) => {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+      throw new Error("Contacts returned an invalid address");
+    const item = raw as Record<string, unknown>;
+    const address = {
+      label: contactText(item.label, "address label", 80),
+      street: contactText(item.street, "street", 320),
+      city: contactText(item.city, "city", 320),
+      state: contactText(item.state, "state", 320),
+      postalCode: contactText(item.postalCode, "postal code", 80),
+      country: contactText(item.country, "country", 160),
+      countryCode: contactText(item.countryCode, "country code", 8),
+    };
+    if (![address.street, address.city, address.state, address.postalCode, address.country].some(Boolean))
+      throw new Error("Contacts returned an empty address");
+    return address;
+  });
+}
+
+function normalizeCardDetail(value: unknown, seen: Set<string>): ContactCardDetail {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid card detail");
+  const card = value as Record<string, unknown>;
+  const token = normalizeContactToken(card.token);
+  if (seen.has(token)) throw new Error("Contacts returned a duplicate comparison card");
+  seen.add(token);
+  const birthday = contactText(card.birthday, "birthday", 10);
+  if (birthday && !/^(?:\d{4}\-|--)\d{2}\-\d{2}$/.test(birthday))
+    throw new Error("Contacts returned an invalid birthday");
+  return {
+    token,
+    revision: normalizeContactRevision(card.revision),
+    cardNumber: finiteInteger(card.cardNumber, "card number", 1, MAX_COMPARE_CARDS),
+    accountNumber: finiteInteger(card.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS),
+    sourceName: contactSourceName(card.sourceName),
+    hasPhoto: card.hasPhoto === true,
+    displayName: contactText(card.displayName, "display name", 160),
+    firstName: contactText(card.firstName, "first name", 160),
+    middleName: contactText(card.middleName, "middle name", 160),
+    lastName: contactText(card.lastName, "last name", 160),
+    nickname: contactText(card.nickname, "nickname", 160),
+    organization: contactText(card.organization, "organization", 320),
+    department: contactText(card.department, "department", 320),
+    jobTitle: contactText(card.jobTitle, "job title", 320),
+    birthday,
+    note: contactText(card.note, "note", 1000),
+    phones: normalizeLabeledValues(card.phones, "phone"),
+    emails: normalizeLabeledValues(card.emails, "email"),
+    urls: normalizeLabeledValues(card.urls, "URL"),
+    addresses: normalizeAddresses(card.addresses),
+  };
+}
+
+export function normalizeContactDraft(value: unknown): ContactCardDraft {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("contact card draft is invalid");
+  const card = value as Record<string, unknown>;
+  const birthday = contactText(card.birthday, "birthday", 10);
+  if (birthday && !/^(?:\d{4}\-|--)\d{2}\-\d{2}$/.test(birthday))
+    throw new Error("birthday must be YYYY-MM-DD or --MM-DD");
+  const draft = {
+    firstName: contactText(card.firstName, "first name", 160),
+    middleName: contactText(card.middleName, "middle name", 160),
+    lastName: contactText(card.lastName, "last name", 160),
+    nickname: contactText(card.nickname, "nickname", 160),
+    organization: contactText(card.organization, "organization", 320),
+    department: contactText(card.department, "department", 320),
+    jobTitle: contactText(card.jobTitle, "job title", 320),
+    birthday,
+    note: contactText(card.note, "note", 1000),
+    phones: normalizeLabeledValues(card.phones, "phone"),
+    emails: normalizeLabeledValues(card.emails, "email"),
+    urls: normalizeLabeledValues(card.urls, "URL"),
+    addresses: normalizeAddresses(card.addresses),
+  };
+  if (![draft.firstName, draft.lastName, draft.nickname, draft.organization].some(Boolean))
+    throw new Error("contact card needs a name, nickname, or organization");
+  return draft;
+}
+
+export function normalizeContactComparison(
+  value: unknown, requestedHandle: string,
+): ContactComparison {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid card comparison");
+  const body = value as Record<string, unknown>;
+  const handle = normalizeHandle(body.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  const cardCount = finiteInteger(body.cardCount, "card count", 1, MAX_COMPARE_CARDS);
+  const sourceCount = finiteInteger(body.sourceCount, "source count", 1, MAX_COMPARE_CARDS);
+  if (!Array.isArray(body.cards) || body.cards.length !== cardCount)
+    throw new Error("Contacts returned an invalid comparison-card list");
+  const seen = new Set<string>();
+  const cards = body.cards.map((card) => normalizeCardDetail(card, seen));
+  if (cards.some((card, index) => card.cardNumber !== index + 1))
+    throw new Error("Contacts returned inconsistent comparison-card numbers");
+  if (new Set(cards.map((card) => card.accountNumber)).size !== sourceCount)
+    throw new Error("Contacts returned inconsistent comparison accounts");
+  return {
+    handle,
+    name: normalizeIdentityName(body.name),
+    cardCount,
+    sourceCount,
+    writeEnabled: body.writeEnabled === true,
+    cards,
+  };
+}
+
+function normalizeLinkMetadata(
+  value: Record<string, unknown>, requestedHandle: string,
+): Omit<ContactLinkPreview, "ready"> {
+  const handle = normalizeHandle(value.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  const action = value.action;
+  if (action !== "Link Selected Cards" && action !== "Merge Selected Cards"
+      && action !== "Merge and Link Selected Cards")
+    throw new Error("Contacts returned an invalid link action");
+  return {
+    handle,
+    name: normalizeIdentityName(value.name),
+    cardCount: finiteInteger(value.cardCount, "card count", 2, MAX_COMPARE_CARDS),
+    sourceCount: finiteInteger(value.sourceCount, "source count", 1, MAX_COMPARE_CARDS),
+    writeEnabled: value.writeEnabled === true,
+    action,
+  };
+}
+
+function normalizeExpectedLinkAction(value: unknown): ContactLinkPreview["action"] {
+  if (value !== "Link Selected Cards" && value !== "Merge Selected Cards"
+      && value !== "Merge and Link Selected Cards")
+    throw new Error("the confirmed Contacts action is invalid");
+  return value;
+}
+
+function normalizeMutationPreview(
+  value: unknown, requestedHandle: string, expectedAction?: ContactMutationPreview["action"],
+): ContactMutationPreview {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Contacts returned an invalid mutation preview");
+  const preview = value as Record<string, unknown>;
+  const action = preview.action;
+  if (action !== "edit" && action !== "delete" && action !== "consolidate")
+    throw new Error("Contacts returned an invalid contact action");
+  if (expectedAction && action !== expectedAction)
+    throw new Error("the contact action changed; preview it again");
+  const handle = normalizeHandle(preview.handle);
+  if (identityKey(handle) !== identityKey(requestedHandle))
+    throw new Error("Contacts returned a different handle");
+  if (!Array.isArray(preview.changedFields) || preview.changedFields.length < 1
+      || preview.changedFields.length > 13)
+    throw new Error("Contacts returned an invalid change summary");
+  return {
+    action,
+    handle,
+    name: normalizeIdentityName(preview.name),
+    cardNumber: finiteInteger(preview.cardNumber, "card number", 1, MAX_COMPARE_CARDS),
+    cardCount: finiteInteger(preview.cardCount, "card count", 1, MAX_COMPARE_CARDS),
+    accountNumber: finiteInteger(
+      preview.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+    ),
+    sourceName: contactSourceName(preview.sourceName),
+    sourceCardCount: finiteInteger(
+      preview.sourceCardCount, "source card count", 0, MAX_COMPARE_CARDS - 1,
+    ),
+    changedFields: preview.changedFields.map((field) => contactText(field, "changed field", 40)),
+    planHash: normalizeContactRevision(preview.planHash),
+    writeEnabled: preview.writeEnabled === true,
+  };
+}
+
+type ContactMutationOperation =
+  "edit-prepare" | "edit" | "delete-prepare" | "delete" | "merge-prepare" | "merge";
+
+export function contactMutationOnMac(
+  operation: ContactMutationOperation,
+  input: Record<string, unknown>,
+  runner: Runner = spawnSync,
+): { preview?: ContactMutationPreview; result?: ContactMutationResult } {
+  const handle = normalizeHandle(input.handle);
+  const ownerToken = normalizeContactToken(input.ownerToken);
+  const request: Record<string, unknown> = { operation, handle, ownerToken };
+  let action: ContactMutationPreview["action"];
+  if (operation === "edit-prepare" || operation === "edit") {
+    action = "edit";
+    request.token = normalizeContactToken(input.token);
+    request.revision = normalizeContactRevision(input.revision);
+    request.card = normalizeContactDraft(input.card);
+  } else if (operation === "delete-prepare" || operation === "delete") {
+    action = "delete";
+    request.token = normalizeContactToken(input.token);
+    request.revision = normalizeContactRevision(input.revision);
+  } else {
+    action = "consolidate";
+    request.targetToken = normalizeContactToken(input.targetToken);
+    request.card = normalizeContactDraft(input.card);
+    // Explicit cross-name merge: the second owner token widens the scope to
+    // both people's cards; it must be a distinct, valid token.
+    if (input.otherOwnerToken !== undefined && input.otherOwnerToken !== null
+        && input.otherOwnerToken !== "") {
+      const otherOwnerToken = normalizeContactToken(input.otherOwnerToken);
+      if (otherOwnerToken === ownerToken)
+        throw new Error("the other person must be a different candidate");
+      request.otherOwnerToken = otherOwnerToken;
+    }
+    if (!Array.isArray(input.revisions) || input.revisions.length < 2
+        || input.revisions.length > MAX_COMPARE_CARDS)
+      throw new Error("contact revision list is invalid");
+    const seen = new Set<string>();
+    request.revisions = input.revisions.map((raw) => {
+      if (raw === null || typeof raw !== "object" || Array.isArray(raw))
+        throw new Error("contact revision is invalid");
+      const item = raw as Record<string, unknown>;
+      const token = normalizeContactToken(item.token);
+      if (seen.has(token)) throw new Error("contact revision list contains a duplicate card");
+      seen.add(token);
+      return { token, revision: normalizeContactRevision(item.revision) };
+    });
+  }
+  const applying = operation === "edit" || operation === "delete" || operation === "merge";
+  if (applying) request.planHash = normalizeContactRevision(input.planHash);
+  const home = process.env.HOME ?? homedir();
+  const result = runner(join(home, "bin", "contacts"), ["--json", "resolve"], {
+    encoding: "utf8",
+    input: JSON.stringify(request),
+    timeout: 35000,
+    maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
+  });
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES)
+    throw new Error("Contacts returned too much data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts operation failed"));
+  const preview = normalizeMutationPreview(applying ? body : body.preview, handle, action);
+  if (!applying) return { preview };
+  if (body.applied !== true) throw new Error("Contacts did not confirm the contact change");
+  const mutation: ContactMutationResult = {
+    ...preview,
+    applied: true,
+    undoToken: normalizeUndoToken(body.undoToken),
+  };
+  if (action !== "delete") {
+    mutation.revision = normalizeContactRevision(body.revision);
+    mutation.displayName = contactText(body.displayName, "display name", 160);
+  }
+  return { result: mutation };
+}
+
+function vCardFileName(name: string): string {
+  const safe = name.normalize("NFKC")
+    .replace(/[\\/\0-\x1f\x7f]/g, "_")
+    .replace(/^\.+/, "")
+    .trim()
+    .slice(0, 120);
+  return `${safe || "Contact"}.vcf`;
+}
+
+function writeClipboardVCard(card: Buffer, name: string, runtimeRoot: string): {
+  path: string;
+  fileName: string;
+} {
+  const copyDirectory = join(
+    runtimeRoot,
+    "blip",
+    "vcards",
+    `${Date.now()}-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+  const directoryFd = openPinnedDirectory(copyDirectory, true);
+  const fileName = vCardFileName(name);
+  let fileFd = -1;
+  try {
+    fileFd = openSync(
+      pinnedPath(directoryFd, fileName),
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    let offset = 0;
+    while (offset < card.length)
+      offset += writeSync(fileFd, card, offset, card.length - offset);
+    fchmodSync(fileFd, 0o600);
+    fsyncSync(fileFd);
+  } finally {
+    if (fileFd >= 0) closeSync(fileFd);
+    closeSync(directoryFd);
+  }
+  return { path: join(copyDirectory, fileName), fileName };
+}
+
+/** Export one unambiguous Mac contact to an owner-only runtime .vcf file. */
+export function exportContactVCard(
+  handle: unknown,
+  runner: Runner = spawnSync,
+  runtimeRoot: string = process.env.XDG_RUNTIME_DIR
+    ?? `/run/user/${typeof process.getuid === "function" ? process.getuid() : 1000}`,
+): { handle: string; name: string; bytes: number; fileName: string; fileUri: string } {
+  const normalizedHandle = normalizeHandle(handle);
+  const home = process.env.HOME ?? homedir();
+  const result = runner(join(home, "bin", "contacts"), ["--json", "resolve"], {
+    encoding: "utf8",
+    input: JSON.stringify({ operation: "vcard", handle: normalizedHandle }),
+    timeout: 35000,
+    maxBuffer: MAX_VCARD_RESPONSE_BYTES,
+  });
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_VCARD_RESPONSE_BYTES)
+    throw new Error("Contacts returned too much vCard data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned an invalid vCard response"); }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid vCard response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts vCard export failed"));
+  if (typeof body.vcard !== "string" || body.vcard.length > MAX_VCARD_RESPONSE_BYTES
+      || !/^[A-Za-z0-9+/=\r\n]+$/.test(body.vcard))
+    throw new Error("Contacts returned an invalid vCard");
+  const card = Buffer.from(body.vcard.replace(/[\r\n]/g, ""), "base64");
+  if (!card.length || card.length > MAX_VCARD_BYTES
+      || !card.subarray(0, 32).toString("utf8").startsWith("BEGIN:VCARD"))
+    throw new Error("Contacts returned an invalid vCard");
+  const name = normalizeIdentityName(body.name);
+  const file = writeClipboardVCard(card, name, runtimeRoot);
+  return {
+    handle: normalizedHandle,
+    name,
+    bytes: card.length,
+    fileName: file.fileName,
+    fileUri: pathToFileURL(file.path).href,
+  };
+}
+
+export function resolveOnMac(
+  operation: "candidates" | "open" | "compare" | "link-prepare" | "link"
+    | "inspect" | "remove" | "undo" | "discard-unsaved",
+  handle: unknown = undefined,
+  token: unknown = undefined,
+  runner: Runner = spawnSync,
+  ownerToken: unknown = undefined,
+  expectedAction: unknown = undefined,
+  otherOwnerToken: unknown = undefined,
+): {
+  handle?: string;
+  candidates?: IdentityCandidate[];
+  opened?: boolean;
+  name?: string;
+  cardNumber?: number;
+  cardCount?: number;
+  accountNumber?: number;
+  sourceName?: string;
+  preview?: ContactRepairPreview;
+  removal?: ContactRemoval;
+  undo?: ContactUndo;
+  comparison?: ContactComparison;
+  linkPreview?: ContactLinkPreview;
+  linkResult?: ContactLinkResult;
+  discarded?: boolean;
+} {
+  const normalizedHandle = operation === "undo" || operation === "discard-unsaved"
+    ? "" : normalizeHandle(handle);
+  const request: Record<string, unknown> = { operation };
+  if (operation === "undo") request.undoToken = normalizeUndoToken(token);
+  else if (operation === "discard-unsaved") { /* no contact data crosses this boundary */ }
+  else request.handle = normalizedHandle;
+  if (operation === "open" || operation === "inspect" || operation === "remove")
+    request.token = normalizeContactToken(token);
+  if (operation === "compare" || operation === "link-prepare" || operation === "link")
+    request.ownerToken = normalizeContactToken(token);
+  if (operation === "compare" && otherOwnerToken !== undefined && otherOwnerToken !== null
+      && otherOwnerToken !== "") {
+    const normalizedOther = normalizeContactToken(otherOwnerToken);
+    if (normalizedOther === request.ownerToken)
+      throw new Error("the other person must be a different candidate");
+    request.otherOwnerToken = normalizedOther;
+  }
+  const confirmedAction = operation === "link" ? normalizeExpectedLinkAction(expectedAction) : "";
+  if (operation === "link") request.expectedAction = confirmedAction;
+  if (operation === "inspect" || operation === "remove") {
+    const normalizedOwner = normalizeContactToken(ownerToken);
+    if (normalizedOwner === request.token) throw new Error("the correct and repair contact cannot be the same");
+    request.ownerToken = normalizedOwner;
+  }
+  const home = process.env.HOME ?? homedir();
+  const result: SpawnSyncReturns<string> = runner(
+    join(home, "bin", "contacts"),
+    ["--json", "resolve"],
+    {
+      encoding: "utf8",
+      input: JSON.stringify(request),
+      timeout: operation === "candidates" || operation === "open" ? 15000 : 35000,
+      maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
+    },
+  );
+  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+  const stdout = String(result.stdout || "");
+  if (Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES)
+    throw new Error("Contacts returned too much data");
+  let response: unknown;
+  try { response = JSON.parse(stdout); }
+  catch { throw new Error("Contacts returned invalid JSON"); }
+  if (operation === "candidates") {
+    const candidates = normalizeBridgeCandidates(response, normalizedHandle);
+    return { handle: normalizedHandle, candidates };
+  }
+  if (response === null || typeof response !== "object" || Array.isArray(response))
+    throw new Error("Contacts returned an invalid response");
+  const body = response as Record<string, unknown>;
+  if (result.status !== 0 || body.ok !== true)
+    throw new Error(safeError(body.error || "Contacts operation failed"));
+  if (operation === "discard-unsaved") {
+    if (typeof body.discarded !== "boolean")
+      throw new Error("Contacts returned an invalid unsaved-change result");
+    return { discarded: body.discarded };
+  }
+  if (operation === "open") {
+    if (body.opened !== true) throw new Error("Contacts could not open this card");
+    return {
+      handle: normalizedHandle,
+      opened: true,
+      name: normalizeIdentityName(body.name),
+      cardNumber: finiteInteger(body.cardNumber, "card number", 1, MAX_IDENTITY_CARDS),
+      cardCount: finiteInteger(body.cardCount, "card count", 1, MAX_IDENTITY_CARDS),
+      accountNumber: finiteInteger(
+        body.accountNumber, "contact account number", 1, MAX_IDENTITY_CARDS,
+      ),
+      sourceName: contactSourceName(body.sourceName),
+    };
+  }
+  if (operation === "compare") {
+    return { comparison: normalizeContactComparison(body, normalizedHandle) };
+  }
+  if (operation === "link-prepare") {
+    const metadata = normalizeLinkMetadata(body, normalizedHandle);
+    if (typeof body.ready !== "boolean") throw new Error("Contacts returned an invalid link preview");
+    return { linkPreview: { ...metadata, ready: body.ready } };
+  }
+  if (operation === "link") {
+    const metadata = normalizeLinkMetadata(body, normalizedHandle);
+    if (metadata.action !== confirmedAction)
+      throw new Error("Contacts link action changed; review the cards again");
+    if (body.linked !== true) throw new Error("Contacts did not confirm the link action");
+    return { linkResult: { ...metadata, linked: true } };
+  }
+  if (operation === "inspect") {
+    return { handle: normalizedHandle, preview: normalizeRepairPreview(body.preview, normalizedHandle) };
+  }
+  if (operation === "remove") {
+    const preview = normalizeRepairPreview(body, normalizedHandle);
+    if (body.removed !== true) throw new Error("Contacts did not confirm the removal");
+    return {
+      handle: normalizedHandle,
+      removal: { ...preview, removed: true, undoToken: normalizeUndoToken(body.undoToken) },
+    };
+  }
+  if (body.restored !== true) throw new Error("Contacts did not confirm the restore");
+  const undoAction = body.action;
+  if (undoAction !== "field-removal" && undoAction !== "edit" && undoAction !== "delete"
+      && undoAction !== "consolidate")
+    throw new Error("Contacts returned an invalid undo action");
+  return {
+    undo: {
+      restored: true,
+      alreadyPresent: body.alreadyPresent === true,
+      action: undoAction,
+      handle: normalizeHandle(body.handle),
+      name: normalizeIdentityName(body.name),
+      cardCount: finiteInteger(body.cardCount, "restored card count", 1, MAX_COMPARE_CARDS),
+      fieldCount: finiteInteger(body.fieldCount, "restored field count", 1, 13),
+    },
+  };
+}
+
+export async function readStdinBounded(
+  input: AsyncIterable<Uint8Array | string> = process.stdin as any,
+  maximum = MAX_IDENTITY_REQUEST_BYTES,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const raw of input) {
+    const chunk = typeof raw === "string" ? Buffer.from(raw) : Buffer.from(raw);
+    total += chunk.length;
+    if (total > maximum) throw new Error("identity request is too large");
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function parseRequest(text: string): Record<string, unknown> {
+  let value: unknown;
+  try { value = JSON.parse(text); }
+  catch { throw new Error("identity request must be valid JSON"); }
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    throw new Error("identity request must be a JSON object");
+  return value as Record<string, unknown>;
+}
+
+function safeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error || "identity operation failed");
+  return message.replace(UNSAFE_TEXT, " ").replace(/\s+/g, " ").trim().slice(0, 180)
+    || "identity operation failed";
+}
+
+function emit(value: unknown): void {
+  const output = JSON.stringify(value);
+  if (Buffer.byteLength(output) > MAX_IDENTITY_OUTPUT_BYTES)
+    throw new Error("identity helper output exceeded its contract");
+  process.stdout.write(`${output}\n`);
+}
+
+async function main(): Promise<void> {
+  const operation = process.argv[2] || "read";
+  try {
+    if (operation === "read") {
+      emit({ ok: true, contactWrites: contactWritesEnabled() });
+      return;
+    }
+    const request = parseRequest(await readStdinBounded());
+    if (operation === "candidates") {
+      const result = resolveOnMac("candidates", request.handle);
+      emit({
+        ok: true,
+        handle: result.handle,
+        ambiguous: (result.candidates?.length ?? 0) > 1,
+        candidates: result.candidates ?? [],
+      });
+      return;
+    }
+    if (operation === "vcard") {
+      const result = exportContactVCard(request.handle);
+      emit({
+        ok: true, handle: result.handle, name: result.name,
+        bytes: result.bytes, fileName: result.fileName, fileUri: result.fileUri,
+      });
+      return;
+    }
+    if (operation === "audit") {
+      const result = auditContactsOnMac(request.handles);
+      emit({ ok: true, audit: result.audit, cached: result.cached });
+      return;
+    }
+    if (operation === "open") {
+      const result = resolveOnMac("open", request.handle, request.token);
+      emit({
+        ok: true,
+        opened: result.opened === true,
+        name: result.name,
+        cardNumber: result.cardNumber,
+        cardCount: result.cardCount,
+        accountNumber: result.accountNumber,
+        sourceName: result.sourceName,
+      });
+      return;
+    }
+    if (operation === "compare" || operation === "link-prepare" || operation === "link") {
+      if (operation !== "compare" && !contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac(
+        operation, request.handle, request.ownerToken, spawnSync, undefined,
+        request.expectedAction, request.otherOwnerToken,
+      );
+      if (operation === "compare") emit({ ok: true, comparison: result.comparison });
+      else if (operation === "link-prepare") emit({ ok: true, preview: result.linkPreview });
+      else emit({ ok: true, ...result.linkResult });
+      return;
+    }
+    if (["edit-prepare", "edit", "delete-prepare", "delete", "merge-prepare", "merge"]
+      .includes(operation)) {
+      const mutationOperation = operation as ContactMutationOperation;
+      const applying = operation === "edit" || operation === "delete" || operation === "merge";
+      if (applying && !contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = contactMutationOnMac(mutationOperation, request);
+      if (result.preview) emit({ ok: true, preview: result.preview });
+      else emit({ ok: true, ...result.result });
+      return;
+    }
+    if (operation === "inspect" || operation === "remove") {
+      if (!contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac(operation, request.handle, request.token, spawnSync, request.ownerToken);
+      if (operation === "inspect") emit({ ok: true, preview: result.preview });
+      else emit({ ok: true, ...result.removal });
+      return;
+    }
+    if (operation === "undo") {
+      if (!contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac("undo", undefined, request.undoToken);
+      emit({ ok: true, ...result.undo });
+      return;
+    }
+    if (operation === "discard-unsaved") {
+      if (!contactWritesEnabled())
+        throw new Error("contact writes are disabled; set contact_writes=on in bridge.conf");
+      const result = resolveOnMac("discard-unsaved");
+      emit({ ok: true, discarded: result.discarded === true });
+      return;
+    }
+    throw new Error(
+      "operation must be read, candidates, vcard, audit, open, compare, edit-prepare, "
+      + "edit, delete-prepare, delete, merge-prepare, merge, link-prepare, link, inspect, remove, undo, or discard-unsaved",
+    );
+  } catch (error) {
+    emit({ ok: false, error: safeError(error) });
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) void main();

--- a/contact-management.ts
+++ b/contact-management.ts
@@ -44,6 +44,12 @@ export interface IdentityCandidate {
   cards: IdentitySourceCard[];
 }
 
+/** A single named person needs no identity decision, even across sources.
+ * This selects a read-only comparison; it never authorizes a mutation. */
+export function initialContactToken(candidates: IdentityCandidate[]): string {
+  return candidates.length === 1 ? candidates[0]!.token : "";
+}
+
 export interface IdentitySourceCard {
   token: string;
   accountNumber: number;
@@ -1230,6 +1236,7 @@ async function main(): Promise<void> {
       emit({
         ok: true,
         handle: result.handle,
+        initialToken: initialContactToken(result.candidates ?? []),
         ambiguous: (result.candidates?.length ?? 0) > 1,
         candidates: result.candidates ?? [],
       });

--- a/contact-repair.test.ts
+++ b/contact-repair.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./bridge/mac/contact-repair.js", import.meta.url), "utf8")
+  .replace(/^#![^\n]*\n/, "");
+let contactsApplication: any = null;
+const repair = new Function(
+  "ObjC",
+  "Application",
+  source + "\nreturn { normalizeRequest: normalizeRequest, perform: perform, setCard: setCard };",
+)({ import() {} }, () => contactsApplication) as {
+  normalizeRequest: (request: any) => any;
+  perform: (request: any) => any;
+  setCard: (contacts: any, person: any, card: any) => void;
+};
+
+function scalar(initial = "") {
+  let value = initial;
+  const property = (() => value) as (() => string) & { set: (next: string) => void };
+  property.set = (next: string) => { value = next; };
+  return property;
+}
+
+function labeled(label: string, value: string) {
+  return { label: () => label, value: () => value };
+}
+
+function fixture() {
+  const originalPhone = labeled("_$!<Mobile>!$_", "+1 (404) 555-0101");
+  const phones = [originalPhone];
+  const removed: any[] = [];
+  const added: any[] = [];
+  // JXA collection specifiers are callable AND support .push (the add
+  // pattern that works on current macOS); mirror that shape here.
+  function collection(entries: any[]) {
+    const property = (() => entries) as any;
+    property.push = (entry: any) => { added.push(entry); entries.push(entry); };
+    return property;
+  }
+  const person: any = {
+    firstName: scalar("Alex"), middleName: scalar(""), lastName: scalar("Rivera"),
+    nickname: scalar(), organization: scalar(), department: scalar(), jobTitle: scalar(),
+    note: scalar(), birthDate: scalar(), phones: collection(phones),
+    emails: collection([]), urls: collection([]), addresses: collection([]),
+  };
+  const contacts: any = {
+    // field removal deletes the entry specifier (the remove-from-person
+    // Apple event is broken on current macOS)
+    delete(entry: any) {
+      removed.push(entry);
+      phones.splice(phones.indexOf(entry), 1);
+    },
+    Phone(properties: any) {
+      return labeled(properties.label || "", properties.value);
+    },
+    Email(properties: any) { return labeled(properties.label || "", properties.value); },
+    Url(properties: any) { return labeled(properties.label || "", properties.value); },
+    Address(properties: any) { return properties; },
+    // the add-to-person Apple event is broken on current macOS; entries
+    // arrive through the collection specifiers' push instead
+  };
+  const card = {
+    firstName: "Alex", middleName: "Morgan", lastName: "Rivera",
+    nickname: "", organization: "", department: "", jobTitle: "",
+    birthday: "", note: "",
+    phones: [{ label: "_$!<Mobile>!$_", value: "+1 (404) 555-0101" }],
+    emails: [], urls: [], addresses: [],
+  };
+  return { contacts, person, card, originalPhone, removed, added };
+}
+
+describe("Contacts.app edit reconciliation", () => {
+  test("discarding a pending edit explicitly quits Contacts without saving", () => {
+    let quitArgument: any = null;
+    contactsApplication = {
+      running: () => true,
+      unsaved: () => true,
+      quit: (argument: any) => { quitArgument = argument; },
+    };
+    expect(repair.perform(repair.normalizeRequest({ operation: "discard-unsaved" })))
+      .toEqual({ ok: true, discarded: true });
+    expect(quitArgument).toEqual({ saving: "no" });
+  });
+
+  test("a scalar-only edit preserves the existing phone field", () => {
+    const f = fixture();
+    repair.setCard(f.contacts, f.person, f.card);
+    expect(f.removed).toEqual([]);
+    expect(f.added).toEqual([]);
+    expect(f.person.middleName()).toBe("Morgan");
+  });
+
+  test("a changed collection removes the concrete field object before replacing it", () => {
+    const f = fixture();
+    f.card.phones[0].value = "+1 (404) 555-0199";
+    repair.setCard(f.contacts, f.person, f.card);
+    expect(f.removed).toEqual([f.originalPhone]);
+    expect(f.added).toHaveLength(1);
+    expect(f.added[0].value()).toBe("+1 (404) 555-0199");
+  });
+
+  test("an add-only collection change keeps existing fields and pushes the additions", () => {
+    // removing a damaged stored row fails where additions still work, so an
+    // edit that only ADDS values must never take the remove-all path
+    const f = fixture();
+    f.card.phones.push({ label: "_$!<Home>!$_", value: "+1 (404) 555-0102" });
+    repair.setCard(f.contacts, f.person, f.card);
+    expect(f.removed).toEqual([]);
+    expect(f.added).toHaveLength(1);
+    expect(f.added[0].value()).toBe("+1 (404) 555-0102");
+    expect(f.person.phones()).toHaveLength(2);
+  });
+});

--- a/contact-ui.test.ts
+++ b/contact-ui.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+const identitySettings = readFileSync(new URL("./ContactManagement.qml", import.meta.url), "utf8");
+const identities = readFileSync(new URL("./ContactOperations.qml", import.meta.url), "utf8");
+const contactCompare = readFileSync(new URL("./ContactCardCompare.qml", import.meta.url), "utf8");
+const contactEditor = readFileSync(new URL("./ContactCardEditor.qml", import.meta.url), "utf8");
+  test("Mac contact writes require preview, confirmation, and expose undo", () => {
+    expect(identitySettings).toContain('label: "Remove this " + root.handleNoun() + "…"');
+    // the undo offer shows only in the workspace of the contact it changed
+    expect(identitySettings).toContain("root.handleKey(root.resolver.undoHandle)");
+    // the conflict flow speaks in outcomes, not implementation terms: picking
+    // a person opens their cards; "session"/identities.json stay out of it
+    expect(identitySettings).toContain('"WORKING ON: "');
+    expect(identitySettings).toContain("Work on this person");
+    expect(identitySettings).toContain("Pick a person below. That only opens their cards for review");
+    expect(identitySettings).not.toContain("Select for this session");
+    expect(identitySettings).not.toContain("SELECTED FOR THIS SESSION");
+    expect(identitySettings).toContain('label: "Remove from Mac Contacts"');
+    expect(identitySettings).toContain("An undo receipt will be saved on the Mac");
+    expect(identitySettings).toContain('label: "Undo Mac change"');
+    expect(identities).toContain("function inspectOnMac(handle, token, ownerToken)");
+    expect(identities).toContain("function removeOnMac()");
+    expect(identities).toContain("function undoOnMac()");
+    expect(identities).toContain("repairPreview.writeEnabled");
+    expect(identities).toContain("validToken(repairPreview.ownerToken)");
+  });
+
+  test("contact comparison is local and linking has a separate upstream confirmation", () => {
+    expect(identitySettings).toContain("Manage " + '" + sourceCandidate.modelData.recordCount');
+    expect(identitySettings).toContain("ContactCardCompare");
+    expect(contactCompare).toContain('title: "Compare source cards"');
+    expect(contactCompare).toContain('title: "Consolidate into one card"');
+    expect(contactCompare).toContain('title: "Or link cards · optional"');
+    expect(contactCompare).not.toContain("step: \"");
+    expect(contactCompare).toContain("Reload cards from Mac");
+    expect(contactCompare).toContain("Back to contact tasks");
+    expect(contactCompare).toContain("DIFFERENCES ONLY");
+    expect(contactCompare).toContain("sharedRowMap");
+    expect(contactCompare).toContain("MERGED PREVIEW");
+    expect(contactCompare).toContain("function displayFieldLabel(fieldType, value)");
+    expect(contactCompare).toContain('detail.toLowerCase() === fieldType.toLowerCase()');
+    expect(contactCompare).toContain("displayFieldLabel(group.name, item.label)");
+    expect(contactCompare).toContain('displayFieldLabel("Address", address.label)');
+    expect(contactCompare).toContain("Prepare link in Contacts…");
+    expect(contactCompare).toContain("CONFIRM AN UPSTREAM CONTACTS CHANGE");
+    expect(contactCompare).toContain("Checking makes no changes");
+    expect(contactCompare).toContain("Edit in Blip…");
+    expect(contactCompare).toContain("cardBox.modelData.sourceName");
+    expect(identitySettings).toContain("sourceCard.modelData.sourceName");
+    expect(contactCompare).toContain("Text.PlainText");
+    expect(contactCompare).not.toContain("Array.isArray(card.phones)");
+    expect(identities).toContain("function compareCards(handle, ownerToken, otherOwnerToken)");
+    expect(identities).toContain("function prepareLink()");
+    expect(identities).toContain("function linkCards()");
+    expect(identities).toContain("linkPreview.ready");
+    expect(identities).toContain("expectedAction: linkPreview.action");
+  });
+
+  test("the contact workspace edits, deletes, and consolidates only after preview", () => {
+    expect(contactCompare).toContain("ContactCardEditor");
+    expect(contactCompare).toContain("Merge into \" + modelData.sourceName");
+    expect(contactEditor).toContain("Review changes…");
+    expect(contactEditor).toContain("Delete this source card…");
+    expect(contactEditor).toContain("Review merged contact…");
+    expect(contactEditor).toContain("REVIEW CONSOLIDATION");
+    expect(contactEditor).toContain("This is a read-only preview. Nothing below has been saved to Contacts.");
+    expect(contactEditor).toContain("MERGED CONTACT TO KEEP");
+    expect(contactEditor).toContain("DELETE AFTER MERGE");
+    expect(contactEditor).toContain("FINAL CONFIRMATION");
+    expect(contactEditor).toContain("Back to edit");
+    expect(contactEditor).toContain("Save to Mac Contacts");
+    expect(contactEditor).toContain("Merge and delete source cards");
+    expect(contactEditor).toContain("function cleanLabel(value)");
+    expect(contactEditor).toContain("originalLabel: text(item.label)");
+    expect(contactEditor).toContain('value === cleanLabel(original) ? original : value');
+    expect(contactEditor.indexOf('label: valueList.emptyLabel')).toBeGreaterThan(
+      contactEditor.indexOf('model: parent.model'),
+    );
+    expect(contactEditor.indexOf('label: "Add address"')).toBeGreaterThan(
+      contactEditor.indexOf('model: root.previewOpen ? null : addresses'),
+    );
+    expect(contactEditor).toContain("Text.PlainText");
+    expect(identities).toContain("function prepareCardEdit(card, draft)");
+    expect(identities).toContain("function prepareCardDelete(card)");
+    expect(identities).toContain("function prepareConsolidation(targetCard, draft)");
+    expect(identities).toContain("function applyMutation()");
+    expect(identities).toContain("mutationPreview.planHash");
+  });
+
+// The consolidation draft's dedupe logic lives in ContactCardCompare.qml as
+// plain-JS functions; extract and execute them so the collapse rules are
+// tested for behaviour, not just presence. Brace-walking keeps the extraction
+// honest when the functions change shape.
+function extractQmlFunction(source: string, name: string): string {
+  const marker = `  function ${name}(`;
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error(`function ${name} not found`);
+  let depth = 0;
+  for (let i = source.indexOf("{", start); i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}" && --depth === 0)
+      return source.slice(start, i + 1);
+  }
+  throw new Error(`function ${name} never closes`);
+}
+
+describe("consolidation draft dedupe (executed from QML source)", () => {
+  const uniqueList: (cards: unknown[], property: string, address: boolean) => Record<string, string>[] =
+    new Function(
+      [
+        extractQmlFunction(contactCompare, "addressFields"),
+        extractQmlFunction(contactCompare, "addressField"),
+        extractQmlFunction(contactCompare, "addressSubsumes"),
+        extractQmlFunction(contactCompare, "uniqueList"),
+        "return uniqueList;",
+      ].join("\n"),
+    )();
+
+  const home = {
+    label: "Home", street: "1234 Cherry Ln", city: "Springfield",
+    state: "MN", postalCode: "55555", country: "United States",
+  };
+
+  test("an address differing only by an unset field collapses to the complete copy", () => {
+    // The live case: countryCode "us" on one source card, unset on the other.
+    const kept = uniqueList(
+      [{ addresses: [{ ...home, countryCode: "us" }] }, { addresses: [{ ...home }] }],
+      "addresses", true,
+    );
+    expect(kept.length).toBe(1);
+    expect(kept[0].countryCode).toBe("us");
+  });
+
+  test("the more complete copy wins regardless of card order", () => {
+    const kept = uniqueList(
+      [{ addresses: [{ ...home }] }, { addresses: [{ ...home, countryCode: "us" }] }],
+      "addresses", true,
+    );
+    expect(kept.length).toBe(1);
+    expect(kept[0].countryCode).toBe("us");
+  });
+
+  test("addresses that disagree on a filled field both survive", () => {
+    const kept = uniqueList(
+      [{ addresses: [home] }, { addresses: [{ ...home, city: "Minneapolis" }] }],
+      "addresses", true,
+    );
+    expect(kept.length).toBe(2);
+  });
+
+  test("an all-empty address never reaches the draft", () => {
+    const kept = uniqueList(
+      [{ addresses: [{ label: "Home", street: "", city: "" }] }, { addresses: [home] }],
+      "addresses", true,
+    );
+    expect(kept.length).toBe(1);
+    expect(kept[0].street).toBe("1234 Cherry Ln");
+  });
+
+  test("value-keyed lists keep exact-match semantics", () => {
+    const kept = uniqueList(
+      [
+        { phones: [{ label: "Work", value: "(555) 010-4477" }] },
+        { phones: [{ label: "Work", value: "(555) 010-4477" }, { label: "Mobile", value: "+15550104477" }] },
+      ],
+      "phones", false,
+    );
+    // Exact duplicates collapse; a differently formatted number is not our
+    // call to merge.
+    expect(kept.map((entry) => entry.value)).toEqual(["(555) 010-4477", "+15550104477"]);
+  });
+});

--- a/contact-ui.test.ts
+++ b/contact-ui.test.ts
@@ -11,8 +11,8 @@ const contactEditor = readFileSync(new URL("./ContactCardEditor.qml", import.met
     // the conflict flow speaks in outcomes, not implementation terms: picking
     // a person opens their cards; "session"/identities.json stay out of it
     expect(identitySettings).toContain('"WORKING ON: "');
-    expect(identitySettings).toContain("Work on this person");
-    expect(identitySettings).toContain("Pick a person below. That only opens their cards for review");
+    expect(identitySettings).toContain("Review cards");
+    expect(identitySettings).toContain("Choose a person to review their cards.");
     expect(identitySettings).not.toContain("Select for this session");
     expect(identitySettings).not.toContain("SELECTED FOR THIS SESSION");
     expect(identitySettings).toContain('label: "Remove from Mac Contacts"');
@@ -32,8 +32,8 @@ const contactEditor = readFileSync(new URL("./ContactCardEditor.qml", import.met
     expect(contactCompare).toContain('title: "Consolidate into one card"');
     expect(contactCompare).toContain('title: "Or link cards · optional"');
     expect(contactCompare).not.toContain("step: \"");
-    expect(contactCompare).toContain("Reload cards from Mac");
-    expect(contactCompare).toContain("Back to contact tasks");
+    expect(contactCompare).toContain("Reload cards");
+    expect(contactCompare).toContain("Choose another person");
     expect(contactCompare).toContain("DIFFERENCES ONLY");
     expect(contactCompare).toContain("sharedRowMap");
     expect(contactCompare).toContain("MERGED PREVIEW");
@@ -44,7 +44,7 @@ const contactEditor = readFileSync(new URL("./ContactCardEditor.qml", import.met
     expect(contactCompare).toContain("Prepare link in Contacts…");
     expect(contactCompare).toContain("CONFIRM AN UPSTREAM CONTACTS CHANGE");
     expect(contactCompare).toContain("Checking makes no changes");
-    expect(contactCompare).toContain("Edit in Blip…");
+    expect(contactCompare).toContain("Edit contact…");
     expect(contactCompare).toContain("cardBox.modelData.sourceName");
     expect(identitySettings).toContain("sourceCard.modelData.sourceName");
     expect(contactCompare).toContain("Text.PlainText");
@@ -169,4 +169,36 @@ describe("consolidation draft dedupe (executed from QML source)", () => {
     // call to merge.
     expect(kept.map((entry) => entry.value)).toEqual(["(555) 010-4477", "+15550104477"]);
   });
+});
+
+test("contact handoff creates the window once before selecting the contact", () => {
+  const source = readFileSync(new URL("./BarWidget.qml", import.meta.url), "utf8");
+  const loader: any = { item: null };
+  const events: string[] = [];
+  const showApp = () => {
+    events.push("show");
+    loader.item = { manageContact: (handle: string) => { events.push(handle); return true; } };
+  };
+  const handoff = new Function("showApp", "windowLoader",
+    extractQmlFunction(source, "manageContact") + "; return manageContact;")(showApp, loader);
+  expect(handoff("+15551234567")).toBe(true);
+  expect(events).toEqual(["show", "+15551234567"]);
+});
+
+test("an existing contact editor survives a handoff for another person", () => {
+  const source = readFileSync(new URL("./ContactWorkspace.qml", import.meta.url), "utf8");
+  const operations = { activeHandle: "+15551234567", findCandidates: () => { throw new Error("must retain editor"); } };
+  const review = new Function("operations", "opened", "forceActiveFocus",
+    extractQmlFunction(source, "review") + "; return review;")(operations, true, () => {});
+  expect(review("+15551234567")).toBe(true);
+  expect(review("+15551234568")).toBe(false);
+});
+
+test("a first-window handoff queues behind the initial access check", () => {
+  const state = new Function("worker", "currentOperation", "safeText",
+    'let pendingReviewHandle = ""; ' + extractQmlFunction(identities, "findCandidates")
+      + '; return { request: findCandidates, queued: () => pendingReviewHandle };')(
+    { running: true }, "read", (s: string) => s);
+  expect(state.request("+15551234567")).toBe(true);
+  expect(state.queued()).toBe("+15551234567");
 });

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -91,3 +91,13 @@ timestamp when `chat.db` changes; the client then fetches privately.
 
 Send tapbacks, edit or unsend, see typing indicators.
 Those need Apple private APIs that Blip deliberately does not use.
+
+## Optional contact management
+
+Explicit contact management requests can return bounded card fields (including
+notes and addresses) to memory. Exported vCards are owner-only files under
+`$XDG_RUNTIME_DIR/blip/vcards/`; no message text is included. Mutations require
+both write gates and a separate confirmation. Undo receipts remain owner-only
+on the Mac and expire after seven days. Deletion/merge undo recreates text
+fields; original accounts, links, and photos cannot be restored. Apple's own
+Link/Merge handoff has no automatic Blip undo. Nothing edits Contacts SQLite.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -83,3 +83,16 @@ nonblocking descriptors with owner/type checks. Writes use a private staging
 file and descriptor-relative atomic rename. It holds contact summaries, never
 messages, and requires matching handle-set and live store fingerprints before
 reuse. It is a cache, not user configuration.
+
+## Draft contact write boundary
+
+The optional `contact-management.ts` helper accepts bounded stdin requests.
+Writes require `contact_writes=on` in owner-controlled `bridge.conf` plus an
+independent Mac write gate. Preview/apply uses exact card tokens, content
+revisions and plan hashes; only validated native operations reach Contacts.
+The optional Swift helper performs Contacts-framework mutations. The Apple
+UI handoff pins the selected cards and the exact enabled Link/Merge action,
+requiring Automation and Accessibility. Undo receipts stay private on the Mac.
+
+This draft still needs Mac integration validation of mutation failure and
+recovery behavior before merge. Linux checks use synthetic fixtures only.

--- a/scripts/blip-setup
+++ b/scripts/blip-setup
@@ -32,11 +32,12 @@ conf_dir="$HOME/.config/blip"
 conf="$conf_dir/bridge.conf"
 
 # bridge.conf is DATA (audit #7): read the two keys we care about, never source it.
-prev_automation=""; prev_country=""
+prev_automation=""; prev_country=""; prev_contact_writes=""
 if [[ -r "$conf" ]]; then
   [[ -z "$host" ]] && host="$(sed -n 's/^host=//p' "$conf" | head -1 | tr -d '"\x27 ')"
   prev_automation="$(sed -n 's/^automation=//p' "$conf" | head -1 | tr -d '"\x27 ')"
   prev_country="$(sed -n 's/^country_code=//p' "$conf" | head -1 | tr -d '"\x27 ')"
+  prev_contact_writes="$(sed -n 's/^contact_writes=//p' "$conf" | head -1 | tr -d '"\x27 ')"
 fi
 if [[ -z "${host:-}" ]]; then
   read -r -p "Mac ssh target ([user@]host, Tailscale name works best): " host
@@ -52,7 +53,7 @@ fi
 # ui_font, ui_font_size, anything set by hand — must survive a re-run; a
 # wholesale rewrite silently re-enabled what the user had turned off (Astra #18).
 kept=""
-[[ -r "$conf" ]] && kept="$(grep -vE '^[[:space:]]*(#|$|host=|remote_bin=|python=|key=|automation=|country_code=)' "$conf" || true)"
+[[ -r "$conf" ]] && kept="$(grep -vE '^[[:space:]]*(#|$|host=|remote_bin=|python=|key=|automation=|country_code=|contact_writes=)' "$conf" || true)"
 mkdir -p "$conf_dir"
 {
   echo "# Blip bridge — read (never sourced) by ~/bin/imsg, imsg-send, imsg-read, contacts"
@@ -62,6 +63,7 @@ mkdir -p "$conf_dir"
   echo "python=python3"
   echo "key=$HOME/.ssh/blip_ed25519"
   echo "# on = local scripts may send/read through 'qs ipc call nixfred.blip …'"
+  echo "contact_writes=${BLIP_CONTACT_WRITES:-${prev_contact_writes:-off}}"
   echo "automation=${BLIP_AUTOMATION:-${prev_automation:-off}}"   # a re-run keeps a hand-set value
   echo "# country calling code for numbers typed without one (1 = US/Canada, 44 = UK, 49 = DE…)"
   echo "country_code=${prev_country:-1}"
@@ -136,6 +138,14 @@ if ssh -n -o ConnectTimeout=6 -o BatchMode=yes -- "$host" true 2>/dev/null; then
   if ! ssh "$host" "python3 -c 'import sqlite3, subprocess'" >/dev/null 2>&1; then
     echo "✗ python3 on $host cannot run: install Xcode Command Line Tools there —  xcode-select --install  — then re-run blip-setup" >&2
     exit 1
+  fi
+
+  # Contact writes require a second, Mac-local gate that the restricted Blip
+  # key cannot create for itself. Only an explicit setup environment opt-in
+  # installs it; ordinary setup remains read-only/open-only.
+  if [[ "${BLIP_CONTACT_WRITES:-off}" == on ]]; then
+    ssh "$host" 'umask 077; mkdir -p ~/.blip; printf "enabled-v1\n" > ~/.blip/contact-writes-enabled; chmod 0600 ~/.blip/contact-writes-enabled'
+    echo "✓ Mac contact-write gate enabled (explicit BLIP_CONTACT_WRITES=on)"
   fi
 
   # 4b. Dedicated key, confined on the Mac to blip-dispatch (restrict = no


### PR DESCRIPTION
Adds an optional contact workspace for editing source cards, consolidation, deletion, narrow phone/email cleanup, Apple's Link/Merge handoff, and undo. Open it through a conversation’s Contact review → Manage contact. Person selection lasts only for the current session.

The settings/preferences system and saved display-name overrides have been removed from this branch too. The existing comparison/editor and native mutation contracts remain: bounded stdin requests, exact card tokens and revisions, preview/apply confirmation, independent Linux and Mac write gates, and private Mac undo receipts. Near-duplicate address consolidation and its behavior tests are preserved.

Messaging and #24’s read-only scan need no Swift helper. This draft’s full card comparison, vCard export, and native mutations use the optional compiled Contacts helper; installation skips compilation when Swift is unavailable. Contact writes require explicit setup opt-in. Delete/consolidation undo recreates text fields but cannot restore original accounts, links, or photos; Apple's UI Link/Merge handoff has no automatic Blip undo.

Validation: 413 Bun tests and 84 synthetic Python bridge tests pass. Python compilation, shell syntax/ShellCheck, JXA syntax, and plugin validation pass. Review, scan, management, and comparison screens were exercised and inspected with an isolated fake bridge; no real contacts or conversations were accessed.

Remains **draft** pending the read-only extractions below and Mac integration validation of mutation failure/recovery behavior. #24 has merged. The Mac write paths were not exercised during this revision.

### Read-only functionality extracted for separate review

- #59 removes the 200-handle total scan limit by batching bounded Mac requests.
- #60 adds full read-only source-card details without the optional Swift helper.
- #61 restores Copy vCard for an explicitly selected source card without enabling contact writes.

This draft still contains its earlier detail/export implementations. Once #60 and #61 land, rebase this branch onto main, reuse those read-only paths, and remove the duplicated viewers/export plumbing. The remaining diff should focus on editing, merge/consolidation, cleanup, delete, undo, and their write gates. The write-path validation below describes the existing draft; no new Mac mutation validation has been performed.


### Contact management layout and navigation

Quick review stays in the menubar. “Manage contact ↗” opens that contact directly in the detached Blip window. An existing workspace retains its editor or preview when another contact is requested. Startup handoffs queue behind the initial access check.

One matching person opens directly to their source cards; conflicting matches still require a choice. Single cards show contact details without comparison controls. Action rows stack or wrap, and two-card comparisons adapt to the window width. Shared buttons support keyboard focus.

Validated with synthetic screenshots of review, single-card details, comparisons at 720 and 1040 window widths, and the editor. 452 Bun tests and 92 Python tests pass, including window handoff lifecycle coverage. Preview, exact-token validation, local/Mac write gates, and explicit confirmation remain in place.
