### PR TITLE
iMessage-app cards read as text instead of a replacement character

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: python3 -m py_compile bridge/mac/imsg bridge/mac/imsg-send bridge/mac/contacts bridge/mac/tcc-check bridge/mac/blip-check bridge/mac/blip-dispatch
       - name: group-photo lookup (no macOS needed)
         run: python3 bridge/mac/test_group_photo.py
+      - name: iMessage app cards read as text (no macOS needed)
+        run: python3 bridge/mac/test_app_cards.py
       - name: shell scripts (bash -n + shellcheck)
         run: |
           bash -n bridge/linux/blip-shim scripts/blip-setup scripts/sync-bridge.sh bridge/mac/install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **iMessage-app cards read as text instead of a replacement character.**
+  Ask to Buy requests, Fitness sharing, Find My and other app cards store
+  U+FFFD as their message text and the real content in an MSMessage payload.
+  Blip showed the � — or an empty bubble — in the conversation, the list
+  preview and the toast; on one family database that was 254 messages. The
+  bridge now returns the payload's `ldtext`, the sentence Messages itself
+  shows when the app cannot render the card, falling back to the card's
+  caption and then the app's name. Link cards are unchanged. Mac side:
+  re-run the install one-liner so `~/.blip/bin/imsg` picks it up.
 - **Group photos show up as photos again.** Messages stores a group's picture
   on an announcement row (`item_type = 3`). The bridge hides those rows so
   they never become empty unread bubbles, and the photo lookup joined through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,12 @@ what it is handed. Keep it that way.
   true, which would have silently hidden the GA Power SMS from 99123 that took
   a day to make arrive at all. A default that hides messages is not a
   preference.
+- **An iMessage-app card is text, in the payload, not in the text column.**
+  Ask to Buy, Fitness sharing, Find My and friends store U+FFFD as the message
+  text and an MSMessage archive in `payload_data`; `ldtext` there is the
+  sentence Messages itself shows when it cannot render the app, then the
+  caption, then the app name (`_app_card_text`). Link cards are the one
+  balloon that is not an app; they stay links.
 - **`chat:null` exists.** Use `chatKey()`; never `String(m.chat)`.
 - **Group ids come in two shapes**: 32 hex, or `chat<digits>`. `isGroupChat()` is
   "not a phone/email" — never a positive regex on one shape.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Linux side. If the Mac is asleep, the widget dims and says so.
 - **"Read 4:42 PM"** under the last message of yours they've read (display only — Blip never sends receipts)
 - **inline replies** quoted above the bubble · **Edited** tags · "unsent a message" tombstones
 - **link cards** — URL messages show the preview image, title, and host, like Messages. Apple only decorates some links; for the rest Blip fetches the page's own Open Graph card itself, so a bare URL still gets its picture. Click opens the link, **right-click opens the share sheet** (open · copy · QR for your phone · send to a device via LocalSend, Omarchy's share). `link_previews=off` in `bridge.conf` disables the fetching
+- **iMessage-app cards read as text** — Ask to Buy, Fitness sharing, Find My: the sentence Messages shows for them, instead of a replacement character
 - **photos render inline** — images ≤5MB auto-fetch over SSH (HEIC converted on the Mac); click opens full-size. PDFs/videos are chips — click fetches and opens them
 - **send files** — Ctrl+V an image into the compose box, type `/attach <path>`, or drag-and-drop; a caption rides along
 - select text and Ctrl+C · right-click a bubble to copy it whole · right-click a **link** in a bubble for the share sheet

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import html
 import json
 import os
 import plistlib
@@ -316,7 +317,59 @@ def fmt_ts(apple_ns: int | None) -> str:
 
 
 def message_text(row: sqlite3.Row) -> str:
-    return row["text"] or decode_attributed_body(row["attributedBody"]) or ""
+    return _app_card_text(row) or row["text"] or decode_attributed_body(row["attributedBody"]) or ""
+
+
+def _unarchive(blob) -> dict | None:
+    """The NSKeyedArchiver plist in a blob, or None if it is not one."""
+    try:
+        p = plistlib.loads(bytes(blob))
+        return p if isinstance(p.get("$objects"), list) and "root" in p["$top"] else None
+    except Exception:
+        return None
+
+
+def _deref(objs: list, v, depth: int = 0):
+    """Follow archive references: UIDs into the object table, NSURL to its
+    string, NSDictionary to a plain dict. Anything deeper than six hops is
+    a cycle or an object we do not model — None."""
+    if depth > 6:
+        return None
+    if isinstance(v, plistlib.UID):
+        if v.data == 0:   # $null
+            return None
+        return _deref(objs, objs[v.data], depth + 1) if v.data < len(objs) else None
+    if isinstance(v, dict) and "NS.relative" in v:   # NSURL
+        return _deref(objs, v["NS.relative"], depth + 1)
+    if isinstance(v, dict) and "NS.keys" in v and "NS.objects" in v:   # NSDictionary
+        pairs = ((_deref(objs, k, depth + 1), _deref(objs, o, depth + 1))
+                 for k, o in zip(v["NS.keys"], v["NS.objects"]))
+        return {k: o for k, o in pairs if isinstance(k, str)}
+    return v
+
+
+def _app_card_text(row) -> str | None:
+    """Messages' own words for an iMessage-app card — Ask to Buy, Fitness
+    sharing, Find My, … The text column holds U+FFFD for these; the payload is
+    an MSMessage archive whose `ldtext` is the sentence Messages shows when the
+    app cannot render the card, then the card's caption, then the app's name.
+    Link cards are not apps and keep their URL. Anything unreadable → None.
+    Apple escapes some of these sentences as HTML ("Photo &amp; Video") and
+    leaves others raw; html.unescape makes them one thing."""
+    if "payload_data" not in row.keys():   # a snippet row, not a base_select row
+        return None
+    bundle = row["balloon_bundle_id"] or ""
+    if not bundle or bundle.endswith("URLBalloonProvider") or not row["payload_data"]:
+        return None
+    p = _unarchive(row["payload_data"])
+    root = _deref(p["$objects"], p["$top"]["root"]) if p else None
+    if not isinstance(root, dict):
+        return None
+    info = root.get("userInfo") if isinstance(root.get("userInfo"), dict) else {}
+    for text in (root.get("ldtext"), info.get("caption"), root.get("an")):
+        if isinstance(text, str) and text.strip():
+            return html.unescape(text.strip())[:500]
+    return None
 
 
 def pinned_chat_identifiers() -> list[set[str]]:
@@ -465,23 +518,13 @@ def _parse_rich_link(blob: bytes) -> dict | None:
     LPLinkMetadata) into {url, title, summary, image_index}. image_index
     indexes the message's .pluginPayloadAttachment rows (ROWID order), which
     hold the preview PNGs. Best-effort: any oddity → None."""
-    import plistlib
-    try:
-        p = plistlib.loads(blob)
-        objs = p["$objects"]
-    except Exception:
+    p = _unarchive(blob)
+    if not p:
         return None
+    objs = p["$objects"]
 
-    def deref(v, depth=0):
-        if depth > 6:
-            return None
-        if isinstance(v, plistlib.UID):
-            if v.data == 0:   # $null
-                return None
-            return deref(objs[v.data], depth + 1) if v.data < len(objs) else None
-        if isinstance(v, dict) and "NS.relative" in v:   # NSURL
-            return deref(v["NS.relative"], depth + 1)
-        return v
+    def deref(v):
+        return _deref(objs, v)
 
     md = None
     for o in objs:

--- a/bridge/mac/test_app_cards.py
+++ b/bridge/mac/test_app_cards.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""iMessage-app cards (Ask to Buy, Fitness sharing, Find My, …) store U+FFFD
+as their text and an MSMessage archive as payload. message_text() returns the
+archive's `ldtext` — the sentence Messages shows when the app cannot render —
+then the caption, then the app name. Link cards and everything else are
+untouched."""
+from __future__ import annotations
+
+import plistlib
+import sqlite3
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+IMSG = Path(__file__).with_name("imsg")
+APP = "com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.PeopleMessageService.AskToBuy"
+LINK = "com.apple.messages.URLBalloonProvider"
+
+
+def load_imsg():
+    loader = SourceFileLoader("blip_imsg", str(IMSG))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    mod = module_from_spec(spec)
+    sys.modules[loader.name] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+def archive(root: dict) -> bytes:
+    """A minimal NSKeyedArchiver plist: strings inline, dicts as NSDictionary,
+    exactly the shape Messages writes for an MSMessage payload."""
+    objs: list = ["$null"]
+
+    def put(v):
+        if isinstance(v, dict):
+            node = {"NS.keys": [], "NS.objects": []}
+            objs.append(node)
+            uid = plistlib.UID(len(objs) - 1)
+            for k, o in v.items():
+                node["NS.keys"].append(put(k))
+                node["NS.objects"].append(put(o))
+            return uid
+        objs.append(v)
+        return plistlib.UID(len(objs) - 1)
+
+    top = put(root)
+    return plistlib.dumps({"$version": 100000, "$archiver": "NSKeyedArchiver", "$top": {"root": top}, "$objects": objs},
+                          fmt=plistlib.FMT_BINARY)
+
+
+def row(text: str | None, balloon: str | None, payload: bytes | None) -> sqlite3.Row:
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.execute("CREATE TABLE m (text TEXT, attributedBody BLOB, balloon_bundle_id TEXT, payload_data BLOB)")
+    con.execute("INSERT INTO m VALUES (?, NULL, ?, ?)", (text, balloon, payload))
+    return con.execute("SELECT * FROM m").fetchone()
+
+
+class AppCards(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = load_imsg().message_text
+
+    def test_ldtext_is_the_message(self) -> None:
+        payload = archive({"an": "Ask to Buy", "ldtext": "Sam would like to buy Trail Maps", "userInfo": {"caption": "ignored"}})
+        self.assertEqual(self.text(row("�", APP, payload)), "Sam would like to buy Trail Maps")
+
+    def test_html_entities_are_decoded_and_a_raw_ampersand_survives(self) -> None:
+        # Apple escapes some sentences ("Photo &amp; Video Editor") and leaves others raw.
+        self.assertEqual(self.text(row("�", APP, archive({"ldtext": "asked for Photo &amp; Video Editor"}))), "asked for Photo & Video Editor")
+        self.assertEqual(self.text(row("�", APP, archive({"ldtext": "Trail & Ridge"}))), "Trail & Ridge")
+
+    def test_caption_when_there_is_no_ldtext(self) -> None:
+        payload = archive({"an": "Ask to Buy", "userInfo": {"caption": "Sam would like to buy Trail Maps", "subcaption": ""}})
+        self.assertEqual(self.text(row("�", APP, payload)), "Sam would like to buy Trail Maps")
+
+    def test_app_name_when_the_card_has_no_words(self) -> None:
+        payload = archive({"an": "Ask to Buy", "userInfo": {"caption": ""}})
+        self.assertEqual(self.text(row(None, APP, payload)), "Ask to Buy")
+
+    def test_a_link_card_keeps_its_url(self) -> None:
+        payload = archive({"an": "not an app", "ldtext": "never shown"})
+        self.assertEqual(self.text(row("https://oatlug.org", LINK, payload)), "https://oatlug.org")
+
+    def test_no_payload_or_garbage_leaves_the_text_alone(self) -> None:
+        self.assertEqual(self.text(row("�", APP, None)), "�")
+        self.assertEqual(self.text(row("�", APP, b"not a plist")), "�")
+        self.assertEqual(self.text(row("�", APP, plistlib.dumps(["not", "an", "archive"]))), "�")
+
+    def test_an_ordinary_message_is_untouched(self) -> None:
+        self.assertEqual(self.text(row("hello", None, None)), "hello")
+
+    def test_rows_without_the_columns_still_work(self) -> None:
+        con = sqlite3.connect(":memory:")
+        con.row_factory = sqlite3.Row
+        con.execute("CREATE TABLE m (text TEXT, attributedBody BLOB)")
+        con.execute("INSERT INTO m VALUES ('snippet', NULL)")
+        self.assertEqual(self.text(con.execute("SELECT * FROM m").fetchone()), "snippet")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

iMessage-app cards — Ask to Buy requests, Fitness sharing, Find My and friends — read as the sentence Messages itself shows for them, instead of a replacement character or an empty bubble. Everywhere: the conversation, the list preview, the toast, search. Link cards are unchanged.

## Why

These cards store `U+FFFD` as their message text and the real content in an MSMessage archive in `payload_data`. The bridge returned the text column, so every consumer showed `�`. On one family database that was 254 messages, 213 of them children asking to buy something, and the thread they live in read as a column of question marks.

Apple stores a plain-text fallback for exactly this case: `ldtext`, the sentence Messages shows when the receiving device cannot render the app. It is present on every Activity and Find My card and on 187 of 213 Ask to Buy cards; the rest carry the app's name.

## How

- **`bridge/mac/imsg`** — `message_text()` tries `_app_card_text()` first: for a balloon that is not the URL provider and has a payload, unarchive it and return `ldtext`, else the card's `caption`, else the app name `an`, HTML-unescaped (Apple escapes some sentences, "Photo &amp; Video", and leaves others raw) and capped at 500 characters. Anything unreadable → the row is left as it was.
- The link-card decoder's reference following becomes `_unarchive` / `_deref`, shared; `_deref` now also resolves an archived `NSDictionary`, which an MSMessage payload is at its root. Link cards decode as before.
- **`bridge/mac/test_app_cards.py`** (new) + one CI step, same shape as `test_group_photo.py`.
- CHANGELOG (Unreleased), README (Conversation features), CLAUDE.md (invariant).

No client change: bubbles, previews, toasts and search already take the bridge's text.

## How it was verified

- [x] `bun test` is green (CI will check) — 323 pass; `test_app_cards.py` 8 pass; `test_group_photo.py` pass; every Mac tool compiles
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [ ] UI change → none; the same bubbles carry real text
- [x] Touches an invariant in `CLAUDE.md` → **new: an iMessage-app card is text, in the payload, not in the text column**

Against a live `chat.db`, old tool vs new, `recent 600`: 577 ordinary messages unchanged, 17 link cards unchanged, the 6 app cards in the window went from the placeholder to sentences of 77–84 characters; none is a placeholder or empty afterwards. `--rich recent 300`: the `link` field is byte-identical on all rows, so the shared helper changed nothing for link cards. The thread that started this went from 6 placeholders to 0.

The 8 tests build MSMessage-shaped archives with `plistlib`: `ldtext` wins; `caption` when there is no `ldtext`; the app name when the card has no words; HTML entities decoded and a raw `&` preserved; a link card keeps its URL; no payload, garbage, a non-archive plist and a row without the two columns all leave the text alone.

Note: like #31–#33, this adds a line at the top of the CHANGELOG (and one CI step); whichever lands later gets a one-line rebase from me.
