### PR TITLE
Drop rows with neither a chat nor a handle: leftovers of deleted conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **No more nameless conversation at the top of the list.** Deleting a
+  conversation removes its chat row, but Messages in iCloud keeps the message
+  rows, and some arrive with no handle either. Grouped by their empty identity
+  they became one thread with no name and no number that could not be opened.
+  Rows with neither a chat nor a handle are now dropped where messages enter
+  the collector; rows with a handle are untouched, since some SMS senders only
+  ever exist that way.
 - **Group photos show up as photos again.** Messages stores a group's picture
   on an announcement row (`item_type = 3`). The bridge hides those rows so
   they never become empty unread bubbles, and the photo lookup joined through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,11 @@ what it is handed. Keep it that way.
   true, which would have silently hidden the GA Power SMS from 99123 that took
   a day to make arrive at all. A default that hides messages is not a
   preference.
-- **`chat:null` exists.** Use `chatKey()`; never `String(m.chat)`.
+- **`chat:null` exists.** Use `chatKey()`; never `String(m.chat)`. A row with
+  neither chat nor handle is a leftover of a deleted conversation (iCloud keeps
+  the row, the chat and the join are gone); `fetchMessages` drops it
+  (`hasIdentity`), or it becomes a nameless, unopenable thread. Rows with a
+  handle stay — some SMS senders only ever exist that way.
 - **Group ids come in two shapes**: 32 hex, or `chat<digits>`. `isGroupChat()` is
   "not a phone/email" — never a positive regex on one shape.
 - **Deleted messages stay in chat.db for 30 days** (`chat_recoverable_message_join`).

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -502,6 +502,18 @@ describe("fetchMessages", () => {
     expect(r.msgs).toHaveLength(1);
   });
 
+  test("drops rows with neither chat nor handle, keeps handle-only rows", () => {
+    // Leftovers of deleted conversations arrive with no chat and no handle;
+    // one-off SMS senders arrive with no chat but a handle, and must stay.
+    const r = fetchMessages(10, fake({ status: 0, stdout: JSON.stringify([
+      msg(),
+      msg({ chat: null as unknown as string, handle: "31614" }),
+      msg({ chat: null as unknown as string, handle: null as unknown as string }),
+    ]) }));
+    expect(r.ok).toBe(true);
+    expect(r.msgs.map((m) => m.handle)).toEqual(["+15551234567", "31614"]);
+  });
+
   test("exit 69 reports the Mac offline, not a crash", () => {
     // 69 = EX_UNAVAILABLE, the documented code from the imsg shim's reachability guard.
     const r = fetchMessages(10, fake({ status: 69 }));

--- a/collector.ts
+++ b/collector.ts
@@ -400,6 +400,18 @@ export function chatKey(m: ImsgMessage | undefined): string {
 }
 
 /**
+ * A row with neither a chat nor a handle is a leftover of a conversation that
+ * no longer exists: deleting a conversation removes the chat row and the join,
+ * and Messages in iCloud keeps the message rows in sync regardless. Messages
+ * shows such rows nowhere; grouped by their empty identity they became one
+ * nameless, unopenable thread here. Rows WITH a handle stay — some SMS
+ * senders only ever exist that way (see chatKey).
+ */
+export function hasIdentity(m: ImsgMessage): boolean {
+  return chatKey(m) !== "";
+}
+
+/**
  * Group a flat message window into threads, newest-first.
  *
  * `unread` counts inbound messages strictly newer than the thread's read mark:
@@ -851,7 +863,7 @@ export function fetchMessages(limit: number, runner = spawnSync): FetchResult {
   try {
     const parsed = JSON.parse(res.stdout as string);
     if (!Array.isArray(parsed)) throw new Error("not an array");
-    return { ok: true, online: true, error: "", msgs: parsed as ImsgMessage[] };
+    return { ok: true, online: true, error: "", msgs: (parsed as ImsgMessage[]).filter(hasIdentity) };
   } catch (e) {
     return { ok: false, online: true, error: `bad JSON from imsg: ${e}`, msgs: [] };
   }


### PR DESCRIPTION
## What

A message row with neither a chat nor a handle no longer becomes a thread. Such rows are leftovers of deleted conversations; Messages shows them nowhere. Rows that have a handle are untouched.

## Why

Deleting a conversation removes its chat row and the `chat_message_join` rows, but Messages in iCloud keeps the message rows in sync regardless, and some carry no handle either (sent messages, older group announcements). Blip grouped them by their empty identity into **one thread with no name and no number**, dated by its newest member, that could not be opened. On one database: 21 such rows spanning 2018 to 2026, surfacing as a single nameless thread near the top of the list.

The obvious "require a chat join" filter would be wrong, and the data shows why: some SMS senders — banks, services, short codes — get a chat row that their messages are never joined to, and Blip shows them only because `chatKey()` falls back to the handle. Nine senders on the same database exist solely that way. So the rule is the narrowest one: no chat **and** no handle means no identity, and no identity means no thread.

## How

- **`collector.ts`** — `hasIdentity(m)` (`chatKey(m) !== ""`), applied in `fetchMessages()` where every message enters, so threads, toasts and the unread ledger never see such a row.
- **`collector.test.ts`** — a normal row, a handle-only row and an identity-less row in; the first two come out.
- CLAUDE.md's `chat:null` invariant gains the rule; CHANGELOG under Unreleased.

## How it was verified

- [x] `bun test` is green (CI will check) — 324 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [ ] UI change → none; one row disappears from the list
- [x] Touches an invariant in `CLAUDE.md` → **`chat:null` exists** — extended, not changed

Against the live bridge, running collector vs patched, `--deep`: threads 306 → 305, the nameless thread is the one that goes; short-code threads 3 → 3; alphanumeric-sender threads 160 → 160.

Note: like #31 and #32, this adds a line at the top of the CHANGELOG (and an invariant line in CLAUDE.md); whichever lands later gets a one-line rebase from me.
