### PR TITLE
compose: wrap long text and attach copied files

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1111,7 +1111,7 @@ FocusScope {
         if (!root.inThread || String(root.active.chat) !== root.pasteChat) return
         try {
           var d = JSON.parse(text.trim())
-          if (d.kind === "image") root.setDraft(String(d.path || ""))
+          if (d.kind === "image" || d.kind === "file") root.setDraft(String(d.path || ""))
           else if (d.kind === "text") {
             composeField.insert(composeField.cursorPosition, String(d.text || ""))
           }
@@ -2563,40 +2563,81 @@ FocusScope {
 
         RowLayout {
           Layout.fillWidth: true
+          Layout.maximumWidth: parent.width
           visible: root.inThread
           spacing: Style.space(6)
 
-          TextField {
-            id: composeField
+          // Width must be assigned by the layout *before* wrap can happen.
+          // A bare TextArea's implicitWidth is the unwrapped line, so RowLayout
+          // otherwise grows with the text and the caret scrolls sideways.
+          Item {
+            id: composeSlot
             Layout.fillWidth: true
-            // NEVER disabled: this field is the panel's exclusive keyboard-focus
-            // holder, and disabling the focused editor dismisses the whole
-            // panel (0.7.2 postmortem; Codex design review #8). readOnly
-            // instead; send() is the authoritative online/sendability guard.
-            enabled: true
-            readOnly: !root.online || !root.isSendable(root.active)
-            placeholderText: root.draftPath !== ""
-              ? "caption (optional) — Enter sends the file"
-              : root.isSendable(root.active) ? "iMessage" : "Read-only — group id unknown"
-            foreground: root.foreground
-            accent: root.mineFill
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.bodySmall
-            onAccepted: root.send()
-            Keys.onEscapePressed: root.back()
-            // Ctrl+V goes through paste.ts: an image on the clipboard becomes
-            // a draft chip; text falls through to a manual insert. One process
-            // snapshots types AND data — probing then re-reading races.
-            Keys.onPressed: (event) => {
-              if (event.matches(StandardKey.Paste)) {
-                event.accepted = true
-                root.startPaste()
+            Layout.preferredWidth: 0
+            Layout.minimumWidth: 0
+            Layout.alignment: Qt.AlignBottom
+            Layout.preferredHeight: {
+              var line = Math.ceil(composeField.font.pixelSize * 1.35)
+              var pad = composeField.topPadding + composeField.bottomPadding
+              var h = composeField.contentHeight + pad
+              return Math.round(Math.min(Math.max(h, line + pad), line * 5 + pad))
+            }
+            clip: true
+
+            TextArea {
+              id: composeField
+              anchors.fill: parent
+              wrapMode: TextEdit.Wrap
+              // NEVER disabled: this field is the panel's exclusive keyboard-focus
+              // holder, and disabling the focused editor dismisses the whole
+              // panel (0.7.2 postmortem; Codex design review #8). readOnly
+              // instead; send() is the authoritative online/sendability guard.
+              enabled: true
+              readOnly: !root.online || !root.isSendable(root.active)
+              placeholderText: root.draftPath !== ""
+                ? "caption (optional) — Enter sends the file"
+                : root.isSendable(root.active) ? "iMessage" : "Read-only — group id unknown"
+              color: root.foreground
+              placeholderTextColor: Qt.darker(root.foreground, 1.6)
+              selectionColor: Style.selectionFillFor(root.foreground, root.mineFill)
+              selectedTextColor: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              readonly property var _composeBorder: Border.controlSpec(
+                activeFocus ? "focus" : (hovered ? "hover-cursor" : "normal"),
+                root.foreground, root.mineFill)
+              leftPadding: Style.spacing.controlPaddingX + Border.left(_composeBorder)
+              rightPadding: Style.spacing.controlPaddingX + Border.right(_composeBorder)
+              topPadding: Style.spacing.inputPaddingY + Border.top(_composeBorder)
+              bottomPadding: Style.spacing.inputPaddingY + Border.bottom(_composeBorder)
+              background: BorderSurface {
+                color: Style.controlFill(composeField.activeFocus, composeField.hovered, root.foreground, root.mineFill)
+                borderSpec: composeField._composeBorder
+                radius: Style.cornerRadius
+              }
+              Keys.onEscapePressed: root.back()
+              // Ctrl+V goes through paste.ts: an image on the clipboard becomes
+              // a draft chip; text falls through to a manual insert. One process
+              // snapshots types AND data — probing then re-reading races.
+              // Enter sends (iMessage); Shift+Enter inserts a newline.
+              Keys.onPressed: (event) => {
+                if (event.matches(StandardKey.Paste)) {
+                  event.accepted = true
+                  root.startPaste()
+                  return
+                }
+                if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
+                    && !(event.modifiers & Qt.ShiftModifier)) {
+                  event.accepted = true
+                  root.send()
+                }
               }
             }
           }
 
           // send button — the blue arrow circle (lit when text OR a file is queued)
           Rectangle {
+            Layout.alignment: Qt.AlignBottom
             readonly property bool armed: composeField.text.trim() !== "" || root.draftPath !== ""
             width: Style.space(28); height: width; radius: width / 2
             color: armed ? root.mineFill : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.15)

--- a/paste.ts
+++ b/paste.ts
@@ -3,7 +3,7 @@
  * Blip clipboard paste helper — snapshots the Wayland clipboard ONCE and
  * reports what it held: an image (staged as a draft file) or text.
  *
- *   bun paste.ts   →  {kind:"image", path, url} | {kind:"text", text} | {kind:"none"}
+ *   bun paste.ts   →  {kind:"image", path, url} | {kind:"file", path, url} | {kind:"text", text} | {kind:"none"}
  *
  * QML intercepts Ctrl+V and calls this instead of letting TextEdit paste,
  * because the decision (attach vs insert) needs the mime types, and probing
@@ -31,6 +31,41 @@ export function extFor(mime: string): string {
   return { "image/png": "png", "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif" }[mime] ?? "img";
 }
 
+/** First local file:// path in a uri-list or GNOME copied-files dump. */
+export function firstFileUri(raw: string): string {
+  for (const line of raw.split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t || t.startsWith("#") || t === "copy" || t === "cut") continue;
+    if (!t.startsWith("file://")) continue;
+    let path = "";
+    try {
+      path = decodeURIComponent(t.slice("file://".length));
+    } catch {
+      continue;
+    }
+    if (path.startsWith("localhost/")) path = path.slice("localhost".length);
+    if (path.startsWith("/")) return path;
+  }
+  return "";
+}
+
+/** A single absolute path or file:// URI that names an existing regular file. */
+export function existingLocalFile(text: string): string {
+  const t = text.trim();
+  if (t === "" || /[\r\n]/.test(t) || t.includes("\0")) return "";
+  const path = t.startsWith("file://") ? firstFileUri(t)
+    : (t.startsWith("/") && !t.startsWith("//") ? t : "");
+  if (path === "") return "";
+  try {
+    if (statSync(path).isFile()) return path;
+  } catch { /* not a file */ }
+  return "";
+}
+
+function asFile(path: string): Record<string, string> {
+  return { kind: "file", path, url: pathToFileURL(path).href };
+}
+
 function gcDrafts(): void {
   const now = Date.now();
   try {
@@ -47,6 +82,8 @@ export function snapshotClipboard(runner = spawnSync): Record<string, string> {
   const types = runner("wl-paste", ["--list-types"], { encoding: "utf8", timeout: 4000 });
   if (types.status !== 0) return { kind: "none" };
   const offered = (types.stdout as string).trim().split("\n").filter(Boolean);
+  const paste = (mime: string, extra: Record<string, unknown> = {}) =>
+    runner("wl-paste", ["-t", mime], { encoding: "utf8", timeout: 4000, ...extra });
 
   const imageMime = pickImageType(offered);
   if (imageMime !== "") {
@@ -65,8 +102,23 @@ export function snapshotClipboard(runner = spawnSync): Record<string, string> {
     }
   }
 
+  // File managers put the path as text/uri-list (and often text/plain), not
+  // image/*. Treat that as an attachment, matching drag-and-drop.
+  for (const mime of ["text/uri-list", "x-special/gnome-copied-files"]) {
+    if (!offered.includes(mime)) continue;
+    const dump = paste(mime);
+    if (dump.status !== 0) continue;
+    const decoded = firstFileUri(String(dump.stdout || ""));
+    const path = decoded !== "" ? existingLocalFile(decoded) : "";
+    if (path !== "") return asFile(path);
+  }
+
   const text = runner("wl-paste", ["--no-newline", "-t", "text"], { encoding: "utf8", timeout: 4000 });
-  if (text.status === 0 && (text.stdout as string) !== "") return { kind: "text", text: text.stdout as string };
+  if (text.status === 0 && (text.stdout as string) !== "") {
+    const path = existingLocalFile(text.stdout as string);
+    if (path !== "") return asFile(path);
+    return { kind: "text", text: text.stdout as string };
+  }
   return { kind: "none" };
 }
 

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { CACHE_DIR, bakeOrientation, cacheFileName, exifOrientation, fetchAttachment, isImageMime, jpegtranArgs, lruEvictions, sanitizeName, wantsJpeg } from "./fetch";
-import { extFor, pickImageType } from "./paste";
+import { extFor, existingLocalFile, firstFileUri, pickImageType, snapshotClipboard } from "./paste";
 import { resolveTarget, sendFile } from "./send-file";
 import { linkHost, linkify, normalizeLink, selectThread } from "./thread";
 import { AVATAR_DIR, AVATAR_NONE_TTL_MS, AVATAR_TTL_MS, avatarArgs, avatarKey, fetchAvatar } from "./avatar";
-import { readFileSync, writeFileSync, unlinkSync, utimesSync } from "node:fs";
+import { readFileSync, writeFileSync, unlinkSync, utimesSync, mkdtempSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // A real 16×8 baseline JPEG (ImageMagick, -strip): no APP1 at all.
@@ -458,6 +459,29 @@ describe("paste type picking", () => {
   test("extensions map sanely", () => {
     expect(extFor("image/png")).toBe("png");
     expect(extFor("image/tiff")).toBe("img");
+  });
+  test("uri-list yields the first local file", () => {
+    expect(firstFileUri("file:///tmp/photo.png\n")).toBe("/tmp/photo.png");
+    expect(firstFileUri("copy\nfile:///tmp/a%20b.png")).toBe("/tmp/a b.png");
+    expect(firstFileUri("https://example.com/x.png")).toBe("");
+  });
+  test("a copied file path attaches instead of pasting as text", () => {
+    const dir = mkdtempSync(join(tmpdir(), "blip-paste-"));
+    const file = join(dir, "shot.png");
+    writeFileSync(file, "x");
+    expect(existingLocalFile("file://" + file)).toBe(file);
+    expect(existingLocalFile(file)).toBe(file);
+    expect(existingLocalFile("not a path")).toBe("");
+    const uri = "file://" + file;
+    const runner = ((_cmd: string, args: string[]) => {
+      if (args.includes("--list-types")) return { status: 0, stdout: "text/uri-list\ntext/plain\n", stderr: "" };
+      if (args.includes("text/uri-list")) return { status: 0, stdout: uri + "\n", stderr: "" };
+      return { status: 1, stdout: "", stderr: "" };
+    }) as never;
+    const snap = snapshotClipboard(runner);
+    expect(snap.kind).toBe("file");
+    expect(snap.path).toBe(file);
+    unlinkSync(file);
   });
 });
 

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -29,6 +29,15 @@ describe("QML safety invariants", () => {
     expect(panel).not.toContain("!sendProc.running");
   });
 
+  test("compose wraps at the box edge instead of scrolling sideways", () => {
+    const start = panel.indexOf("id: composeField");
+    expect(start).toBeGreaterThan(-1);
+    const compose = panel.slice(Math.max(0, start - 80), start + 2800);
+    expect(compose).toContain("TextArea {");
+    expect(compose).toContain("wrapMode: TextEdit.Wrap");
+    expect(compose).toContain("anchors.fill: parent");
+  });
+
   test("send completion owns immutable chat and draft context", () => {
     expect(panel).toContain("var completedChat = root.sendChat");
     expect(panel).toContain("if (composeField.text === completedText) composeField.text = \"\"");


### PR DESCRIPTION
## What

Two Linux compose-box fixes, both found while using Blip on Omarchy.

1. **Copied files attach instead of pasting a path.** File managers put `text/uri-list` (and often a `file://` path as `text/plain`) on the clipboard, not `image/png`. Ctrl+V was inserting that path as a text message. The clipboard helper now treats a local file URI/path as an attachment, the same as drag-and-drop.
2. **Compose wraps at the box edge.** The field was a single-line `TextField`, so long text scrolled sideways. It is now a width-capped wrapping `TextArea`. Enter still sends; Shift+Enter inserts a newline.

## Why

Pasting a photo from the file manager sent the local path as iMessage text. Typing a normal sentence ran off the right edge of the compose box.

## How it was verified

- [x] `bun test` is green (CI will check) — 315 pass, including new paste/uri-list tests and a QML wrap invariant
- [x] Any send/receive behavior was exercised against **my own number only** — never a contact or a group
- [ ] UI change → screenshot attached — verified live on Omarchy (file paste + wrap); no screenshot of a real conversation
- [ ] Touches an invariant in `CLAUDE.md` → named below, and the doc updated if it changed

No `CLAUDE.md` invariant change. Message text still stays off argv; compose remains never-disabled (`readOnly` while sending).

Made with [Cursor](https://cursor.com)