### PR TITLE
Contacts saved without a country code get their name and photo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
       - name: unit tests (collector, thread, tier2, ui invariants)
         run: bun test
       - name: Mac tools compile (python3 syntax, no macOS needed)
-        run: python3 -m py_compile bridge/mac/imsg bridge/mac/imsg-send bridge/mac/contacts bridge/mac/tcc-check bridge/mac/blip-check bridge/mac/blip-dispatch
+        run: python3 -m py_compile bridge/mac/imsg bridge/mac/imsg-send bridge/mac/contacts bridge/mac/tcc-check bridge/mac/blip-check bridge/mac/blip-dispatch bridge/mac/calling_codes.py
       - name: group-photo lookup (no macOS needed)
         run: python3 bridge/mac/test_group_photo.py
+      - name: phone matching, the way Contacts does it (no macOS needed)
+        run: python3 bridge/mac/test_phone_match.py
       - name: shell scripts (bash -n + shellcheck)
         run: |
           bash -n bridge/linux/blip-shim scripts/blip-setup scripts/sync-bridge.sh bridge/mac/install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Contacts saved without a country code get their name and photo.** The
+  bridge matched phone numbers on their last ten digits, which is a whole
+  national number in North America and nothing anywhere else: a card saved
+  as `123 45 678` never met the handle `+4712345678`, so that person — the
+  owner's own card included — showed as a bare number with initials. When the
+  exact key finds nothing, `imsg` now matches the way Contacts does: the Mac's
+  region fills in the missing country code (`calling_codes.py`, generated from
+  libphonenumber), and two numbers are the same when the calling codes agree
+  and one national number ends with the other — a saved trunk zero
+  (`07700 900123`) included. A North American card shorter than ten digits is
+  missing its area code and is refused rather than guessed. The exact key
+  still decides first, so nothing that resolved before changes. Mac side:
+  re-run the install one-liner so `~/.blip/bin/imsg` picks it up.
 - **Group photos show up as photos again.** Messages stores a group's picture
   on an announcement row (`item_type = 3`). The bridge hides those rows so
   they never become empty unread bubbles, and the photo lookup joined through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,16 @@ what it is handed. Keep it that way.
   (`name_for`) and photos (`cmd_avatar`) treat a collision only WITHIN one
   source as ambiguous. Got this wrong twice (2.0.0 photos, 1.9.4 names →
   "Rob T shows as a number").
+  **Phone numbers match the way Contacts matches them.** The last-ten key is
+  exact, tried first, and decides whenever it hits. Only when it finds nothing
+  does the region-aware rule run (`_same_number`): a card saved without a
+  country code gets the Mac's region (`AppleLocale`, via
+  `calling_codes.py`), and two numbers are the same when their calling codes
+  are equal and one national number ends with the other — libphonenumber's
+  SHORT_NSN_MATCH, with a floor of seven digits and one refusal Contacts does
+  not make: a North American card shorter than ten digits has no area code and
+  matches nothing. "123 45 678" is how numbers are saved outside North
+  America; before this, every such person, the owner included, was a bare number.
   **Sources are RANKED, never counted** (`_source_ranks`, read from
   `~/Library/Accounts/Accounts4.sqlite`): `0` the local "On My Mac" store,
   which has no backing account and is what the owner typed; `1` the owner's

--- a/README.md
+++ b/README.md
@@ -388,8 +388,10 @@ Messages, Blip simply stops showing them.
 
 **Outside North America:** set `country_code=44` (etc.) in
 `~/.config/blip/bridge.conf` so a number typed without a country code in
-"New message" resolves correctly. Green-bubble (SMS/RCS) conversations
-send on their own service automatically.
+"New message" resolves correctly. Contacts saved without a country code
+(`123 45 678`, `07700 900123`) get their name and photo the way Contacts
+resolves them: the Mac's own region fills in the code. Green-bubble (SMS/RCS)
+conversations send on their own service automatically.
 
 **Two or more monitors:** one bar widget per screen is normal; only the one
 on the first screen polls and owns the app window, the others show the

--- a/bridge/mac/calling_codes.py
+++ b/bridge/mac/calling_codes.py
@@ -1,0 +1,64 @@
+"""Country calling codes: ISO 3166-1 alpha-2 region -> E.164 calling code.
+
+Generated from libphonenumber's PhoneNumberMetadata.xml, release v9.0.38, on 2026-09-04.
+Regenerate (about once a decade — the last new code was Kosovo, 2017):
+
+    curl -sL https://raw.githubusercontent.com/google/libphonenumber/<release>/resources/PhoneNumberMetadata.xml \\
+      | python3 -c "import sys,xml.etree.ElementTree as E; print({t.get('id'): int(t.get('countryCode')) for t in E.parse(sys.stdin).getroot().iter('territory') if t.get('id') != '001'})"
+
+Used by imsg to give a phone number saved without a country code the Mac's own
+region, the way Contacts does, and to split a +number into calling code and
+national number. Calling codes are prefix-free (no code is the start of another),
+so the split is unambiguous.
+"""
+from __future__ import annotations
+
+REGION_TO_CALLING_CODE: dict[str, int] = {
+    "AC": 247, "AD": 376, "AE": 971, "AF": 93, "AG": 1, "AI": 1, "AL": 355, "AM": 374,
+    "AO": 244, "AR": 54, "AS": 1, "AT": 43, "AU": 61, "AW": 297, "AX": 358, "AZ": 994,
+    "BA": 387, "BB": 1, "BD": 880, "BE": 32, "BF": 226, "BG": 359, "BH": 973, "BI": 257,
+    "BJ": 229, "BL": 590, "BM": 1, "BN": 673, "BO": 591, "BQ": 599, "BR": 55, "BS": 1,
+    "BT": 975, "BW": 267, "BY": 375, "BZ": 501, "CA": 1, "CC": 61, "CD": 243, "CF": 236,
+    "CG": 242, "CH": 41, "CI": 225, "CK": 682, "CL": 56, "CM": 237, "CN": 86, "CO": 57,
+    "CR": 506, "CU": 53, "CV": 238, "CW": 599, "CX": 61, "CY": 357, "CZ": 420, "DE": 49,
+    "DJ": 253, "DK": 45, "DM": 1, "DO": 1, "DZ": 213, "EC": 593, "EE": 372, "EG": 20,
+    "EH": 212, "ER": 291, "ES": 34, "ET": 251, "FI": 358, "FJ": 679, "FK": 500, "FM": 691,
+    "FO": 298, "FR": 33, "GA": 241, "GB": 44, "GD": 1, "GE": 995, "GF": 594, "GG": 44,
+    "GH": 233, "GI": 350, "GL": 299, "GM": 220, "GN": 224, "GP": 590, "GQ": 240, "GR": 30,
+    "GT": 502, "GU": 1, "GW": 245, "GY": 592, "HK": 852, "HN": 504, "HR": 385, "HT": 509,
+    "HU": 36, "ID": 62, "IE": 353, "IL": 972, "IM": 44, "IN": 91, "IO": 246, "IQ": 964,
+    "IR": 98, "IS": 354, "IT": 39, "JE": 44, "JM": 1, "JO": 962, "JP": 81, "KE": 254,
+    "KG": 996, "KH": 855, "KI": 686, "KM": 269, "KN": 1, "KP": 850, "KR": 82, "KW": 965,
+    "KY": 1, "KZ": 7, "LA": 856, "LB": 961, "LC": 1, "LI": 423, "LK": 94, "LR": 231,
+    "LS": 266, "LT": 370, "LU": 352, "LV": 371, "LY": 218, "MA": 212, "MC": 377, "MD": 373,
+    "ME": 382, "MF": 590, "MG": 261, "MH": 692, "MK": 389, "ML": 223, "MM": 95, "MN": 976,
+    "MO": 853, "MP": 1, "MQ": 596, "MR": 222, "MS": 1, "MT": 356, "MU": 230, "MV": 960,
+    "MW": 265, "MX": 52, "MY": 60, "MZ": 258, "NA": 264, "NC": 687, "NE": 227, "NF": 672,
+    "NG": 234, "NI": 505, "NL": 31, "NO": 47, "NP": 977, "NR": 674, "NU": 683, "NZ": 64,
+    "OM": 968, "PA": 507, "PE": 51, "PF": 689, "PG": 675, "PH": 63, "PK": 92, "PL": 48,
+    "PM": 508, "PR": 1, "PS": 970, "PT": 351, "PW": 680, "PY": 595, "QA": 974, "RE": 262,
+    "RO": 40, "RS": 381, "RU": 7, "RW": 250, "SA": 966, "SB": 677, "SC": 248, "SD": 249,
+    "SE": 46, "SG": 65, "SH": 290, "SI": 386, "SJ": 47, "SK": 421, "SL": 232, "SM": 378,
+    "SN": 221, "SO": 252, "SR": 597, "SS": 211, "ST": 239, "SV": 503, "SX": 1, "SY": 963,
+    "SZ": 268, "TA": 290, "TC": 1, "TD": 235, "TG": 228, "TH": 66, "TJ": 992, "TK": 690,
+    "TL": 670, "TM": 993, "TN": 216, "TO": 676, "TR": 90, "TT": 1, "TV": 688, "TW": 886,
+    "TZ": 255, "UA": 380, "UG": 256, "US": 1, "UY": 598, "UZ": 998, "VA": 39, "VC": 1,
+    "VE": 58, "VG": 1, "VI": 1, "VN": 84, "VU": 678, "WF": 681, "WS": 685, "XK": 383,
+    "YE": 967, "YT": 262, "ZA": 27, "ZM": 260, "ZW": 263,
+}
+
+# Non-geographic services (international freephone, satellite, ...): valid
+# calling codes with no region, kept so a +number to one still splits cleanly.
+NON_GEOGRAPHIC_CALLING_CODES = frozenset([800, 808, 870, 878, 881, 882, 883, 888, 979])
+
+CALLING_CODES: frozenset[str] = frozenset(
+    str(c) for c in set(REGION_TO_CALLING_CODE.values()) | NON_GEOGRAPHIC_CALLING_CODES
+)
+
+
+def split_calling_code(digits: str) -> tuple[str, str] | None:
+    """"4712345678" -> ("47", "12345678"); None when no calling code fits."""
+    for n in (1, 2, 3):
+        if digits[:n] in CALLING_CODES:
+            return digits[:n], digits[n:]
+    return None

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import functools
 import json
 import os
 import plistlib
@@ -31,6 +32,9 @@ import sqlite3
 import struct
 import sys
 from glob import glob
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+from calling_codes import REGION_TO_CALLING_CODE, split_calling_code  # noqa: E402  (sibling module)
 
 DB_PATH = os.path.expanduser("~/Library/Messages/chat.db")
 PINNING_PLIST_PATHS = (
@@ -143,12 +147,79 @@ def _ab_sources() -> list[str]:
     return sorted(paths, key=lambda p: (_rank_of(p, ranks), p))
 
 
+def _digits(s: str) -> str:
+    return re.sub(r"\D", "", s or "")
+
+
 def _normalize_phone(s: str) -> str:
-    digits = re.sub(r"\D", "", s or "")
+    digits = _digits(s)
     return digits[-10:] if len(digits) >= 10 else digits
 
 
-_NAME_INDEX: dict[str, str] | None = None
+# ---- Phone numbers the way Contacts compares them ------------------------
+#
+# The last-ten key above is exact and is tried first, so nothing that resolves
+# today can change. It is also North American: ten digits is a whole national
+# number there and nothing anywhere else, so a card saved as "123 45 678" never
+# met the handle +4712345678 and its owner showed as a bare number.
+#
+# The fallback is libphonenumber's rule, which is what Contacts runs on: give a
+# number saved without a country code the Mac's own region, and call two
+# numbers the same when their calling codes are equal and one national number
+# ends with the other. Two guards on top: a floor of seven shared digits (a
+# local number), and a North American card shorter than ten digits is missing
+# its area code and matches nothing — Contacts would guess; Blip does not.
+
+_GLOBAL_PREFS = os.path.expanduser("~/Library/Preferences/.GlobalPreferences.plist")
+_LOCAL_NUMBER_DIGITS = 7
+
+Phone = tuple[str, str]   # (calling code, national number), digits only
+
+
+def _calling_code_for_locale(locale: str) -> str | None:
+    """"en_US@rg=nozzzz" (a region override) or "nb_NO" -> "47"; None when unknown."""
+    m = re.search(r"rg=([a-z]{2})", locale, re.I) or re.search(r"_([A-Z]{2})", locale)
+    cc = REGION_TO_CALLING_CODE.get(m.group(1).upper()) if m else None
+    return str(cc) if cc else None
+
+
+@functools.lru_cache(maxsize=None)
+def _home_calling_code() -> str | None:
+    """The Mac's region as a calling code, from AppleLocale."""
+    try:
+        with open(_GLOBAL_PREFS, "rb") as f:
+            return _calling_code_for_locale(str(plistlib.load(f).get("AppleLocale", "")))
+    except (OSError, plistlib.InvalidFileException):
+        return None
+
+
+def _parse_phone(raw: str) -> Phone | None:
+    """"+47 123 45 678" and "0047…" split on the calling code; "123 45 678"
+    takes the Mac's region. None when neither applies."""
+    s = (raw or "").strip()
+    digits = _digits(s)
+    if s.startswith("+"):
+        return split_calling_code(digits)
+    if s.startswith("00"):
+        return split_calling_code(digits[2:])
+    home = _home_calling_code()
+    return (home, digits) if home and digits else None
+
+
+def _same_number(handle: Phone, card: Phone) -> bool:
+    """libphonenumber's SHORT_NSN_MATCH with Blip's two guards (see above)."""
+    if card[0] != handle[0]:
+        return False
+    if card[0] == "1" and len(card[1]) < 10:
+        return False
+    for nsn in {card[1], card[1].removeprefix("0")}:   # a saved trunk zero (07700…) is not in the handle
+        if min(len(nsn), len(handle[1])) >= _LOCAL_NUMBER_DIGITS and (handle[1].endswith(nsn) or nsn.endswith(handle[1])):
+            return True
+    return False
+
+
+_NAME_INDEX: dict[str, str] | None = None            # exact keys: last-ten digits, lowercased email
+_PHONE_INDEX: dict[Phone, str] | None = None          # every saved number, parsed, for the region-aware fallback
 
 
 def _is_dm_id(s: str | None) -> bool:
@@ -186,7 +257,7 @@ def name_for(handle: str | None) -> str | None:
     """Resolve a Messages handle (phone or email) to a Contacts display name.
     Lazily builds an in-memory index from all AddressBook source DBs on first
     call. Returns None if no contact match."""
-    global _NAME_INDEX
+    global _NAME_INDEX, _PHONE_INDEX
     if not handle:
         return None
     if _NAME_INDEX is None:
@@ -199,7 +270,7 @@ def name_for(handle: str | None) -> str | None:
         # most common spelling only breaks ties within one rank. Counting every
         # source equally let a synced directory's bulk rows rename people.
         # key -> name -> [best source rank seen, times seen]
-        votes: dict[str, dict[str, list]] = {}
+        votes: dict[str | Phone, dict[str, list]] = {}
         ranks = _source_ranks()
         for path in _ab_sources():
             rank = _rank_of(path, ranks)
@@ -214,7 +285,7 @@ def name_for(handle: str | None) -> str | None:
                         "ZORGANIZATION AS org, ZNICKNAME AS nick FROM ZABCDRECORD"
                     )
                 }
-                local: dict[str, str | None] = {}   # None = ambiguous within this source
+                local: dict[str | Phone, str | None] = {}   # None = ambiguous within this source
                 for r in con.execute(
                     "SELECT ZOWNER AS pk, ZFULLNUMBER AS num FROM ZABCDPHONENUMBER"
                 ):
@@ -222,6 +293,9 @@ def name_for(handle: str | None) -> str | None:
                     key = _normalize_phone(r["num"] or "")
                     if name and key:
                         local[key] = None if (key in local and local[key] not in (None, name)) else (local.get(key) or name)
+                    parsed = _parse_phone(r["num"] or "")
+                    if name and parsed:
+                        local[parsed] = None if (parsed in local and local[parsed] not in (None, name)) else (local.get(parsed) or name)
                 for r in con.execute(
                     "SELECT ZOWNER AS pk, ZADDRESS AS addr FROM ZABCDEMAILADDRESS"
                 ):
@@ -241,13 +315,18 @@ def name_for(handle: str | None) -> str | None:
             except sqlite3.DatabaseError:
                 continue
         # Nearest source first; only then the most common spelling.
-        _NAME_INDEX = {
-            k: min(v.items(), key=lambda kv: (kv[1][0], -kv[1][1]))[0]
-            for k, v in votes.items()
-        }
+        resolved = {k: min(v.items(), key=lambda kv: (kv[1][0], -kv[1][1]))[0] for k, v in votes.items()}
+        _NAME_INDEX = {k: n for k, n in resolved.items() if isinstance(k, str)}
+        _PHONE_INDEX = {k: n for k, n in resolved.items() if isinstance(k, tuple)}
     if "@" in handle:
         return _NAME_INDEX.get(handle.strip().lower()) or None
-    return _NAME_INDEX.get(_normalize_phone(handle)) or None
+    hit = _NAME_INDEX.get(_normalize_phone(handle))
+    if hit:
+        return hit
+    # No exact key: a unique region-aware match names it; two different names do not.
+    parsed = _parse_phone(handle)
+    near = {n for card, n in _PHONE_INDEX.items() if parsed and _same_number(parsed, card)}
+    return near.pop() if len(near) == 1 else None
 
 
 def label(handle: str | None, is_from_me: int, with_names: bool) -> str:
@@ -1245,34 +1324,50 @@ def cmd_avatar(con, args):
     handle = (args.handle or "").strip()
     if not handle or len(handle) > 320:
         sys.exit("error: bad handle")
-    want_email = "@" in handle
-    key = handle.lower() if want_email else _normalize_phone(handle)
-    if not key:
-        sys.exit(1)
-    candidates: list[tuple[str, int]] = []
-    for path in _ab_sources():
-        try:
-            con2 = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
-            q = ("SELECT ZOWNER AS pk, ZADDRESS AS v FROM ZABCDEMAILADDRESS" if want_email
-                 else "SELECT ZOWNER AS pk, ZFULLNUMBER AS v FROM ZABCDPHONENUMBER")
-            pks = set()
-            for pk, v in con2.execute(q):
-                k = (v or "").strip().lower() if want_email else _normalize_phone(v or "")
-                if k and k == key and pk is not None:
-                    pks.add(pk)
-            con2.close()
-        except sqlite3.DatabaseError:
-            continue
-        if len(pks) == 1:
-            candidates.append((path, pks.pop()))
-        # len > 1 inside ONE source: ambiguous there — skip that source only
-    for path, pk in candidates:
+    for path, pk in _avatar_candidates(handle):
         data = _avatar_bytes(path, pk)
         if data:
             sys.stdout.buffer.write(data)
             sys.stdout.buffer.flush()
             return
     sys.exit(1)
+
+
+def _avatar_candidates(handle: str) -> list[tuple[str, int]]:
+    """(source db, record pk) per source that names this handle unambiguously,
+    nearest source first. The exact key decides when it hits; the region-aware
+    match only runs in a source with no exact hit — the rule name_for applies."""
+    want_email = "@" in handle
+    key = handle.lower() if want_email else _normalize_phone(handle)
+    if not key:
+        return []
+    parsed = None if want_email else _parse_phone(handle)
+    candidates: list[tuple[str, int]] = []
+    for path in _ab_sources():
+        try:
+            con2 = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+            q = ("SELECT ZOWNER AS pk, ZADDRESS AS v FROM ZABCDEMAILADDRESS" if want_email
+                 else "SELECT ZOWNER AS pk, ZFULLNUMBER AS v FROM ZABCDPHONENUMBER")
+            exact: set[int] = set()
+            near: set[int] = set()
+            for pk, v in con2.execute(q):
+                if pk is None:
+                    continue
+                if want_email:
+                    if (v or "").strip().lower() == key:
+                        exact.add(pk)
+                elif _normalize_phone(v or "") == key:
+                    exact.add(pk)
+                elif parsed and (card := _parse_phone(v or "")) and _same_number(parsed, card):
+                    near.add(pk)
+            con2.close()
+        except sqlite3.DatabaseError:
+            continue
+        pks = exact or near
+        if len(pks) == 1:
+            candidates.append((path, pks.pop()))
+        # len > 1 inside ONE source: ambiguous there — skip that source only
+    return candidates
 
 
 def cmd_attachment(con, args):

--- a/bridge/mac/install.sh
+++ b/bridge/mac/install.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 dest="$HOME/.blip/bin"
 mkdir -p "$dest"
-for t in imsg imsg-send imsg-read contacts tcc-check blip-check blip-dispatch; do
+for t in imsg imsg-send imsg-read contacts tcc-check blip-check blip-dispatch calling_codes.py; do
   if [[ -f "$here/$t" ]]; then
     install -m 0755 "$here/$t" "$dest/$t"
   else

--- a/bridge/mac/test_phone_match.py
+++ b/bridge/mac/test_phone_match.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Phone numbers match the way Contacts matches them: the exact last-ten key
+first, then libphonenumber's rule — the Mac's region for a card saved without
+a country code, equal calling codes, one national number a suffix of the
+other. Names (name_for) and photos (_avatar_candidates) follow the one rule."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+HERE = Path(__file__).parent
+JPEG = b"\xff\xd8\xff\xe0" + b"\0" * 32
+
+
+def load(tool: str):
+    loader = SourceFileLoader(f"blip_{tool}", str(HERE / tool))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    mod = module_from_spec(spec)
+    sys.modules[loader.name] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+class FakeAddressBook:
+    """One Contacts source under a temp dir, with the three tables the bridge reads."""
+
+    def __init__(self, root: str, source: str = "SRC-A") -> None:
+        folder = os.path.join(root, "Sources", source)
+        os.makedirs(folder)
+        self.path = os.path.join(folder, "AddressBook-v22.abcddb")
+        self.con = sqlite3.connect(self.path)
+        self.con.executescript(
+            """
+            CREATE TABLE ZABCDRECORD (Z_PK INTEGER PRIMARY KEY, ZFIRSTNAME TEXT, ZLASTNAME TEXT,
+              ZORGANIZATION TEXT, ZNICKNAME TEXT, ZTHUMBNAILIMAGEDATA BLOB, ZIMAGEDATA BLOB);
+            CREATE TABLE ZABCDPHONENUMBER (ZOWNER INTEGER, ZFULLNUMBER TEXT);
+            CREATE TABLE ZABCDEMAILADDRESS (ZOWNER INTEGER, ZADDRESS TEXT);
+            """
+        )
+        self.next_pk = 1
+
+    def card(self, first: str, last: str, *, phones=(), emails=(), photo: bytes | None = None) -> int:
+        pk = self.next_pk
+        self.next_pk += 1
+        self.con.execute(
+            "INSERT INTO ZABCDRECORD (Z_PK, ZFIRSTNAME, ZLASTNAME, ZTHUMBNAILIMAGEDATA) VALUES (?, ?, ?, ?)",
+            (pk, first, last, photo),
+        )
+        for p in phones:
+            self.con.execute("INSERT INTO ZABCDPHONENUMBER VALUES (?, ?)", (pk, p))
+        for e in emails:
+            self.con.execute("INSERT INTO ZABCDEMAILADDRESS VALUES (?, ?)", (pk, e))
+        self.con.commit()
+        return pk
+
+
+class Base(unittest.TestCase):
+    home = "47"   # the Mac's region as a calling code; None = unknown
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.book = FakeAddressBook(self.tmp.name)
+        self.imsg = load("imsg")
+        # Point the bridge at the fixture. No Accounts db means "no ranks, no
+        # child delegates", the documented fallback; the region is set directly.
+        self.imsg._AB_GLOB = os.path.join(self.tmp.name, "Sources", "*", "AddressBook-v22.abcddb")
+        self.imsg._ACCOUNTS_DB = os.path.join(self.tmp.name, "no-such-Accounts4.sqlite")
+        self.imsg._NAME_INDEX = None
+        self.imsg._home_calling_code = lambda: self.home
+
+    def tearDown(self) -> None:
+        self.book.con.close()
+        self.tmp.cleanup()
+
+
+class CallingCodes(unittest.TestCase):
+    def test_table_is_prefix_free_and_splits_unambiguously(self) -> None:
+        cc = load("calling_codes.py")
+        codes = sorted(cc.CALLING_CODES, key=len)
+        self.assertFalse([(a, b) for a in codes for b in codes if a != b and b.startswith(a)])
+        self.assertEqual(cc.split_calling_code("4712345678"), ("47", "12345678"))
+        self.assertEqual(cc.split_calling_code("14155550100"), ("1", "4155550100"))
+        self.assertEqual(cc.split_calling_code("447700900123"), ("44", "7700900123"))
+        self.assertEqual(cc.split_calling_code("3546123456"), ("354", "6123456"))   # Iceland: 7-digit national numbers
+        self.assertEqual(cc.REGION_TO_CALLING_CODE["NO"], 47)
+
+
+class RegionDetection(unittest.TestCase):
+    def test_region_comes_from_apple_locale(self) -> None:
+        imsg = load("imsg")
+        for locale, want in (("en_US@rg=nozzzz", "47"), ("nb_NO", "47"), ("en_US", "1"), ("en_GB", "44"), ("", None)):
+            self.assertEqual(imsg._calling_code_for_locale(locale), want, locale)
+
+    def test_the_reader_uses_the_prefs_file_and_survives_a_missing_one(self) -> None:
+        import plistlib
+        imsg = load("imsg")
+        with tempfile.TemporaryDirectory() as tmp:
+            imsg._GLOBAL_PREFS = os.path.join(tmp, "prefs.plist")
+            with open(imsg._GLOBAL_PREFS, "wb") as f:
+                plistlib.dump({"AppleLocale": "nb_NO"}, f)
+            self.assertEqual(imsg._home_calling_code(), "47")
+            imsg._home_calling_code.cache_clear()
+            imsg._GLOBAL_PREFS = os.path.join(tmp, "missing.plist")
+            self.assertIsNone(imsg._home_calling_code())
+
+
+class Names(Base):
+    def test_a_us_number_in_four_spellings_still_resolves(self) -> None:
+        self.book.card("Alex", "Rivera", phones=["+1 (555) 555-0100"])
+        for h in ("+15555550100", "5555550100", "(555) 555-0100", "555-555-0100"):
+            self.assertEqual(self.imsg.name_for(h), "Alex Rivera", h)
+
+    def test_a_card_without_country_code_takes_the_macs_region(self) -> None:
+        self.book.card("Nora", "Berg", phones=["123 45 678"])
+        self.assertEqual(self.imsg.name_for("+4712345678"), "Nora Berg")
+
+    def test_a_card_saved_with_00_splits_like_plus(self) -> None:
+        self.book.card("Nora", "Berg", phones=["0047 123 45 678"])
+        self.assertEqual(self.imsg.name_for("+4712345678"), "Nora Berg")
+
+    def test_the_exact_key_wins_over_the_region_rule(self) -> None:
+        self.book.card("Ada", "Exact", phones=["+47 123 45 678"])
+        self.book.card("Bea", "Suffix", phones=["123 45 678"])
+        self.assertEqual(self.imsg.name_for("+4712345678"), "Ada Exact")
+
+    def test_two_matching_cards_name_nobody(self) -> None:
+        self.book.card("Ada", "One", phones=["123 45 678"])
+        self.book.card("Bea", "Two", phones=["7 123 45 678"])
+        self.assertIsNone(self.imsg.name_for("+4712345678"))
+
+    def test_a_different_number_of_the_same_length_never_matches(self) -> None:
+        # What Contacts itself answers: a suffix relation, not shared trailing digits.
+        self.book.card("Nora", "Berg", phones=["123 45 678"])
+        self.assertIsNone(self.imsg.name_for("+4713345678"))     # one digit off
+        self.assertIsNone(self.imsg.name_for("+4712345670"))     # last digit off
+        self.assertEqual(self.imsg.name_for("+4712345678"), "Nora Berg")
+
+    def test_another_country_never_matches(self) -> None:
+        self.book.card("Nora", "Berg", phones=["12345678"])
+        self.assertIsNone(self.imsg.name_for("+3112345678"))      # the same eight digits, Dutch
+
+    def test_email_handles_are_untouched(self) -> None:
+        self.book.card("Sam", "Okafor", emails=["Sam@Example.com"])
+        self.assertEqual(self.imsg.name_for("sam@example.com"), "Sam Okafor")
+        self.assertIsNone(self.imsg.name_for("nobody@example.com"))
+
+
+class TrunkZero(Base):
+    home = "44"
+
+    def test_a_uk_card_saved_with_its_zero_matches(self) -> None:
+        self.book.card("Rob", "Taylor", phones=["07700 900123"])
+        self.assertEqual(self.imsg.name_for("+447700900123"), "Rob Taylor")
+
+    def test_an_italian_zero_is_part_of_the_number(self) -> None:
+        self.imsg._home_calling_code = lambda: "39"
+        self.book.card("Giulia", "Rossi", phones=["06 1234567"])
+        self.assertEqual(self.imsg.name_for("+39061234567"), "Giulia Rossi")
+
+
+class NorthAmerica(Base):
+    home = "1"
+
+    def test_a_seven_digit_local_card_is_refused_not_guessed(self) -> None:
+        self.book.card("Casey", "Local", phones=["555-0100"])
+        self.assertIsNone(self.imsg.name_for("+14155550100"))
+        self.assertIsNone(self.imsg.name_for("+12125550100"))
+
+    def test_a_ten_digit_card_resolves_as_before(self) -> None:
+        self.book.card("Casey", "Full", phones=["415-555-0100"])
+        self.assertEqual(self.imsg.name_for("+14155550100"), "Casey Full")
+
+
+class NoRegion(Base):
+    home = None
+
+    def test_a_national_card_stays_a_number_and_plus_cards_still_work(self) -> None:
+        self.book.card("Nora", "Berg", phones=["123 45 678"])
+        self.book.card("Ada", "Plus", phones=["+47 198 77 665"])
+        self.assertIsNone(self.imsg.name_for("+4712345678"))
+        self.assertEqual(self.imsg.name_for("+4719877665"), "Ada Plus")
+
+
+class Photos(Base):
+    def test_the_region_rule_picks_the_card_when_nothing_is_exact(self) -> None:
+        pk = self.book.card("Nora", "Berg", phones=["123 45 678"], photo=JPEG)
+        self.assertEqual(self.imsg._avatar_candidates("+4712345678"), [(self.book.path, pk)])
+
+    def test_the_exact_card_is_preferred(self) -> None:
+        exact = self.book.card("Ada", "Exact", phones=["+4712345678"])
+        self.book.card("Bea", "Suffix", phones=["123 45 678"], photo=JPEG)
+        self.assertEqual(self.imsg._avatar_candidates("+4712345678"), [(self.book.path, exact)])
+
+    def test_an_ambiguous_source_yields_no_candidate(self) -> None:
+        self.book.card("Ada", "One", phones=["123 45 678"], photo=JPEG)
+        self.book.card("Bea", "Two", phones=["7 123 45 678"], photo=JPEG)
+        self.assertEqual(self.imsg._avatar_candidates("+4712345678"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Contacts saved without a country code now get their name and photo. `imsg` keeps matching on the exact last-ten key first; when that finds nothing, it matches the way Contacts does: the Mac's own region fills in the missing country code, and two numbers are the same when their calling codes agree and one national number ends with the other, a saved trunk zero (`07700 900123`) included.

Nothing that resolves today changes — the exact key still decides whenever it hits.

## Why

The last-ten key is a whole national number in North America and nothing anywhere else. A card saved as `123 45 678` never met the handle `+4712345678`, so that person showed as a bare number with initials — the owner's own card included, which is how this was found. On one Norwegian address book, 99 of 386 numbers are saved without a country code.

## How

- **`bridge/mac/calling_codes.py`** (new) — region → calling code for 245 regions, generated from libphonenumber v9.0.38; the regeneration one-liner is in its header. The set is prefix-free, so splitting a `+` number into calling code and national number is unambiguous. `imsg` imports it as a sibling; `install.sh` and the CI compile step know about it.
- **`bridge/mac/imsg`** — `_parse_phone()` splits `+…`/`00…` on the calling code and gives a bare number the Mac's region (`AppleLocale`, `rg=` override honoured). `_same_number()` is libphonenumber's SHORT_NSN_MATCH with two guards: a floor of seven shared digits, and a North American card shorter than ten digits is refused rather than guessed (it is missing its area code; Contacts would guess). `name_for` keeps a second index of every saved number, parsed, for the fallback. `cmd_avatar`'s candidate selection is now `_avatar_candidates()` and follows the same rule, exact first per source.
- **`bridge/mac/test_phone_match.py`** (new) + one CI step, same shape as `test_group_photo.py`.
- **Not touched**: the `contacts` CLI. Blip never calls its lookup.
- README (Outside North America), CLAUDE.md (new invariant), CHANGELOG (Unreleased).

## How it was verified

- [x] `bun test` is green (CI will check) — 323 pass; `test_phone_match.py` 19 pass; `test_group_photo.py` pass; every Mac tool compiles
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send; it only resolves names and photos
- [ ] UI change → none; the same tiles and rows render better data
- [x] Touches an invariant in `CLAUDE.md` → **new: phone numbers match the way Contacts matches them**; the cross-source ambiguity rule is unchanged

Against a live `chat.db`, old tool vs new, through the real `name_for` on every distinct phone handle (1393): **1356 resolve as before, 37 gain a name, 0 lose one, 0 change to a different name.** In the conversation list, unnamed phone threads went 9 → 6; the three that gained are people whose cards are saved without a country code. The owner's own photo now streams (0 → 58 KB); a card saved with `+47` returns byte-identical bytes before and after. A Dutch-looking handle ending in the same eight digits resolves to nothing.

Cross-checked against Contacts itself on macOS 26, via `CNContact.predicateForContactsMatchingPhoneNumber` on the owner's own card (saved without a country code): the `+47` handle and the national form both resolve to the card; the same-length number with a leading digit changed, the same-length number with two digits changed, and a US number ending in the same ten digits all resolve to nothing. The rule in this PR gives the same five answers.

The 19 tests cover: the table is prefix-free and splits correctly (incl. Iceland's 7-digit national numbers); region from `AppleLocale` in five spellings and a missing prefs file; a US number in four spellings; the region rule; `00` prefixes; exact beats suffix; two matching cards name nobody; a same-length different number never matches; another country never matches; the UK trunk zero; the Italian zero; the North American refusal; the no-region fallback; and the photo path three ways. Example numbers are unassignable (`+47 1xx…`), the UK drama range, or 555-01xx.
