### PR TITLE
Unsent messages are tombstones again, not empty bubbles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: python3 -m py_compile bridge/mac/imsg bridge/mac/imsg-send bridge/mac/contacts bridge/mac/tcc-check bridge/mac/blip-check bridge/mac/blip-dispatch
       - name: group-photo lookup (no macOS needed)
         run: python3 bridge/mac/test_group_photo.py
+      - name: unsent messages are tombstones, not empty bubbles (no macOS needed)
+        run: python3 bridge/mac/test_unsent.py
       - name: shell scripts (bash -n + shellcheck)
         run: |
           bash -n bridge/linux/blip-shim scripts/blip-setup scripts/sync-bridge.sh bridge/mac/install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Unsent messages are tombstones again, not empty bubbles.** On macOS 26 an
+  Undo Send no longer sets `date_retracted`; Apple records it as an edit —
+  `date_edited` stamped, body cleared, the withdrawn parts listed as `rp` in
+  `message_summary_info`. The bridge read only the date columns, so every
+  unsend since January arrived as an empty bubble tagged "Edited". It now
+  reads the summary blob too: `rp` means unsent (and not edited), `ec` means
+  a real edit as before, and the old `date_retracted` path still works on
+  older Macs. In the conversation with yourself, where every message lands
+  twice, the withdrawn copy now wins over its echo instead of being folded
+  away as transport noise. Mac side: re-run the install one-liner so
+  `~/.blip/bin/imsg` picks it up.
 - **Group photos show up as photos again.** Messages stores a group's picture
   on an announcement row (`item_type = 3`). The bridge hides those rows so
   they never become empty unread bubbles, and the photo lookup joined through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,14 @@ what it is handed. Keep it that way.
 - **`chat:null` exists.** Use `chatKey()`; never `String(m.chat)`.
 - **Group ids come in two shapes**: 32 hex, or `chat<digits>`. `isGroupChat()` is
   "not a phone/email" — never a positive regex on one shape.
+- **An unsend is not an edit, and on macOS 26 it never sets `date_retracted`.**
+  Undo Send stamps `date_edited`, clears the body, and records the withdrawn
+  parts as `rp` in `message_summary_info`; a real edit carries `ec` and keeps
+  its body. `_edit_flags` reads both, retracted wins, so the tombstone shows
+  instead of an empty bubble marked "Edited". In the SELF-THREAD an unsend
+  withdraws only the sent copy and the echo keeps its text — the echo shape
+  inverted — so `dedupeSelfEcho` keeps the retracted outbound row and drops
+  the echo, instead of the other way round.
 - **Deleted messages stay in chat.db for 30 days** (`chat_recoverable_message_join`).
   claude-on-mac's `imsg` hides them (1.4.0+); Blip assumes that.
 - **Announcements are not messages.** Joins, leaves, renames and location-sharing

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -514,6 +514,26 @@ def _parse_rich_link(blob: bytes) -> dict | None:
     }
 
 
+def _unsent(summary_info) -> bool:
+    """True when message_summary_info lists withdrawn parts (`rp`).
+
+    macOS 26 records an Undo Send as an edit: date_edited is stamped, the body
+    is cleared, and date_retracted stays 0 — `rp` in this plist is the only
+    trace. A real edit carries `ec` (the history) and no `rp`. Anything
+    unreadable is not an unsend."""
+    try:
+        return bool(plistlib.loads(bytes(summary_info)).get("rp"))
+    except (plistlib.InvalidFileException, ValueError, TypeError, AttributeError):
+        return False
+
+
+def _edit_flags(date_edited, date_retracted, summary_info) -> dict:
+    """An unsend is not an edit, whatever date_edited says."""
+    if date_retracted or _unsent(summary_info):
+        return {"retracted": True}
+    return {"edited": True} if date_edited else {}
+
+
 def enrich(con, rows, with_names: bool):
     """Per-ROWID extras for --rich JSON. Returns (kept_rows, extras) where
     tapback rows are folded onto their targets and dropped from kept_rows."""
@@ -614,10 +634,8 @@ def enrich(con, rows, with_names: bool):
         e = extras[r["ROWID"]]
         if r["is_from_me"] and r["date_read"]:
             e["read_at"] = fmt_ts(r["date_read"])
-        if has_edit and r["date_edited"]:
-            e["edited"] = True
-        if has_edit and r["date_retracted"]:
-            e["retracted"] = True
+        if has_edit:
+            e.update(_edit_flags(r["date_edited"], r["date_retracted"], r["message_summary_info"]))
         if r["orig_guid"] and r["orig_guid"] in osnip:
             e["reply_to"] = osnip[r["orig_guid"]]
         fx = _effect_name(r["style_id"])
@@ -706,9 +724,9 @@ def base_select(con) -> str:
     global _BASE_SELECT_CACHE
     if _BASE_SELECT_CACHE is None:
         edit_cols = (
-            "m.date_edited, m.date_retracted,"
+            "m.date_edited, m.date_retracted, m.message_summary_info,"
             if _has_col(con, "date_edited")
-            else "0 AS date_edited, 0 AS date_retracted,"
+            else "0 AS date_edited, 0 AS date_retracted, NULL AS message_summary_info,"
         )
         _BASE_SELECT_CACHE = f"""
             SELECT m.ROWID, m.date, m.is_from_me, m.text, m.attributedBody,

--- a/bridge/mac/test_unsent.py
+++ b/bridge/mac/test_unsent.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression: on macOS 26 an Undo Send never sets date_retracted. It stamps
+date_edited, clears the body, and lists the withdrawn parts as `rp` in
+message_summary_info. Read only the dates and every unsend since January 2026
+is an empty bubble tagged "Edited"; the tombstone never shows."""
+from __future__ import annotations
+
+import plistlib
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+IMSG = Path(__file__).with_name("imsg")
+
+
+def load_imsg():
+    loader = SourceFileLoader("blip_imsg", str(IMSG))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    mod = module_from_spec(spec)
+    sys.modules[loader.name] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+# The two shapes seen on a real macOS 26 chat.db, keys as Apple writes them.
+UNSENT = plistlib.dumps({"amc": 1, "ust": False, "otr": {"0": b"\x00"}, "rp": [0]}, fmt=plistlib.FMT_BINARY)
+EDITED = plistlib.dumps({"amc": 1, "ust": False, "otr": {"0": b"\x00"}, "ec": {"0": [{"d": 1.0, "t": b"\x00"}]}, "ep": [0]},
+                        fmt=plistlib.FMT_BINARY)
+STAMP = 800_000_000_000_000_000   # a date_edited value (ns since 2001); any non-zero will do
+
+
+class Unsent(unittest.TestCase):
+    def setUp(self) -> None:
+        self.unsent = load_imsg()._unsent
+
+    def test_rp_means_unsent(self) -> None:
+        self.assertTrue(self.unsent(UNSENT))
+
+    def test_a_real_edit_is_not_unsent(self) -> None:
+        self.assertFalse(self.unsent(EDITED))
+
+    def test_missing_or_broken_blobs_are_not_unsent(self) -> None:
+        for blob in (None, b"", b"not a plist", plistlib.dumps({"rp": []}), plistlib.dumps(["rp"])):
+            self.assertFalse(self.unsent(blob), repr(blob)[:24])
+
+
+class EditFlags(unittest.TestCase):
+    def setUp(self) -> None:
+        self.flags = load_imsg()._edit_flags
+
+    def test_macos_26_unsend_is_retracted_not_edited(self) -> None:
+        # date_edited stamped, date_retracted 0, rp in the summary: what Undo Send writes now
+        self.assertEqual(self.flags(STAMP, 0, UNSENT), {"retracted": True})
+
+    def test_older_macos_unsend_still_works(self) -> None:
+        self.assertEqual(self.flags(0, STAMP, None), {"retracted": True})
+        self.assertEqual(self.flags(STAMP, STAMP, None), {"retracted": True})
+
+    def test_a_real_edit_is_edited(self) -> None:
+        self.assertEqual(self.flags(STAMP, 0, EDITED), {"edited": True})
+        self.assertEqual(self.flags(STAMP, 0, None), {"edited": True})
+
+    def test_an_untouched_message_has_no_flags(self) -> None:
+        self.assertEqual(self.flags(0, 0, None), {})
+        self.assertEqual(self.flags(None, None, b""), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/collector.ts
+++ b/collector.ts
@@ -356,6 +356,9 @@ export function dedupeSelfEcho(msgs: ImsgMessage[], knownSelfChats: string[] = [
   const emptySent = new Set(
     msgs.filter((m) => selfChats.has(chatKey(m)) && m.from_me && m.text === "").map(contextKey),
   );
+  const retractedSent = new Set(
+    msgs.filter((m) => selfChats.has(chatKey(m)) && m.from_me && m.retracted === true).map(contextKey),
+  );
   const selfText = new Map<string, number>();
   const seenIds = new Set<string>();
   const out: ImsgMessage[] = [];
@@ -368,7 +371,12 @@ export function dedupeSelfEcho(msgs: ImsgMessage[], knownSelfChats: string[] = [
     const context = contextKey(m);
     // The empty outbound half of a known self echo is transport noise. Keep
     // empty inbound rows: they can represent an attachment and are unread.
-    if (selfChats.has(chatKey(m)) && m.from_me && m.text === "") continue;
+    // An unsend leaves the same shape with the opposite truth — the empty
+    // outbound row IS the message (the tombstone) and the echo is what Undo
+    // Send never reached — so there the echo goes and the row stays.
+    if (retractedSent.has(context)) {
+      if (!m.from_me) continue;
+    } else if (selfChats.has(chatKey(m)) && m.from_me && m.text === "") continue;
 
     if (selfContexts.has(context) && m.text !== "") {
       const key = contentKey(m);

--- a/scripts/demo/fake-imsg
+++ b/scripts/demo/fake-imsg
@@ -112,7 +112,7 @@ function conversation(): Row[] {
         }))
         : null,
       reply_to: m.reply_to ? { text: String(m.reply_to), from_me: false } : null,
-      edited: false, retracted: false, effect: null, audio: false, link: null,
+      edited: m.edited === true, retracted: m.retracted === true, effect: null, audio: false, link: null,
     };
     return row;
   });

--- a/thread.test.ts
+++ b/thread.test.ts
@@ -313,6 +313,20 @@ describe("dedupeSelfEcho", () => {
     expect(b[0]!.from_me).toBe(true);
   });
 
+  test("an unsent message keeps its tombstone: the retracted twin wins, the echo goes", () => {
+    // Undo Send in the self-thread withdraws only the sent copy; the echo still
+    // carries the text. Same shape as the echo case, opposite truth.
+    const self = msg().chat;
+    const out = dedupeSelfEcho([
+      msg({ ts: "2026-08-30 21:08:22", from_me: true, text: "", retracted: true }),
+      msg({ ts: "2026-08-30 21:08:22", from_me: false, text: "taken back" }),
+    ], [self]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.retracted).toBe(true);
+    expect(out[0]!.from_me).toBe(true);
+    expect(out[0]!.text).toBe("");
+  });
+
   test("a genuine inbound with no empty twin stays theirs", () => {
     const out = dedupeSelfEcho([msg({ ts: "2026-08-30 21:08:22", from_me: false, text: "theirs" })]);
     expect(out[0]!.from_me).toBe(false);


### PR DESCRIPTION
## What

Unsent messages render as the tombstone Blip already has ("They unsent a message") instead of an empty bubble tagged "Edited". Nothing is hidden: the row stays in the thread, shown the way Messages shows it.

## Why

On macOS 26 an Undo Send no longer sets `date_retracted`. Apple records it as an edit: `date_edited` is stamped, `text` and `attributedBody` are cleared, and the withdrawn parts are listed as `rp` in `message_summary_info`. The bridge read only the two date columns, so it saw "edited, empty body" and passed a bubble through; the tombstone path in `BlipView.qml` never got its flag.

![An unsent message in a conversation: a dim italic "Jamie Rivera unsent a message" line where the bubble was, with the run's timestamp under it](https://raw.githubusercontent.com/Fileri/blip/pr-assets/unsent/app.png)

*Rendered by `scripts/demo/blip-shots` against the fake bridge — invented people, real code paths.*

On one macOS 26 database: `date_retracted` is zero on all ~33,600 rows; 14 rows carry `rp` (all since 2026-01) and no body; 8 rows carry `ec` (a real edit's history) and keep their body. Nothing carries either. Found as "a group with a few empty messages".

## How

- **`bridge/mac/imsg`** — `base_select` reads `m.message_summary_info` beside the two dates (`NULL AS …` on Macs too old to have it, the pattern the dates use). `_unsent(blob)` is true when the plist lists withdrawn parts in `rp`, false for anything missing or unreadable. `_edit_flags(date_edited, date_retracted, summary)` decides: retracted when either the old column or `rp` says so, else edited when `date_edited` says so — an unsend is not an edit, whatever `date_edited` says. The old `date_retracted` path is kept for older Macs. `enrich()` calls it; nothing else changes.
- **`collector.ts`** — the self-thread. Every message there lands twice, and `dedupeSelfEcho` folds the empty outbound row into its text-bearing echo as transport noise. An unsend produces exactly that shape with the opposite meaning: Apple withdraws only the sent copy, the echo keeps its text, and the empty row *is* the message. The retracted outbound row now wins and the echo is dropped, so the tombstone shows there too.
- **`bridge/mac/test_unsent.py`** (new) + one CI step, same shape as `test_group_photo.py`; `thread.test.ts` gains the self-thread case.
- **`scripts/demo/fake-imsg`** — passes `edited` / `retracted` through from a fixture row instead of hardcoding false, so the harness can render the tombstone. The shipped demo data is unchanged; the screenshot above used one extra fixture row locally.
- CHANGELOG (Unreleased); CLAUDE.md gets the invariant so the two columns are not conflated again.

## How it was verified

- [x] `bun test` is green (CI will check) — 324 pass; `test_unsent.py` 7 pass; `test_group_photo.py` pass; every Mac tool compiles
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → no layout change; the existing tombstone renders where an empty bubble did — screenshot above (harness, invented people)
- [x] Touches an invariant in `CLAUDE.md` → **new: an unsend is not an edit, and on macOS 26 it never sets `date_retracted`**

Against the live database, old bridge vs new, `--json --rich thread --chat` on the thread that showed the problem: comparing every field of every row, the only differences are the flags on the three rows in question, `edited` → `retracted`. Over every row with an edit date, a retraction date or a summary blob, the new decision yields 14 retracted and 8 edited, matching the column-level analysis exactly. After install, the thread shows 3 tombstones and 0 empty non-retracted bubbles. A real Undo Send performed on a self-thread during review reproduced the echo problem (the withdrawn text kept showing) and is now rendered as the tombstone.

The 7 tests use `plistlib`-built blobs in the shapes Apple writes (`rp` / `ec` / `otr` / `amc` / `ust`): `rp` means unsent; a real edit does not; missing, empty, non-plist, empty-`rp` and non-dict blobs do not; the macOS 26 unsend is retracted and not edited; the older unsend via `date_retracted` still works; a real edit is edited; an untouched message has no flags.

Note: this branch and #31 both add a line to `ci.yml` and to the top of the CHANGELOG; whichever lands second gets a one-line rebase from me.
