### PR TITLE
avatars: find group photos and retry after a miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         run: bun test
       - name: Mac tools compile (python3 syntax, no macOS needed)
         run: python3 -m py_compile bridge/mac/imsg bridge/mac/imsg-send bridge/mac/contacts bridge/mac/tcc-check bridge/mac/blip-check bridge/mac/blip-dispatch
+      - name: group-photo lookup (no macOS needed)
+        run: python3 bridge/mac/test_group_photo.py
       - name: shell scripts (bash -n + shellcheck)
         run: |
           bash -n bridge/linux/blip-shim scripts/blip-setup scripts/sync-bridge.sh bridge/mac/install.sh

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -473,10 +473,25 @@ FocusScope {
     avatarQueue.push(handle)
     pumpAvatar()
   }
+  // Letters stick in avatarFiles as "". Opening the panel/window again drops
+  // those and re-asks, so a photo set a minute ago is not stuck until tomorrow.
+  function retryBareAvatars() {
+    var m = Object.assign({}, root.avatarFiles)
+    var keys = []
+    for (var k in m) {
+      if (m[k] === "") { keys.push(k); delete m[k] }
+    }
+    if (keys.length === 0) return
+    root.avatarFiles = m
+    for (var i = 0; i < keys.length; i++) root.requestAvatar(keys[i])
+  }
+  onSurfaceOpenChanged: if (surfaceOpen) root.retryBareAvatars()
   function pumpAvatar() {
     if (avatarProc.running || avatarQueue.length === 0) return
     avatarProc.handle = avatarQueue.shift()
-    avatarProc.command = ["bun", root.avatarScript, avatarProc.handle]
+    // --retry skips the 24h "no photo" marker so a picture set after the
+    // first ask (a new group photo, a Contacts card) shows up this session.
+    avatarProc.command = ["bun", root.avatarScript, "--retry", avatarProc.handle]
     avatarProc.running = true
   }
   Process {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+- **Group photos show up as photos again.** Messages stores a group's picture
+  on an announcement row (`item_type = 3`). The bridge hides those rows so
+  they never become empty unread bubbles, and the photo lookup joined through
+  that same filter, so every group with a real picture fell back to a letter.
+  The lookup now reads the raw message table (and `groupPhotoGuid` when the
+  attachment's filename is blank), and streams a 512px JPEG so a multi-megabyte
+  PNG still fits the Linux cache. Groups that only have Messages' member
+  collage still show initials — that collage is not a stored image.
+- **A photo you just assigned is not stuck as a letter.** The first ask
+  remembered "no photo" for a day, and the window remembered the letter for
+  the rest of the session, so a group picture or Contacts card set a minute
+  later never appeared. The UI now re-asks (skipping that marker), and
+  reopening the panel retries any letter.
+
 ## 2.3.2 — 2026-09-04
 
 - **A mute list, for the texts nobody opted into.** Political fundraising

--- a/avatar.ts
+++ b/avatar.ts
@@ -10,7 +10,7 @@
 import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { closeSync, fsyncSync, lstatSync, mkdirSync, openSync, renameSync, utimesSync, writeSync } from "node:fs";
+import { closeSync, fsyncSync, lstatSync, mkdirSync, openSync, renameSync, unlinkSync, utimesSync, writeSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { isGroupChat } from "./collector";
@@ -47,7 +47,7 @@ export function avatarArgs(id: string): string[] {
   return isGroupChat(id) ? ["avatar", "--chat", id] : ["avatar", "--", id];
 }
 
-export function fetchAvatar(handle: string, runner = spawnSync): AvatarResult {
+export function fetchAvatar(handle: string, runner = spawnSync, opts: { retry?: boolean } = {}): AvatarResult {
   const h = handle.trim();
   if (h === "" || h.length > 320 || /[\s\x00-\x1f]/.test(h)) return { ok: false, url: "", error: "bad handle" };
   mkdirSync(AVATAR_DIR, { recursive: true, mode: 0o700 });
@@ -55,7 +55,10 @@ export function fetchAvatar(handle: string, runner = spawnSync): AvatarResult {
   const file = `${base}.jpg`;
   const none = `${base}.none`;
   if (fresh(file)) return { ok: true, url: pathToFileURL(file).href, error: "" };
-  if (fresh(none, AVATAR_NONE_TTL_MS)) return { ok: false, url: "", error: "no photo" };
+  // `--retry` skips the negative marker: a group/contact photo can appear
+  // minutes after we first asked (someone just set one). The UI uses it on
+  // every ask so a letter is not sticky for a day.
+  if (!opts.retry && fresh(none, AVATAR_NONE_TTL_MS)) return { ok: false, url: "", error: "no photo" };
 
   const res = runner(`${HOME}/bin/imsg`, avatarArgs(h), { timeout: 20000, maxBuffer: AVATAR_MAX_BYTES + (1 << 20) });
   if (res.status === 69 || res.status === 255) return { ok: false, url: "", error: "Mac unreachable" };
@@ -79,12 +82,16 @@ export function fetchAvatar(handle: string, runner = spawnSync): AvatarResult {
   const fd = openSync(tmp, "wx", 0o600);
   try { writeSync(fd, bytes); fsyncSync(fd); } finally { closeSync(fd); }
   renameSync(tmp, file);
+  try { unlinkSync(none); } catch { /* no marker, or already gone */ }
   return { ok: true, url: pathToFileURL(file).href, error: "" };
 }
 
 if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const retry = argv.includes("--retry");
+  const handle = argv.find((a) => a !== "--retry") ?? "";
   try {
-    console.log(JSON.stringify(fetchAvatar(process.argv[2] ?? "")));
+    console.log(JSON.stringify(fetchAvatar(handle, spawnSync, { retry })));
   } catch (e) {
     console.log(JSON.stringify({ ok: false, url: "", error: String(e) }));
   }

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -1053,11 +1053,17 @@ def _group_cluster_map(con) -> dict:
     return out
 
 
+def _group_photo_chat_ids(con, chat_identifier: str) -> tuple[str, ...]:
+    clusters = _group_cluster_map(con)
+    canon = clusters.get(chat_identifier, chat_identifier)
+    return tuple(sorted({c for c, k in clusters.items() if k == canon} | {chat_identifier, canon}))
+
+
 def _group_photo_path(con, chat_identifier: str) -> str:
     """Newest group photo for a group chat, or "".
 
     Messages stores a group's photo as an attachment whose filename ends in
-    `GroupPhotoImage` — there is no column on the chat row. Two traps, both
+    `GroupPhotoImage` — there is no column on the chat row. Three traps, all
     hit on a real Mac:
 
     * The carrier message's `group_action_type` is NOT a constant. Photos set
@@ -1065,36 +1071,67 @@ def _group_photo_path(con, chat_identifier: str) -> str:
       change, not a semantic one — no group here has any group-action event
       AFTER its photo, so neither value means "removed"). Matching on the
       filename instead of the action type is what makes both work.
+    * The carrier is an announcement (`item_type = 3`), not a normal message.
+      `MESSAGE_SRC` hides those rows so they never become empty unread bubbles, and
+      a JOIN through it therefore finds no photo even when Messages shows one.
     * The photo can live on a SIBLING chat row. A re-keyed group has several
       rows with different chat_identifiers AND different group_ids; Fred's
       "Sportsball!" keeps its photo on the row Messages retired in Feb 2026.
       So the search spans the whole cluster, not the row it was asked about.
+
+    `chat.properties.groupPhotoGuid` is a second index: it names the
+    attachment even when `filename` is NULL on the GroupPhotoImage row.
     """
-    clusters = _group_cluster_map(con)
-    canon = clusters.get(chat_identifier, chat_identifier)
-    ids = sorted({c for c, k in clusters.items() if k == canon} | {chat_identifier, canon})
+    ids = _group_photo_chat_ids(con, chat_identifier)
     placeholders = ",".join("?" for _ in ids)
     row = con.execute(
         f"""SELECT a.filename
             FROM chat c
             JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID
-            JOIN {MESSAGE_SRC} m ON m.ROWID = cmj.message_id
+            JOIN message m ON m.ROWID = cmj.message_id
             JOIN message_attachment_join maj ON maj.message_id = m.ROWID
             JOIN attachment a ON a.ROWID = maj.attachment_id
-            WHERE a.filename LIKE '%GroupPhotoImage'
+            WHERE (a.filename LIKE '%GroupPhotoImage'
+                   OR a.transfer_name LIKE '%GroupPhotoImage')
+              AND a.filename IS NOT NULL
               AND c.chat_identifier IN ({placeholders})
             ORDER BY m.date DESC LIMIT 1""",
-        tuple(ids),
+        ids,
     ).fetchone()
-    return os.path.expanduser(row["filename"]) if row and row["filename"] else ""
+    if row and row["filename"]:
+        return os.path.expanduser(row["filename"])
+    for r in con.execute(
+        f"SELECT properties FROM chat WHERE chat_identifier IN ({placeholders}) AND properties IS NOT NULL",
+        ids,
+    ):
+        try:
+            blob = plistlib.loads(r["properties"])
+        except (plistlib.InvalidFileException, ValueError, TypeError, OSError):
+            continue
+        guid = blob.get("groupPhotoGuid") if isinstance(blob, dict) else None
+        if not isinstance(guid, str) or not guid:
+            continue
+        hit = con.execute(
+            "SELECT filename FROM attachment WHERE filename IS NOT NULL AND (guid = ? OR original_guid = ?) LIMIT 1",
+            (guid, guid),
+        ).fetchone()
+        if hit and hit["filename"]:
+            return os.path.expanduser(hit["filename"])
+    return ""
+
+
+GROUP_PHOTO_MAX_DIM = 512  # avatars are drawn ~40–80 px; Linux also caps at 2 MB
 
 
 def _stream_group_photo(con, chat_identifier: str) -> None:
-    """`imsg avatar --chat <id>`: the group's own photo as JPEG/PNG bytes.
+    """`imsg avatar --chat <id>`: the group's own photo as JPEG bytes.
     Same hardening as `attachment`: id shape checked, path confined to the
-    Messages store (commonpath), regular file, size ceiling; HEIC or anything
-    unrecognised goes through sips to JPEG. Exit 1 when the group has none."""
+    Messages store (commonpath), regular file, size ceiling. Always resampled
+    through sips to JPEG at GROUP_PHOTO_MAX_DIM so a multi-megabyte PNG still
+    fits the Linux avatar cache. Exit 1 when the group has none."""
     import stat as stat_mod
+    import subprocess
+    import tempfile
     if not re.fullmatch(r"[0-9a-fA-F]{32}|chat[0-9]{1,20}", chat_identifier):
         sys.exit("error: bad group id")
     raw = _group_photo_path(con, chat_identifier)
@@ -1110,30 +1147,25 @@ def _stream_group_photo(con, chat_identifier: str) -> None:
         sys.exit(1)
     if not stat_mod.S_ISREG(st.st_mode) or st.st_size > ATTACH_MAX_BYTES:
         sys.exit(1)
-    with open(path, "rb") as f:
-        kind = _sniff_image(f.read(16))
-    src, tmp = path, None
-    if kind not in ("jpeg", "png"):
-        import subprocess
-        import tempfile
-        fd_t, tmp = tempfile.mkstemp(suffix=".jpg")
-        os.close(fd_t)
+    fd_t, tmp = tempfile.mkstemp(suffix=".jpg")
+    os.close(fd_t)
+    try:
         try:
-            r = subprocess.run(["sips", "-s", "format", "jpeg", path, "--out", tmp],
-                               capture_output=True, timeout=60)
+            r = subprocess.run(
+                ["sips", "-Z", str(GROUP_PHOTO_MAX_DIM), "-s", "format", "jpeg", path, "--out", tmp],
+                capture_output=True, timeout=60,
+            )
         except subprocess.TimeoutExpired:
-            os.unlink(tmp)
             sys.exit("error: sips conversion timed out")
         if r.returncode != 0:
-            os.unlink(tmp)
             sys.exit(1)
-        src = tmp
-    try:
-        with open(src, "rb") as f:
+        with open(tmp, "rb") as f:
             data = f.read(ATTACH_MAX_BYTES + 1)
     finally:
-        if tmp:
+        try:
             os.unlink(tmp)
+        except OSError:
+            pass
     if not data or len(data) > ATTACH_MAX_BYTES:
         sys.exit(1)
     sys.stdout.buffer.write(data)

--- a/bridge/mac/test_group_photo.py
+++ b/bridge/mac/test_group_photo.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Regression: group photos live on item_type=3 rows that MESSAGE_SRC hides."""
+from __future__ import annotations
+
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+import plistlib
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+IMSG = Path(__file__).with_name("imsg")
+
+
+def load_imsg():
+    loader = SourceFileLoader("blip_imsg", str(IMSG))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    mod = module_from_spec(spec)
+    sys.modules[loader.name] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+def schema(con: sqlite3.Connection) -> None:
+    con.executescript(
+        """
+        CREATE TABLE chat (
+          ROWID INTEGER PRIMARY KEY,
+          chat_identifier TEXT,
+          display_name TEXT,
+          style INTEGER,
+          group_id TEXT,
+          original_group_id TEXT,
+          properties BLOB
+        );
+        CREATE TABLE message (
+          ROWID INTEGER PRIMARY KEY,
+          date INTEGER,
+          item_type INTEGER
+        );
+        CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+        CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+        CREATE TABLE attachment (
+          ROWID INTEGER PRIMARY KEY,
+          filename TEXT,
+          transfer_name TEXT,
+          guid TEXT,
+          original_guid TEXT
+        );
+        CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+        CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+        CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+        """
+    )
+
+
+class GroupPhotoPath(unittest.TestCase):
+    def setUp(self) -> None:
+        self.imsg = load_imsg()
+        self.con = sqlite3.connect(":memory:")
+        self.con.row_factory = sqlite3.Row
+        schema(self.con)
+
+    def test_finds_photo_on_announcement_row(self) -> None:
+        cid = "chat640665907856941413"
+        path = "~/Library/Messages/Attachments/xx/GroupPhotoImage"
+        self.con.execute(
+            "INSERT INTO chat (ROWID, chat_identifier, display_name, style) VALUES (1, ?, 'Sportsball!', 43)",
+            (cid,),
+        )
+        self.con.execute("INSERT INTO message (ROWID, date, item_type) VALUES (10, 100, 3)")
+        self.con.execute("INSERT INTO chat_message_join VALUES (1, 10)")
+        self.con.execute(
+            "INSERT INTO attachment (ROWID, filename, transfer_name) VALUES (20, ?, 'GroupPhotoImage')",
+            (path,),
+        )
+        self.con.execute("INSERT INTO message_attachment_join VALUES (10, 20)")
+        got = self.imsg._group_photo_path(self.con, cid)
+        self.assertTrue(got.endswith("GroupPhotoImage"))
+
+    def test_group_photo_guid_when_filename_on_join_is_null(self) -> None:
+        cid = "053856bb0d9a40e392db59eace1c56d1"
+        path = "~/Library/Messages/Attachments/yy/GroupPhotoImage"
+        guid = "AAAA-PHOTO-GUID"
+        props = plistlib.dumps({"groupPhotoGuid": guid}, fmt=plistlib.FMT_BINARY)
+        self.con.execute(
+            "INSERT INTO chat (ROWID, chat_identifier, display_name, style, properties) VALUES (1, ?, 'Named', 43, ?)",
+            (cid, props),
+        )
+        self.con.execute("INSERT INTO message (ROWID, date, item_type) VALUES (10, 100, 3)")
+        self.con.execute("INSERT INTO chat_message_join VALUES (1, 10)")
+        self.con.execute(
+            "INSERT INTO attachment (ROWID, filename, transfer_name, guid) VALUES (20, NULL, 'GroupPhotoImage', ?)",
+            (guid,),
+        )
+        self.con.execute("INSERT INTO message_attachment_join VALUES (10, 20)")
+        self.con.execute(
+            "INSERT INTO attachment (ROWID, filename, guid) VALUES (21, ?, ?)",
+            (path, guid),
+        )
+        got = self.imsg._group_photo_path(self.con, cid)
+        self.assertTrue(got.endswith("GroupPhotoImage"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -512,6 +512,19 @@ describe("contact photos", () => {
     unlinkSync(marker);
   });
 
+  test("retry ignores a fresh no-photo marker so a newly set picture is found", () => {
+    let calls = 0;
+    const miss = (() => ({ status: 1, stdout: Buffer.alloc(0), stderr: "" })) as never;
+    const hit = (() => { calls++; return { status: 0, stdout: Buffer.from([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3]), stderr: "" }; }) as never;
+    const h = `retry-${Date.now()}@example.com`;
+    expect(fetchAvatar(h, miss).ok).toBe(false);
+    expect(fetchAvatar(h, hit).ok).toBe(false);            // marker still fresh
+    expect(calls).toBe(0);
+    expect(fetchAvatar(h, hit, { retry: true }).ok).toBe(true);
+    expect(calls).toBe(1);
+    unlinkSync(`${AVATAR_DIR}/${avatarKey(h)}.jpg`);
+  });
+
   test("a group id asks for the GROUP's photo (--chat), a person for Contacts (--)", () => {
     expect(avatarArgs("ce5a593a78af408282d61461ade89135")).toEqual(["avatar", "--chat", "ce5a593a78af408282d61461ade89135"]);
     expect(avatarArgs("chat123456789")).toEqual(["avatar", "--chat", "chat123456789"]);

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -71,6 +71,9 @@ describe("QML safety invariants", () => {
     expect(panel.split(bind).length - 1).toBe(2);   // list row + pinned tile
     expect(panel).not.toContain('if (!root.isGroupId(String(modelData.chat || ""))) root.requestAvatar(avatarHandle)');
     expect(panel).not.toContain('if (handle === "" || isGroupId(handle)) return');
+    expect(panel).toContain('avatarProc.command = ["bun", root.avatarScript, "--retry", avatarProc.handle]');
+    expect(panel).toContain("function retryBareAvatars()");
+    expect(panel).toContain("onSurfaceOpenChanged: if (surfaceOpen) root.retryBareAvatars()");
   });
 
   test("share sheet: right-click a link, URL on stdin, never argv", () => {


### PR DESCRIPTION
## What

Group tiles with a real Messages picture show that picture instead of a letter. A photo assigned after Blip first asked (a new group picture or a Contacts card) shows up on the next open instead of staying a letter for a day.

## Why

Two stacked misses:

1. Messages stores a group's photo on an announcement row (`item_type = 3`). The bridge hides those rows so they never become empty unread bubbles, and the photo lookup joined through that same filter, so it never saw `GroupPhotoImage`. A multi-megabyte PNG also blew the 2MB Linux avatar cap.
2. The first "no photo" was cached for a day on disk and for the rest of the session in the window, so a picture set a minute later was ignored.

Groups still never borrow a member's face. Collages that Messages draws from members are not a stored image and still show initials.

## How it was verified

- [x] `bun test` is green (CI will check)
- [x] Mac-side lookup unit test (`python3 bridge/mac/test_group_photo.py`) — no live `chat.db`
- [x] Live `imsg avatar --chat` / Contacts fetch against already-assigned photos (metadata and image magic only; no conversation contents)
- [ ] UI change → screenshot attached
- [ ] Touches an invariant in `CLAUDE.md` → named below, and the doc updated if it changed

Invariants: group avatars are the group's own photo, never the last speaker; `MESSAGE_SRC` still hides announcements from the transcript.


Made with [Cursor](https://cursor.com)