### PR TITLE
Mute list: hide spam conversations (ActBlue / "Stop2End" blasts) entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **A mute list, for the texts nobody opted into.** Political fundraising
+  blasts — "the deadline is TONIGHT, rush $25, Reply STOP2END" — arrive from a
+  short code that is different every cycle, so blocking the number is
+  whack-a-mole. `~/.config/blip/mutelist.json` is the allowlist's mirror image
+  in shape (`{ "mute": [...] }` or a bare array, re-read every poll, no
+  restart) and its opposite in effect: a matched conversation is dropped
+  before the unread ledger, the thread list and the toasts are built, so it
+  cannot show, count, or interrupt. Entries match a handle or chat id exactly,
+  or a phrase of two or more characters anywhere in an INBOUND message
+  (`"ActBlue"`, `"WinRed"`, `"Stop2End"`) — the platform's name and the
+  legally required opt-out footer both outlive the rotating number. One match
+  mutes the whole conversation; quoting a muted phrase to a friend never mutes
+  the friend. Nothing is deleted: the messages stay untouched on the Mac.
+
 - **Your own address book decides who someone is.** Contact names were
   resolved by counting sources and taking the most common spelling, so a work
   Exchange account or a synced company directory holding thousands of rows

--- a/README.md
+++ b/README.md
@@ -353,6 +353,28 @@ else still counts and still shows.
 { "allow": ["+15551234567", "them@icloud.com"] }
 ```
 
+**Mute (spam)** — the allowlist's opposite: a muted conversation does not
+show at all. No sidebar row, no unread count, no toast. This is the knob for
+political fundraising blasts — the "the deadline is TONIGHT, rush $25,
+Reply STOP2END" texts that arrive from a short code you have never seen and
+that will be a different short code next week. Listing the number is
+whack-a-mole, so list the words instead: the PAC platform's name (`ActBlue`,
+`WinRed`) and the opt-out footer the law makes every one of them carry
+(`Stop2End`) survive the rotation.
+
+```jsonc
+// ~/.config/blip/mutelist.json — re-read every poll, no restart
+{ "mute": ["ActBlue", "WinRed", "Stop2End", "78462"] }
+```
+
+An entry matches a handle or chat id **exactly** (like the allowlist), or a
+**phrase** of two or more characters anywhere in an inbound message,
+case-insensitively. One match mutes that whole conversation — a blast puts
+its footer on some messages and not others. Only inbound text is tested, so
+forwarding "another ActBlue text, unbelievable" to a friend never mutes the
+friend. Nothing is deleted: the messages are untouched on the Mac and in
+Messages, Blip simply stops showing them.
+
 **Outside North America:** set `country_code=44` (etc.) in
 `~/.config/blip/bridge.conf` so a number typed without a country code in
 "New message" resolves correctly. Green-bubble (SMS/RCS) conversations

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -16,6 +16,11 @@ import {
   displayName,
   fetchMessages,
   loadAllowlist,
+  loadMutelist,
+  matchesMute,
+  mutedChats,
+  dropMuted,
+  dropMutedChats,
   loadState,
   validPins,
   pinsFromChats,
@@ -27,6 +32,7 @@ import {
   unreadCounts,
   unreadOldest,
   type ImsgMessage,
+  type ChatInfo,
 } from "./collector";
 
 const tmp = () => mkdtempSync(join(tmpdir(), "blip-test-"));
@@ -1108,5 +1114,112 @@ describe("pins survive shallow polls", () => {
     expect(validPins({ A: 0, B: null, C: "1", D: 1.5, "": 2, E: 3 })).toEqual({ A: 0, B: null, E: 3 });
     expect(validPins(undefined)).toEqual({});
     expect(validPins("nope")).toEqual({});
+  });
+});
+
+describe("mute list", () => {
+  // A political fundraising blast, in the shape they actually arrive in: a
+  // rotating short code, a body that names the PAC, and the legally required
+  // opt-out footer that never changes.
+  const blast = (over: Partial<ImsgMessage> = {}) =>
+    msg({
+      chat: "78462", handle: "78462", name: null,
+      text: "The deadline is TONIGHT. Rush $25 now: actblue.com/x Reply STOP2END",
+      ...over,
+    });
+
+  test("reads a bare-array mute list", () => {
+    const p = join(tmp(), "mute.json");
+    writeFileSync(p, JSON.stringify(["ActBlue"]));
+    expect(loadMutelist(p)).toEqual(["ActBlue"]);
+  });
+
+  test("reads a {mute:[...]} mute list", () => {
+    const p = join(tmp(), "mute2.json");
+    writeFileSync(p, JSON.stringify({ mute: ["Stop2End"], note: "ignored" }));
+    expect(loadMutelist(p)).toEqual(["Stop2End"]);
+  });
+
+  test("a missing mute list is empty, not an error", () => {
+    expect(loadMutelist(join(tmp(), "none.json"))).toEqual([]);
+  });
+
+  test("non-string and empty entries are filtered out", () => {
+    const p = join(tmp(), "mixed.json");
+    writeFileSync(p, JSON.stringify(["ActBlue", "", 42, null]));
+    expect(loadMutelist(p)).toEqual(["ActBlue"]);
+  });
+
+  test("a phrase matches anywhere in the text, case-insensitively", () => {
+    expect(matchesMute(blast(), ["stop2end"])).toBe(true);
+    expect(matchesMute(blast(), ["ActBlue"])).toBe(true);
+  });
+
+  test("a handle or chat id matches exactly, like the allowlist", () => {
+    expect(matchesMute(blast(), ["78462"])).toBe(true);
+    // ...and only exactly: a substring of a number is not a number.
+    expect(matchesMute(blast({ text: "" }), ["784"])).toBe(false);
+  });
+
+  test("a one-character entry cannot mute the world", () => {
+    expect(matchesMute(msg({ text: "hello" }), ["h"])).toBe(false);
+  });
+
+  test("an empty mute list mutes nothing", () => {
+    expect(matchesMute(blast(), [])).toBe(false);
+    expect(mutedChats([blast()], [])).toEqual([]);
+  });
+
+  test("quoting a muted phrase to a friend does not mute the friend", () => {
+    // Outbound only: you forwarding "look what ActBlue sent me" is not spam.
+    const mine = msg({ chat: "+15550100002", handle: "+15550100002", from_me: true,
+      text: "another ActBlue text, unbelievable" });
+    expect(mutedChats([mine], ["ActBlue"])).toEqual([]);
+  });
+
+  test("one match mutes the whole conversation, not just that message", () => {
+    const window = [
+      blast({ ts: "2026-08-30 09:00:00" }),
+      blast({ ts: "2026-08-30 10:00:00", text: "Are you still with us?" }),
+      msg({ chat: "+15550100002", handle: "+15550100002", text: "lunch?" }),
+    ];
+    const muted = mutedChats(window, ["Stop2End"]);
+    expect(muted).toEqual(["78462"]);
+    const kept = dropMuted(window, muted);
+    expect(kept).toHaveLength(1);
+    expect(kept[0]!.text).toBe("lunch?");
+  });
+
+  test("the chat list drops muted rows too, by id, alias, or preview text", () => {
+    const row = (id: string, last_text: string, aliases: string[] = []): ChatInfo => ({
+      id, name: id, service: "SMS", last: "2026-08-30 10:00:00", last_text,
+      last_from_me: false, last_handle: id, last_name: null, pinned: false, pin_order: null, aliases,
+    });
+    const chats = [
+      row("78462", "Rush $25 now. Reply STOP2END"),
+      row("+15550100002", "lunch?"),
+      row("chat9", "hi", ["78462"]),
+    ];
+    const out = dropMutedChats(chats, ["Stop2End"], ["78462"])!;
+    expect(out.map((c) => c.id)).toEqual(["+15550100002"]);
+  });
+
+  test("your own reply keeps a chat row alive", () => {
+    const row: ChatInfo = {
+      id: "+15550100002", name: "Alex Rivera", service: "iMessage", last: "2026-08-30 10:00:00",
+      last_text: "ugh, ActBlue again", last_from_me: true, last_handle: "+15550100002",
+      last_name: null, pinned: false, pin_order: null, aliases: [],
+    };
+    expect(dropMutedChats([row], ["ActBlue"], [])).toHaveLength(1);
+  });
+
+  test("a shallow poll has no chat list to filter", () => {
+    expect(dropMutedChats(null, ["ActBlue"], [])).toBeNull();
+  });
+
+  test("a muted conversation never toasts, because it never reaches selectToasts", () => {
+    const window = [blast({ ts: "2026-08-30 11:00:00" })];
+    const kept = dropMuted(window, mutedChats(window, ["ActBlue"]));
+    expect(selectToasts(kept, "2026-08-30 10:00:00", ["78462"], [])).toEqual([]);
   });
 });

--- a/collector.ts
+++ b/collector.ts
@@ -30,6 +30,8 @@ const HOME = process.env.HOME ?? homedir();
 export const STATE_PATH = `${HOME}/.local/state/blip/state.json`;
 /** Handles whose inbound messages are allowed to raise a desktop toast. */
 export const ALLOWLIST_PATH = `${HOME}/.config/blip/allowlist.json`;
+/** Handles and phrases whose conversations Blip does not show at all. */
+export const MUTELIST_PATH = `${HOME}/.config/blip/mutelist.json`;
 
 /**
  * Shallow poll window for previews and toasts. An exact metadata-only unread
@@ -262,6 +264,30 @@ export function loadAllowlist(path = ALLOWLIST_PATH): string[] {
     const raw = JSON.parse(readFileSync(path, "utf8"));
     const list = Array.isArray(raw) ? raw : raw?.allow;
     return Array.isArray(list) ? list.filter((h: unknown) => typeof h === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The mute list: political fundraising blasts and their kin, gone.
+ *
+ * Same shape as the allowlist and read the same way — a bare array or
+ * `{ "mute": [...] }`, re-read every poll, absent file means an empty list —
+ * but the opposite polarity, and it silences the whole conversation rather
+ * than just its toast. An entry matches either
+ *   • a handle or chat id EXACTLY (`"+15551234567"`), like the allowlist, or
+ *   • a phrase, case-insensitively, anywhere in an inbound message's text
+ *     (`"ActBlue"`, `"Stop2End"`, `"Reply STOP2END"`).
+ * Phrases are the useful half: the short codes these blasts arrive from
+ * rotate every cycle, but the opt-out footer the law makes them carry does
+ * not. Two characters minimum, so a stray `"a"` cannot mute the world.
+ */
+export function loadMutelist(path = MUTELIST_PATH): string[] {
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8"));
+    const list = Array.isArray(raw) ? raw : raw?.mute;
+    return Array.isArray(list) ? list.filter((h: unknown) => typeof h === "string" && h !== "") : [];
   } catch {
     return [];
   }
@@ -551,6 +577,63 @@ export function selectToasts(
     out.push({ chat: chatKey(m), name: m.name ?? m.handle, text: m.text, ts: m.ts, key });
   }
   return out;
+}
+
+/** One mute entry against one message: an exact handle/chat id, or a phrase
+ *  (two characters or more) anywhere in the text, case-insensitively. */
+export function matchesMute(m: ImsgMessage, mute: string[]): boolean {
+  if (mute.length === 0) return false;
+  const chat = chatKey(m);
+  const text = String(m.text ?? "").toLowerCase();
+  for (const entry of mute) {
+    if (entry === chat || entry === m.handle) return true;
+    if (entry.length >= 2 && text !== "" && text.includes(entry.toLowerCase())) return true;
+  }
+  return false;
+}
+
+/**
+ * Conversations the mute list silences — matched on INBOUND messages only, so
+ * quoting "ActBlue" to a friend never mutes the friend.
+ *
+ * One match mutes the whole chat, not the single message: a fundraising blast
+ * carries its opt-out footer on some messages and not others, and half a
+ * conversation left in the sidebar is worse than none.
+ */
+export function mutedChats(msgs: ImsgMessage[], mute: string[]): string[] {
+  if (mute.length === 0) return [];
+  const out = new Set<string>();
+  for (const m of msgs) if (!m.from_me && matchesMute(m, mute)) out.add(chatKey(m));
+  return [...out];
+}
+
+/** Drop muted conversations before anything is counted. Filtering here rather
+ *  than in the QML is the point: a muted blast never reaches the unread
+ *  ledger, the thread list, or a toast, so it cannot badge the bar either. */
+export function dropMuted(msgs: ImsgMessage[], muted: string[]): ImsgMessage[] {
+  if (muted.length === 0) return msgs;
+  const gone = new Set(muted);
+  return msgs.filter((m) => !gone.has(chatKey(m)));
+}
+
+/**
+ * The same cut on `imsg chats` rows. A deep run completes the sidebar from the
+ * chat list, which reaches back further than the message window — without
+ * this, a blast last seen a month ago would reappear the moment the panel
+ * opened. Rows are matched on their id, their aliases, and their last preview
+ * text, which is the only body a chat row carries.
+ */
+export function dropMutedChats(chats: ChatInfo[] | null, mute: string[], muted: string[]): ChatInfo[] | null {
+  if (chats === null || (mute.length === 0 && muted.length === 0)) return chats;
+  const gone = new Set(muted);
+  const phrases = mute.filter((e) => e.length >= 2).map((e) => e.toLowerCase());
+  return chats.filter((c) => {
+    const ids = [c.id, ...c.aliases];
+    if (ids.some((id) => gone.has(id) || mute.includes(id))) return false;
+    if (c.last_from_me) return true;   // your own reply is not the blast
+    const text = c.last_text.toLowerCase();
+    return text === "" || !phrases.some((p) => text.includes(p));
+  });
 }
 
 /** First http(s) URL in a message, or "". Trailing punctuation that a person
@@ -1136,7 +1219,13 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
   const groups = (deep ? fetchGroups() : null) ?? state.groups;
   // persist only on two independent twins; one may be a coincidence (#6)
   const selfChats = [...new Set([...state.selfChats, ...detectSelfChats(fetched.msgs, 2)])];
-  const msgs = dedupeSelfEcho(fetched.msgs, selfChats);
+  // The mute list cuts here, upstream of every count: a muted conversation is
+  // absent from the ledger, the thread list and the toasts alike, exactly as
+  // if the Mac had never received it. Read fresh each poll, like the allowlist.
+  const mute = loadMutelist();
+  const deduped = dedupeSelfEcho(fetched.msgs, selfChats);
+  const muted = mutedChats(deduped, mute);
+  const msgs = dropMuted(deduped, muted);
   let exactCounts = unreadCounts(msgs, state.readMark, state.readMarks, selfChats);
   let exactOldest = unreadOldest(msgs, state.readMark, state.readMarks, selfChats);
   if (markRead) {
@@ -1155,7 +1244,7 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
   // Deep runs (a surface is open) complete the list from `imsg chats`; a
   // shallow poll returns the window's rows and the widget keeps its last
   // complete list in memory (it skips identical assignments anyway).
-  const chats = deep ? fetchChats() : null;
+  const chats = deep ? dropMutedChats(fetchChats(), mute, muted) : null;
   // One entry per CONVERSATION. A re-keyed group has several chat rows; the
   // bridge names the older ones as aliases of the live row, and the map is
   // cached so shallow polls fold identically (a conversation must never

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -11,6 +11,7 @@ inventory of what lands on disk.
 | `~/.config/blip/bridge.conf` (0600) | Mac ssh target, remote tool dir, path of Blip's key, `automation=` switch | credentials |
 | `~/.ssh/blip_ed25519` | Blip's dedicated ssh key — confined on the Mac to the bridge tools | — |
 | `~/.config/blip/allowlist.json` | handles allowed to raise desktop toasts | message text |
+| `~/.config/blip/mutelist.json` | handles and phrases you typed, whose conversations Blip hides entirely | message text Blip received |
 | `~/.local/state/blip/state.json` (0600, atomic) | poll watermark, read marks, per-chat unread counts and oldest-unread timestamps, self-chat ids, group names/members, opaque SHA-256 toast keys | **message bodies — ever** |
 | `~/.local/state/blip/window.json` | whether the app window was open, its size | anything else |
 | `~/.cache/blip/att/` (0700, files 0600, 500 MB LRU, no expiry) | attachments you viewed, plus images ≤ 5 MB and link-preview thumbnails in any conversation you *open* (they render inline, so they are fetched when the thread is). HEIC arrives converted to JPEG. File names carry the Mac's attachment row id and a sanitized name whose extension follows the MIME type | attachments in conversations you never opened |


### PR DESCRIPTION
## What this is for

Political fundraising spam. The texts that read *"the deadline is TONIGHT, rush \$25 — Reply STOP2END"*, arriving from a five-digit short code you have never seen, which will be a **different** short code next week. Nobody opted into them, `allowlist.json` cannot help (it gates toasts, not the sidebar), and blocking the number is whack-a-mole because the number is disposable.

The two things that are *not* disposable are the platform's name (`ActBlue`, `WinRed`) and the opt-out footer the TCPA makes every one of these carry (`Stop2End`, `Reply STOP`). So the mute list matches **phrases** as well as handles, and that is what makes it work.

## What it does

`~/.config/blip/mutelist.json` — the allowlist's mirror image in shape, its opposite in effect:

```jsonc
// re-read every poll, no restart
{ "mute": ["ActBlue", "WinRed", "Stop2End", "78462"] }
```

Same parser shape as `allowlist.json` (bare array or `{ "mute": [...] }`, non-strings dropped, a missing file is an empty list, re-read every poll). Where the allowlist says *who may raise a toast*, the mute list says *whose conversation Blip shows at all*: a matched chat has no sidebar row, no unread count, no toast.

**Matching**, and the reasoning behind each rule:

- a handle or chat id matches **exactly**, as in the allowlist — a substring of a phone number can never take out an unrelated number;
- a phrase matches **case-insensitively anywhere in the text**, two characters minimum, so a stray one-character entry cannot mute the world;
- **inbound only** — forwarding *"another ActBlue text, unbelievable"* to a friend must not mute the friend;
- **one match mutes the whole conversation**: a blast carries its footer on some messages and not others, and half a thread left in the sidebar is worse than none;
- a chat row whose newest message is **your own reply** survives.

## Where the cut happens

In `collect()`, on the deduped window **before** `unreadCounts`, `buildThreads` and `selectToasts` — and on the `imsg chats` rows a deep run merges in. That second half matters: the chat list reaches back further than the message window, so without it a blast last seen a month ago would reappear the moment the panel opened. Filtering upstream of the ledger means there is no second filter in the QML to keep in sync, and a muted conversation cannot badge the bar.

The watermark still advances across muted rows, so unmuting later does not replay them as a pile of new toasts.

## Invariants

- **No message content on disk.** `mutelist.json` holds only what the user typed; `state.json` is untouched. Added to the `docs/PRIVACY.md` table.
- **Logic in TypeScript, QML only renders.** No QML change at all — the widget renders the thread list it is given.
- **Nothing is deleted.** The messages are untouched on the Mac and still in Messages; Blip stops showing them.

## Tests

14 new tests in `collector.test.ts`, in the allowlist tests' style: loader shapes, exact-vs-phrase matching, the one-character guard, outbound quoting, whole-conversation muting, chat-row filtering by id / alias / preview text, the own-reply survivor, `null` on a shallow poll, and the end-to-end "a muted blast never reaches `selectToasts`". `bun test`: **309 pass, 0 fail**.

Docs: README section next to the toasts one, a `CHANGELOG.md` Unreleased entry, and the privacy table row.
