### PR TITLE
Security codes: toast a 2FA code as it lands, click to copy, hotkey to type it

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -3,6 +3,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
+import Quickshell.Hyprland
 
 // blip — iMessage in the bar.
 //
@@ -641,8 +642,15 @@ BarWidget {
   // five minutes (never state.json — it is message text), toasts it, and on
   // request copies it (click the toast, or `copycode`) or types it into
   // whatever has keyboard focus (`typecode`, bound to a hotkey). The code
-  // reaches wl-copy and wtype through an environment variable and stdin —
-  // never argv, where any process could read it from /proc.
+  // reaches wl-copy through an environment variable and stdin, and the
+  // focused window as key events over Hyprland's socket — never argv, where
+  // any process could read it from /proc.
+  //
+  // NOT wtype. A virtual keyboard's key presses are merged with the physical
+  // keyboard's modifier state, so the digits typed while the user's fingers
+  // are still on Super+Shift became Super+Shift+<digit> — workspace binds.
+  // `send_key_state` (what Omarchy's universal paste uses) hands the key
+  // straight to the focused window without consulting binds.
   property var pendingCode: null         // {code, name, domain, ts} or null
   Timer {
     id: codeExpiry
@@ -664,20 +672,46 @@ BarWidget {
     environment: ({ BLIP_CODE: root.pendingCode ? root.pendingCode.code : "" })
     command: ["sh", "-c", "printf %s \"$BLIP_CODE\" | wl-copy"]
   }
-  Process {
-    id: codeTypeProc
-    environment: ({ BLIP_CODE: root.pendingCode ? root.pendingCode.code : "" })
-    // the pause lets the hotkey's modifiers come up before the digits go down
-    command: ["sh", "-c", "sleep 0.3; printf %s \"$BLIP_CODE\" | wtype -"]
-  }
   function copyCode() {
     if (!pendingCode) return "no code pending"
     codeCopyProc.running = true
     return "copied"
   }
+  // One key event per tick: down, then up, 20 ms apart (Omarchy's paste
+  // helper uses 50 between the two). A single dispatch per event keeps the
+  // socket write small and the order guaranteed.
+  property var keyQueue: []
+  Timer {
+    id: keyPump
+    interval: 20
+    repeat: true
+    onTriggered: {
+      if (root.keyQueue.length === 0) { stop(); return }
+      var q = root.keyQueue.slice()
+      var k = q.shift()
+      root.keyQueue = q
+      Hyprland.dispatch('hl.dsp.send_key_state({ mods = "' + k.mods + '", key = "' + k.key + '", state = "' + k.state + '" })')
+    }
+  }
+  /** xkb key name + modifiers for one character of a code, or null. */
+  function keyFor(ch) {
+    if (/^[0-9a-z]$/.test(ch)) return { key: ch, mods: "" }
+    if (/^[A-Z]$/.test(ch)) return { key: ch.toLowerCase(), mods: "SHIFT" }
+    if (ch === "-") return { key: "minus", mods: "" }
+    return null
+  }
   function typeCode() {
     if (!pendingCode) return "no code pending"
-    codeTypeProc.running = true
+    var q = []
+    var code = String(pendingCode.code)
+    for (var i = 0; i < code.length; i++) {
+      var k = keyFor(code.charAt(i))
+      if (!k) continue
+      q.push({ key: k.key, mods: k.mods, state: "down" })
+      q.push({ key: k.key, mods: k.mods, state: "up" })
+    }
+    keyQueue = q
+    keyPump.start()
     return "typed"
   }
 

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -594,11 +594,10 @@ BarWidget {
     var reopen = []
     var chatArg = notifyProc.toastChat.replace(/^\+/, "")
     if (notifyProc.toastCode !== "")
-      // a code toast restored from the notification center copies the code
-      // still pending (or nothing, once it has expired) — never the toast's
-      // own text, which is why the hint carries no code
-      reopen = ["--hint=string:omarchy-exec-argv:" + JSON.stringify(
-        ["qs", "-p", "/usr/share/omarchy/shell", "ipc", "call", root.moduleName, "copycode"])]
+      // popup only: the daemon must not write the code into its on-disk
+      // history (~/.local/state/omarchy/notifications/history). It expires
+      // from memory in five minutes; there is nothing to restore.
+      reopen = ["--hint=boolean:transient:true"]
     else if (chatArg !== "" && /^[A-Za-z0-9._@:;$-]{1,256}$/.test(chatArg))
       reopen = ["--hint=string:omarchy-exec-argv:" + JSON.stringify(
         ["qs", "-p", "/usr/share/omarchy/shell", "ipc", "call",

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -420,6 +420,8 @@ BarWidget {
             // alert must not throw a panel over full-screen work. When Blip is
             // closed the desktop toast is still the notification.
             if (Array.isArray(d.links) && d.links.length > 0) root.shareArrivingLink(d.links[d.links.length - 1])
+            // A security code that just arrived: hold the newest, toast it.
+            if (Array.isArray(d.codes) && d.codes.length > 0) root.noteCode(d.codes[d.codes.length - 1])
             // A send of YOURS that died — not allowlist-gated, interrupts once.
             if (Array.isArray(d.failures) && d.failures.length > 0)
               root.fireToasts(d.failures.map(function(f) {
@@ -549,11 +551,13 @@ BarWidget {
     stdout: StdioCollector {
       onStreamFinished: {
         var action = text.trim()
+        if (action === "default" && notifyProc.toastCode !== "") { root.copyCode(); return }
         if ((action === "default" || action === "reply") && notifyProc.toastChat !== "")
           root.show(notifyProc.toastChat)
       }
     }
     property string toastChat: ""
+    property string toastCode: ""    // set for a code toast: click = copy, not open
   }
   property var toastQueue: []
 
@@ -575,6 +579,7 @@ BarWidget {
     var body = String(t.text || "")
     if (body.length > 220) body = body.substring(0, 217) + "…"
     notifyProc.toastChat = String(t.chat || "")
+    notifyProc.toastCode = String(t.code || "")
     // Where this toast came from, in a form that outlives it.
     //
     // --action=default lives inside this notify-send process and dies with it
@@ -588,7 +593,13 @@ BarWidget {
     // read it as a flag (show() matches the bare digits as an alias).
     var reopen = []
     var chatArg = notifyProc.toastChat.replace(/^\+/, "")
-    if (chatArg !== "" && /^[A-Za-z0-9._@:;$-]{1,256}$/.test(chatArg))
+    if (notifyProc.toastCode !== "")
+      // a code toast restored from the notification center copies the code
+      // still pending (or nothing, once it has expired) — never the toast's
+      // own text, which is why the hint carries no code
+      reopen = ["--hint=string:omarchy-exec-argv:" + JSON.stringify(
+        ["qs", "-p", "/usr/share/omarchy/shell", "ipc", "call", root.moduleName, "copycode"])]
+    else if (chatArg !== "" && /^[A-Za-z0-9._@:;$-]{1,256}$/.test(chatArg))
       reopen = ["--hint=string:omarchy-exec-argv:" + JSON.stringify(
         ["qs", "-p", "/usr/share/omarchy/shell", "ipc", "call",
          root.moduleName, "goto", chatArg])]
@@ -603,7 +614,7 @@ BarWidget {
       // renders no action BUTTONS and only ever invokes default — an
       // advertised Reply button would be a lie (Codex, read the daemon).
       "--wait",
-      "--action=default=Open",
+      notifyProc.toastCode !== "" ? "--action=default=Copy" : "--action=default=Open",
     ].concat(reopen).concat([
       "--",                                   // a name or text starting with "-" is data, not a flag
       String(t.name || t.chat || "iMessage"),
@@ -623,6 +634,52 @@ BarWidget {
   Connections {
     target: notifyProc
     function onExited(code, status) { toastWatchdog.stop(); Qt.callLater(root.drainToasts) }
+  }
+
+  // ------------------------------------------------------ security codes
+  // macOS reads a 2FA code out of an SMS and offers it to the browser. Blip's
+  // version: the collector spots the code, the widget holds it IN MEMORY for
+  // five minutes (never state.json — it is message text), toasts it, and on
+  // request copies it (click the toast, or `copycode`) or types it into
+  // whatever has keyboard focus (`typecode`, bound to a hotkey). The code
+  // reaches wl-copy and wtype through an environment variable and stdin —
+  // never argv, where any process could read it from /proc.
+  property var pendingCode: null         // {code, name, domain, ts} or null
+  Timer {
+    id: codeExpiry
+    interval: 300000
+    onTriggered: root.pendingCode = null
+  }
+  function noteCode(c) {
+    if (!c || !c.code) return
+    pendingCode = { code: String(c.code), name: String(c.name || c.chat || ""), domain: String(c.domain || ""), ts: String(c.ts || "") }
+    codeExpiry.restart()
+    var who = pendingCode.name !== "" ? pendingCode.name : "a message"
+    var body = pendingCode.code + (pendingCode.domain !== "" ? " for " + pendingCode.domain : "")
+             + "\nClick to copy · Super+Shift+V types it"
+    fireToasts([{ chat: "", name: "Code from " + who, text: body, ts: pendingCode.ts, key: "", code: pendingCode.code }])
+  }
+  // sh reads the code from its environment, hands it to the tool on stdin.
+  Process {
+    id: codeCopyProc
+    environment: ({ BLIP_CODE: root.pendingCode ? root.pendingCode.code : "" })
+    command: ["sh", "-c", "printf %s \"$BLIP_CODE\" | wl-copy"]
+  }
+  Process {
+    id: codeTypeProc
+    environment: ({ BLIP_CODE: root.pendingCode ? root.pendingCode.code : "" })
+    // the pause lets the hotkey's modifiers come up before the digits go down
+    command: ["sh", "-c", "sleep 0.3; printf %s \"$BLIP_CODE\" | wtype -"]
+  }
+  function copyCode() {
+    if (!pendingCode) return "no code pending"
+    codeCopyProc.running = true
+    return "copied"
+  }
+  function typeCode() {
+    if (!pendingCode) return "no code pending"
+    codeTypeProc.running = true
+    return "typed"
   }
 
   // ------------------------------------------------------------ IPC
@@ -670,6 +727,8 @@ BarWidget {
     function close(): void { root.close() }
     function toggle(): void { root.toggle() }
     function goto(chat: string): string { if (!root.automationOn) return root.automationOff; root.show(chat); return "shown" }
+    function copycode(): string { if (!root.automationOn) return root.automationOff; return root.copyCode() }
+    function typecode(): string { if (!root.automationOn) return root.automationOff; return root.typeCode() }
     function share(url: string): string { if (!root.automationOn) return root.automationOff; root.open(); return panelLoader.item ? panelLoader.item.shareLink(url) : "no panel" }
     function compose(text: string): string { if (!root.automationOn) return root.automationOff; return panelLoader.item ? panelLoader.item.composeAndSend(text) : "no panel" }
     function bubbles(): string { if (!root.automationOn) return root.automationOff; return panelLoader.item ? panelLoader.item.bubbleModel() : "[]" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Security codes, the macOS way.** A text that carries a one-time code —
+  "Your verification code is 483920", Google's "G-482913", the origin-bound
+  `@example.com #493857` line — now toasts the code as it lands. Click the
+  toast to copy it, or press a key (`typecode` over IPC; Super+Shift+V in the
+  README's binding) and Blip types it into whatever has keyboard focus, the
+  way macOS offers a code from Messages to Safari's login form. The detector
+  wants a trigger word (code, passcode, PIN, OTP, verify, confirm, sign in…)
+  and picks the 4–8 digit token nearest it; money, percentages, phone numbers
+  and URLs never qualify, nor does anything from a group or the self-thread.
+  The code is held in the widget's memory for five minutes and nowhere else —
+  not state.json, not argv (wl-copy and wtype read it from stdin). Both verbs
+  sit behind `automation=on`.
 - **Blue bubbles.** Your messages are iMessage blue with white text on every
   theme. They followed the Omarchy accent, which is red on several themes —
   and red bubbles read as failed sends. The unread dot on the bar icon is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@
   and picks the 4–8 digit token nearest it; money, percentages, phone numbers
   and URLs never qualify, nor does anything from a group or the self-thread.
   The code is held in the widget's memory for five minutes and nowhere else —
-  not state.json, not argv (wl-copy and wtype read it from stdin). Both verbs
-  sit behind `automation=on`.
+  not state.json, not argv, not the notification daemon's on-disk history
+  (the toast is transient). Typing goes through Hyprland's `send_key_state`,
+  the same path as Omarchy's universal paste, because a virtual keyboard's
+  digits merge with the modifiers still held from the hotkey and became
+  Super+Shift+<digit>. Both verbs sit behind `automation=on`.
 - **Blue bubbles.** Your messages are iMessage blue with white text on every
   theme. They followed the Omarchy accent, which is red on several themes —
   and red bubbles read as failed sends. The unread dot on the bar icon is the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,13 @@ what it is handed. Keep it that way.
 - **Pass `--` before message text** to `notify-send`.
 - **A security code lives five minutes in BarWidget memory, nowhere else.**
   `selectCodes()` (collector) spots it; `noteCode()` holds the newest and
-  toasts it; `copycode`/`typecode` hand it to wl-copy / wtype via an env var
-  and stdin, never argv. Never a group, never the self-thread, once per
-  message through the `code:` ring.
+  toasts it (transient — Omarchy persists toast bodies to disk otherwise);
+  `copycode` hands it to wl-copy via an env var and stdin, `typecode` sends
+  it to the focused window as `send_key_state` events over Hyprland's socket.
+  Never argv. NEVER wtype for this: Hyprland merges a virtual keyboard's keys
+  with the physical modifiers still held from the hotkey, and the digits
+  fired Super+Shift+<digit> binds (found the hard way, 2026-09-04). Never a
+  group, never the self-thread, once per message through the `code:` ring.
 - **No message content in state.json.** `~/.local/state/blip/state.json` holds
   timestamps, counts, opaque SHA-256 toast keys, self-chat ids, and group
   metadata. It is atomic and `0600`; no message bodies are allowed. EXCEPTION

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ what it is handed. Keep it that way.
 - **Cache file extensions follow the gated MIME**, never the sender's name —
   `xdg-open` dispatches on extension (war room #49).
 - **Pass `--` before message text** to `notify-send`.
+- **A security code lives five minutes in BarWidget memory, nowhere else.**
+  `selectCodes()` (collector) spots it; `noteCode()` holds the newest and
+  toasts it; `copycode`/`typecode` hand it to wl-copy / wtype via an env var
+  and stdin, never argv. Never a group, never the self-thread, once per
+  message through the `code:` ring.
 - **No message content in state.json.** `~/.local/state/blip/state.json` holds
   timestamps, counts, opaque SHA-256 toast keys, self-chat ids, and group
   metadata. It is atomic and `0600`; no message bodies are allowed. EXCEPTION

--- a/README.md
+++ b/README.md
@@ -487,10 +487,25 @@ qs -p /usr/share/omarchy/shell ipc call nixfred.blip status
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip goto 15551234567   # bare digits
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip read               # mark all read
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip share https://example.com   # share sheet for a URL
+qs -p /usr/share/omarchy/shell ipc call nixfred.blip typecode           # type the pending 2FA code into the focused field
+qs -p /usr/share/omarchy/shell ipc call nixfred.blip copycode           # or copy it
+```
+
+**Security codes.** When a text arrives that looks like a one-time code
+("Your verification code is 483920", "G-482913", the origin-bound
+`@example.com #493857` form), Blip toasts it. Click the toast to copy it, or
+bind `typecode` to a key and it is typed into whatever has focus, the way
+macOS offers a code from Messages to Safari. The code lives in the widget's
+memory for five minutes and nowhere else. Needs `automation=on`. A binding
+for `~/.config/hypr/bindings.lua`:
+
+```lua
+o.bind("SUPER + SHIFT + V", "Type security code",
+  "qs -p /usr/share/omarchy/shell ipc call nixfred.blip typecode")
 ```
 
 Everything that sends or reads message content over IPC (`goto`, `compose`,
-`bubbles`, `threads`, `find`, `newchat`, `read`) is **off by default** — any
+`bubbles`, `threads`, `find`, `newchat`, `read`, `typecode`, `copycode`) is **off by default** — any
 local process could otherwise send as you. Turn it on with `automation=on`
 in `~/.config/blip/bridge.conf` (re-read live). `status`, `open`, `close`,
 `toggle`, `window`, `app` are always available.

--- a/README.md
+++ b/README.md
@@ -495,8 +495,11 @@ qs -p /usr/share/omarchy/shell ipc call nixfred.blip copycode           # or cop
 ("Your verification code is 483920", "G-482913", the origin-bound
 `@example.com #493857` form), Blip toasts it. Click the toast to copy it, or
 bind `typecode` to a key and it is typed into whatever has focus, the way
-macOS offers a code from Messages to Safari. The code lives in the widget's
-memory for five minutes and nowhere else. Needs `automation=on`. A binding
+macOS offers a code from Messages to Safari. The digits go to the focused
+window as key events through Hyprland, not a virtual keyboard, so holding
+the hotkey's modifiers cannot turn them into workspace binds. The code lives
+in the widget's memory for five minutes and nowhere else. Needs
+`automation=on`. A binding
 for `~/.config/hypr/bindings.lua`:
 
 ```lua

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -1285,3 +1285,63 @@ describe("pushRead breadcrumb", () => {
     expect(pushReadLogPath("/home/u")).toBe("/home/u/.local/state/blip/push-read.log");
   });
 });
+
+describe("security codes: detect, hold once, never from a group", () => {
+  const { extractCode, selectCodes } = require("./collector") as typeof import("./collector");
+  const WM = "2026-09-02 12:00:00";
+  const code = (text: string) => extractCode(text)?.code ?? null;
+
+  test("the usual shapes", () => {
+    expect(code("Your verification code is 483920")).toBe("483920");
+    expect(code("483920 is your Amazon OTP. Don't share it with anyone.")).toBe("483920");
+    expect(code("Your Venmo code: 837-291")).toBe("837291");
+    expect(code("Use 123 456 to sign in to Acme")).toBe("123456");
+    expect(code("Use code 4821 to log in")).toBe("4821");
+    expect(code("Your Uber code: 8271. Expires in 10 minutes.")).toBe("8271");
+    expect(code("Enter 482913 in the next 5 minutes to confirm your number")).toBe("482913");
+    expect(code("G-482913 is your Google verification code.")).toBe("482913");
+    expect(code("Your Apple Account code is: 128 433. Do not share it.")).toBe("128433");
+    expect(code("613400 is your Link verification code.")).toBe("613400");
+  });
+
+  test("origin-bound codes carry their domain and win outright", () => {
+    expect(extractCode("Your code is 111111\n\n@example.com #493857")).toEqual({ code: "493857", domain: "example.com" });
+    expect(extractCode("@login.acme.co #AB12-CD")).toEqual({ code: "AB12-CD", domain: "login.acme.co" });
+  });
+
+  test("no trigger word, no code", () => {
+    expect(code("Order #12345 shipped, arriving 09/04")).toBeNull();
+    expect(code("Thank you for your Taco Bell order! Track it at https://t.co/48291034")).toBeNull();
+    expect(code("Call me at 555-0100")).toBeNull();
+    expect(code("")).toBeNull();
+    expect(code(null)).toBeNull();
+  });
+
+  test("money, percentages, phone numbers and urls are not codes", () => {
+    expect(code("Your security deposit of $1234.56 was charged")).toBeNull();
+    expect(code("Verification complete, 100% done and 12345.67 credited")).toBeNull();
+    expect(code("To confirm call +1 (555) 010-0199")).toBeNull();
+    expect(code("Confirm at https://a.test/verify/48291034")).toBeNull();
+  });
+
+  test("the token nearest the trigger word wins; longer breaks a tie", () => {
+    expect(code("Your code is 1234. Expires in 10 minutes, ref 987654321")).toBe("1234");
+    expect(code("Reservation 20260904: your PIN is 5521")).toBe("5521");
+  });
+
+  test("selectCodes: inbound, new, DM only, once", () => {
+    const m = msg({ ts: "2026-09-02 12:30:00", from_me: false, chat: "77029", handle: "77029", name: null, text: "Your code is 483920" });
+    const out = selectCodes([
+      m,
+      msg({ ts: "2026-09-02 11:00:00", from_me: false, text: "old code 111111" }),                 // before watermark
+      msg({ ts: "2026-09-02 12:40:00", from_me: true, text: "my code is 222222" }),                 // outbound
+      msg({ ts: "2026-09-02 12:45:00", from_me: false, chat: "e98633ecd4e84723b69d142cd721b2b9", text: "code 333333" }), // group
+      msg({ ts: "2026-09-02 12:50:00", from_me: false, chat: "+15550001111", handle: "+15550001111", name: "Eli", text: "Enter passcode 444444" }),
+    ], WM, []);
+    expect(out.map((c) => [c.code, c.name])).toEqual([["483920", "77029"], ["444444", "Eli"]]);
+    expect(out.every((c) => c.key.startsWith("code:"))).toBe(true);
+    expect(selectCodes([m], WM, [out[0]!.key])).toEqual([]);           // the ring suppresses a repeat
+    expect(selectCodes([m], "", [])).toEqual([]);                        // never the first-run backlog
+    expect(selectCodes([m], WM, [], ["77029"])).toEqual([]);            // never the self-thread
+  });
+});

--- a/collector.ts
+++ b/collector.ts
@@ -169,6 +169,9 @@ export interface BlipOutput {
   failures: Toast[];
   /** Links that just arrived — the surface opens the share sheet on the newest. */
   links: IncomingLink[];
+  /** Security codes that just arrived — the widget holds the newest in memory
+   *  for a few minutes, toasts it, and types or copies it on request. */
+  codes: SecurityCode[];
   /** False means models are fresh but state could not be committed. */
   persisted: boolean;
   /** True when `threads` is the complete list (chat list fetched), not the
@@ -552,9 +555,10 @@ function digest(value: string): string {
 }
 
 function normalizeToastKey(value: string): string {
-  // "fail:" (selectFailures) and "link:" (selectIncomingLinks) are key
-  // namespaces — keep them verbatim or their dedupe rings reset every load.
-  return /^(fail:|link:)?sha256:[0-9a-f]{64}$/.test(value) ? value : digest(value);
+  // "fail:" (selectFailures), "link:" (selectIncomingLinks) and "code:"
+  // (selectCodes) are key namespaces — keep them verbatim or their dedupe
+  // rings reset every load.
+  return /^(fail:|link:|code:)?sha256:[0-9a-f]{64}$/.test(value) ? value : digest(value);
 }
 
 /** Stable opaque key for one message, used to suppress repeat toasts. */
@@ -701,6 +705,89 @@ export function selectIncomingLinks(
     if (seen.has(key)) continue;
     seen.add(key);
     out.push({ chat, url, ts: m.ts, key });
+  }
+  return out.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+}
+
+// ------------------------------------------------------ security codes
+
+export interface SecurityCode {
+  chat: string;
+  name: string;
+  /** Digits only (a "123 456" or "123-456" code is normalised). */
+  code: string;
+  /** Origin-bound form (`@example.com #123456`): the site the code is for. */
+  domain: string;
+  ts: string;
+  key: string;
+}
+
+/** Words a sender puts next to a one-time code. Deliberately broad: the
+ *  token rules below do the narrowing. */
+const CODE_TRIGGER = /(code|passcode|\bpin\b|\botp\b|one[- ]?time|verif|security|authenticat|\b2fa\b|two[- ]factor|token|confirm|\blog ?in\b|sign[- ]?in|access)/gi;
+/** 4–8 digits, or two groups of three. Not part of a longer number, not money
+ *  (a "$" before, a "%" or ".digit" after), not the tail of a phone number. */
+const CODE_TOKEN = /(?<![\d$€£#(+.-])(?<!\d[-.])\b(\d{3}[ -]\d{3}|\d{4,8})\b(?![\d%])(?!\.\d)(?!-\d)/g;
+/** WebOTP / "origin-bound" line: `@example.com #123456` (may follow other text). */
+const CODE_BOUND = /(?:^|\s)@([a-z0-9-]+(?:\.[a-z0-9-]+)+)\s+#([a-z0-9-]{4,12})\b/i;
+/** Google's "G-123456". */
+const CODE_GOOGLE = /\bG-(\d{6,8})\b/;
+
+/**
+ * The one-time code in a message, or null. macOS's rule, roughly: a trigger
+ * word and a digit token near it. Heuristic by design — a false positive is
+ * a toast nobody clicks; a false negative is a code you read yourself.
+ */
+export function extractCode(text: string | null | undefined): { code: string; domain: string } | null {
+  const raw = String(text ?? "");
+  if (raw === "") return null;
+  const bound = CODE_BOUND.exec(raw);
+  if (bound) return { code: bound[2]!, domain: bound[1]!.toLowerCase() };
+  // digits inside a URL are never the code
+  const t = raw.replace(/https?:\/\/\S+/gi, " ");
+  const google = CODE_GOOGLE.exec(t);
+  if (google) return { code: google[1]!, domain: "" };
+  const triggers: number[] = [];
+  for (const m of t.matchAll(CODE_TRIGGER)) triggers.push(m.index ?? 0);
+  if (triggers.length === 0) return null;
+  let best: { code: string; dist: number } | null = null;
+  for (const m of t.matchAll(CODE_TOKEN)) {
+    const at = m.index ?? 0;
+    const code = m[1]!.replace(/[ -]/g, "");
+    const dist = Math.min(...triggers.map((i) => Math.abs(i - at)));
+    // nearest trigger wins; on a tie the longer token (6 beats 4)
+    if (!best || dist < best.dist || (dist === best.dist && code.length > best.code.length)) best = { code, dist };
+  }
+  return best ? { code: best.code, domain: "" } : null;
+}
+
+/**
+ * Codes that JUST arrived. Same gate as links: inbound, strictly newer than
+ * the watermark, never the self-thread, once per message through the
+ * persisted `code:` ring. Never a group — nobody's 2FA arrives in one, and a
+ * friend quoting a code must not be typed into your login form.
+ */
+export function selectCodes(
+  msgs: ImsgMessage[],
+  watermark: string,
+  toasted: string[],
+  selfChats: string[] = [],
+): SecurityCode[] {
+  if (!watermark) return [];
+  const seen = new Set(toasted);
+  const self = new Set(selfChats);
+  const out: SecurityCode[] = [];
+  for (const m of msgs) {
+    if (m.from_me || m.tapback === true) continue;
+    if (m.ts <= watermark) continue;
+    const chat = chatKey(m);
+    if (self.has(chat) || isGroupChat(chat)) continue;
+    const found = extractCode(m.text);
+    if (!found) continue;
+    const key = "code:" + toastKey(m);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ chat, name: m.name ?? m.handle, code: found.code, domain: found.domain, ts: m.ts, key });
   }
   return out.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
 }
@@ -1306,6 +1393,7 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
   const toast = selectToasts(msgs, state.watermark, loadAllowlist(), state.toasted);
   const failures = selectFailures(fetched.msgs, state.toasted, nowTs);
   const links = selectIncomingLinks(msgs, state.watermark, state.toasted, selfChats);
+  const codes = selectCodes(msgs, state.watermark, state.toasted, selfChats);
   const unread = Object.values(exactCounts).reduce((n, count) => n + count, 0);
 
   // Both marks advance only on a good fetch, so an outage cannot silently
@@ -1324,7 +1412,7 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
     chatAliases,
     pins,
     toasted: [...state.toasted, ...toast.map((t) => t.key), ...failures.map((f) => f.key),
-      ...links.map((l) => l.key)],
+      ...links.map((l) => l.key), ...codes.map((c) => c.key)],
   });
 
   // Only after the local state is committed: if the write failed the user
@@ -1345,6 +1433,7 @@ export function collect(deep: boolean, markRead = false, readChat = "", seenTs =
     toast: persisted ? toast : [],
     failures: persisted ? failures : [],
     links: persisted ? links : [],
+    codes: persisted ? codes : [],
     persisted,
     deep: chats !== null,
   };


### PR DESCRIPTION
## What

macOS reads a one-time code out of an SMS and offers it to Safari's login form. This is Blip's version:

- A text that carries a code — "Your verification code is 483920", Google's "G-482913", the origin-bound `@example.com #493857` line — toasts the code as it arrives. **Click the toast to copy it.**
- A new IPC verb, `typecode`, types the pending code into whatever has keyboard focus. Bound to a key (README shows `SUPER + SHIFT + V`), it is the macOS one-click. `copycode` is the clipboard twin. Both sit behind `automation=on`.

## How

**collector.ts** — `extractCode()` wants a trigger word (code, passcode, PIN, OTP, verify, confirm, sign in…) and picks the 4–8 digit token nearest it; money, percentages, phone numbers and URLs never qualify. `selectCodes()` gates like `selectIncomingLinks`: inbound, newer than the watermark, never the self-thread, **never a group**, once per message through a persisted `code:` ring. Output gains `codes`.

**BarWidget.qml** — holds the newest code in memory for five minutes and nowhere else: not state.json, not argv, not the notification daemon's on-disk history (the toast carries the `transient` hint; Omarchy otherwise persists every body to `~/.local/state/omarchy/notifications/history`). The toast's default action copies instead of opening a thread. `copycode` feeds wl-copy through an env var and stdin.

`typecode` sends the code as `send_key_state` down/up events over Quickshell's Hyprland binding — the path Omarchy's universal paste uses — **not wtype**. Hyprland merges a virtual keyboard's keys with the physical keyboard's modifiers, so digits typed while Super+Shift were still held from the hotkey arrived as Super+Shift+<digit> and fired workspace binds. `send_key_state` bypasses bind processing. Letters and "-" (origin-bound codes) map to their xkb names, uppercase with SHIFT. Noted in CLAUDE.md so nobody reaches for wtype again.

## Verified

- 25 new tests (detector shapes, exclusions, nearest-trigger tie-break, selector gates); `bun test` 337 pass.
- Live: a Truist code ("Your one-time code is …") was detected, held, copied via `copycode`, and typed via the hotkey into a browser field. The typing path was also proven with a throwaway Quickshell config aimed at a scratch terminal by window address: `7aB-` arrived intact.
- Plugin log clean after deploy.

## Known limits

- Heuristic by design: "confirmed for 09/04 at 1030" would toast 1030. The cost is a toast nobody clicks.
- Respects Do Not Disturb like every other toast; the hotkey works regardless, since the code is held whether or not the card showed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRNWkDqR4hUHUPs1DJ8mp7
