### PR TITLE
Keyboard cursor: scroll to follow it, stop at the ends, arrows in the window

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -256,6 +256,10 @@ FocusScope {
   // so the move functions never translate indexes between the four models.
   // A destroyed row reads back as null (guarded QObject property).
   property Item cursorRow: null
+  // The cursor is kept while the search field holds focus (Esc and Down
+  // return to it), but a row must not LOOK selected while typing happens
+  // elsewhere — Up from the top and a click in the field both got here.
+  readonly property bool cursorShown: !searchField.activeFocus
   property bool pinToBottom: false   // scroll to the newest bubble once layout settles
   property bool bubbleFocused: false // a bubble's TextEdit has focus (text selection in progress)
   property string threadRunningChat: "" // chat owned by the current threadProc
@@ -1753,7 +1757,7 @@ FocusScope {
                   Layout.preferredWidth: Math.max(1, (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3)
                   implicitHeight: pinnedColumn.implicitHeight + Style.space(4)
                   radius: Style.cornerRadius
-                  color: pinnedHover.hovered || hasCursor
+                  color: pinnedHover.hovered || (hasCursor && root.cursorShown)
                     ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                     : "transparent"
 
@@ -1957,7 +1961,7 @@ FocusScope {
                 Layout.fillWidth: true
                 implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 20 : 12)
                 radius: Style.cornerRadius
-                color: rowHover.hovered || hasCursor
+                color: rowHover.hovered || (hasCursor && root.cursorShown)
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
 

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -730,7 +730,7 @@ FocusScope {
   }
   function moveNewCursor(dy) {
     if (newResults.length === 0 || dy === 0) return
-    newCursor = (newCursor + dy + newResults.length) % newResults.length
+    newCursor = Math.max(0, Math.min(newResults.length - 1, newCursor + dy))
     scrollCursorIntoView()
   }
 
@@ -841,7 +841,7 @@ FocusScope {
   }
   function moveSearchCursor(dy) {
     if (searchResults.length === 0 || dy === 0) return
-    searchCursor = (searchCursor + dy + searchResults.length) % searchResults.length
+    searchCursor = Math.max(0, Math.min(searchResults.length - 1, searchCursor + dy))
     scrollCursorIntoView()
   }
   function acceptSearchField() {
@@ -1333,10 +1333,13 @@ FocusScope {
     }
   }
 
-  // ---- keyboard navigation (the host's PanelKeyCatcher calls these)
+  // ---- keyboard navigation (the host's PanelKeyCatcher calls these).
+  // The cursor stops at the ends rather than wrapping: with 300 threads a
+  // press past the last row landing at the top reads as a jump, not a loop
+  // (Omarchy's Dropdown clamps the same way).
   function moveCursor(dy) {
     if (inThread || threads.length === 0 || dy === 0) return
-    cursor = (cursor + dy + threads.length) % threads.length
+    cursor = Math.max(0, Math.min(threads.length - 1, cursor + dy))
     scrollCursorIntoView()
   }
   // Keep the cursor row inside threadFlick's viewport. The list is a

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -248,6 +248,14 @@ FocusScope {
   property bool loading: false
   property string note: ""           // transient status line (send result, errors)
   property int cursor: -1            // keyboard row selection in list view
+  // Chat of the cursor row, so every row answers "am I the cursor?" with one
+  // string compare instead of an O(n) scan of threads per row per keypress.
+  readonly property string cursorChat: cursor >= 0 && cursor < threads.length ? String(threads[cursor].chat) : ""
+  // The row drawing the keyboard cursor right now — a thread row, pinned tile,
+  // search hit or contact hit registers itself when its hasCursor turns true,
+  // so the move functions never translate indexes between the four models.
+  // A destroyed row reads back as null (guarded QObject property).
+  property Item cursorRow: null
   property bool pinToBottom: false   // scroll to the newest bubble once layout settles
   property bool bubbleFocused: false // a bubble's TextEdit has focus (text selection in progress)
   property string threadRunningChat: "" // chat owned by the current threadProc
@@ -258,12 +266,6 @@ FocusScope {
   property string sendText: ""
   property string reloadChat: ""
 
-  function threadIndex(thread) {
-    for (var i = 0; i < root.threads.length; i++) {
-      if (String(root.threads[i].chat) === String(thread.chat)) return i
-    }
-    return -1
-  }
   function avatarInitials(thread) {
     var n = String(thread.name || "")
     if (/^[+0-9]/.test(n) || n === "") return "#"
@@ -729,6 +731,7 @@ FocusScope {
   function moveNewCursor(dy) {
     if (newResults.length === 0 || dy === 0) return
     newCursor = (newCursor + dy + newResults.length) % newResults.length
+    scrollCursorIntoView()
   }
 
   /** Start (or resume) a DM with a picked handle. An existing thread is
@@ -839,6 +842,7 @@ FocusScope {
   function moveSearchCursor(dy) {
     if (searchResults.length === 0 || dy === 0) return
     searchCursor = (searchCursor + dy + searchResults.length) % searchResults.length
+    scrollCursorIntoView()
   }
   function acceptSearchField() {
     var q = searchFieldQuery()
@@ -1333,6 +1337,25 @@ FocusScope {
   function moveCursor(dy) {
     if (inThread || threads.length === 0 || dy === 0) return
     cursor = (cursor + dy + threads.length) % threads.length
+    scrollCursorIntoView()
+  }
+  // Keep the cursor row inside threadFlick's viewport. The list is a
+  // multi-section Column (pinned grid, headers, three Repeaters), so there is
+  // no ListView.positionViewAtIndex — same helper as Omarchy's audio and
+  // tailscale panels. Synchronous: a cursor move does not touch the model, so
+  // the row is already laid out, and the binding that set cursorRow ran
+  // before the caller reached this line.
+  function scrollCursorIntoView() {
+    var row = cursorRow
+    if (!row) return
+    var margin = Style.space(6)
+    var top = row.mapToItem(threadFlick.contentItem, 0, 0).y
+    var bottom = top + row.height
+    var maxY = Math.max(0, threadFlick.contentHeight - threadFlick.height)
+    if (top < threadFlick.contentY + margin)
+      threadFlick.contentY = Math.max(0, top - margin)
+    else if (bottom > threadFlick.contentY + threadFlick.height - margin)
+      threadFlick.contentY = Math.min(maxY, bottom + margin - threadFlick.height)
   }
   function activateCursor() {
     if (!inThread && cursor >= 0) openThread(threads[cursor])
@@ -1360,6 +1383,16 @@ FocusScope {
     if (composeField.activeFocus && (composeField.text.length > 0 || root.draftPath !== ""))
       return false
     return handleTextKey(text) === true
+  }
+  /** Arrow/Enter list navigation for a host without a PanelKeyCatcher (the
+   *  window): true if the key was consumed. A focused editor keeps its arrows
+   *  — the search and new-message fields drive their own cursors. */
+  function catchNavKey(key) {
+    if (editorActive) return false
+    if (key === Qt.Key_Down) { moveCursor(1); return true }
+    if (key === Qt.Key_Up) { moveCursor(-1); return true }
+    if (key === Qt.Key_Return || key === Qt.Key_Enter) { activateCursor(); return true }
+    return false
   }
   function catchEscape() {
     if (newField.activeFocus || newMode) { exitNew(); return true }
@@ -1595,12 +1628,15 @@ FocusScope {
             Repeater {
               model: root.online && root.listShowing && root.newMode ? root.newResults : []
               delegate: Rectangle {
+                id: contactHit
                 required property var modelData
                 required property int index
+                readonly property bool hasCursor: root.newCursor === index
+                onHasCursorChanged: if (hasCursor) root.cursorRow = contactHit
                 Layout.fillWidth: true
                 implicitHeight: contactRow.implicitHeight + Style.space(12)
                 radius: Style.cornerRadius
-                color: contactHover.hovered || root.newCursor === index
+                color: contactHover.hovered || hasCursor
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
                 HoverHandler { id: contactHover }
@@ -1670,14 +1706,17 @@ FocusScope {
               Repeater {
                 model: pinnedGrid.visible ? root.pinnedThreads : []
                 delegate: Rectangle {
+                  id: pinnedTile
                   required property var modelData
+                  // pinned threads sit first in root.threads, so the cursor
+                  // walks these tiles before the rows below
+                  readonly property bool hasCursor: root.cursorChat === String(modelData.chat)
+                  onHasCursorChanged: if (hasCursor) root.cursorRow = pinnedTile
                   Layout.fillWidth: true
                   Layout.preferredWidth: Math.max(1, (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3)
                   implicitHeight: pinnedColumn.implicitHeight + Style.space(4)
                   radius: Style.cornerRadius
-                  // j/k walk root.threads, and pinned threads sort FIRST in it —
-                  // without this the cursor was invisible for those presses.
-                  color: pinnedHover.hovered || root.cursor === root.threadIndex(modelData)
+                  color: pinnedHover.hovered || hasCursor
                     ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                     : "transparent"
 
@@ -1797,12 +1836,15 @@ FocusScope {
             Repeater {
               model: root.online && root.listShowing && root.searchShowing ? root.searchResults : []
               delegate: Rectangle {
+                id: searchHit
                 required property var modelData
                 required property int index
+                readonly property bool hasCursor: root.searchCursor === index
+                onHasCursorChanged: if (hasCursor) root.cursorRow = searchHit
                 Layout.fillWidth: true
                 implicitHeight: hitCol.implicitHeight + Style.space(12)
                 radius: Style.cornerRadius
-                color: hitHover.hovered || root.searchCursor === index
+                color: hitHover.hovered || hasCursor
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
                 HoverHandler { id: hitHover }
@@ -1869,13 +1911,16 @@ FocusScope {
             Repeater {
               model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.unpinnedThreads : []
               delegate: Rectangle {
+                id: threadRow
                 required property var modelData
                 required property int index
+                readonly property bool hasCursor: root.cursorChat === String(modelData.chat)
+                onHasCursorChanged: if (hasCursor) root.cursorRow = threadRow
 
                 Layout.fillWidth: true
                 implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 20 : 12)
                 radius: Style.cornerRadius
-                color: rowHover.hovered || root.cursor === root.threadIndex(modelData)
+                color: rowHover.hovered || hasCursor
                   ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
                   : "transparent"
 

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -366,7 +366,12 @@ FocusScope {
     composeField.text = ""
     clearDraft()   // a queued file must never survive into another thread
     pinToBottom = false
-    Qt.callLater(function() { threadFlick.contentY = 0; root.navigationFocusRequested() })
+    // Top of the list for a mouse user; the cursor row for a keyboard user.
+    Qt.callLater(function() {
+      threadFlick.contentY = 0
+      scrollCursorIntoView()
+      root.navigationFocusRequested()
+    })
   }
 
   function openThread(t) {
@@ -646,6 +651,7 @@ FocusScope {
   function startNew() {
     if (inThread && !splitView) return   // split view: the list pane is right there
     exitSearch()
+    threadFlick.contentY = 0   // the field sits above the rows
     newMode = true
     newResults = []
     newNote = ""
@@ -657,6 +663,14 @@ FocusScope {
     })
   }
 
+  /** Down in an empty search or new-message field: back to the list, cursor
+   *  on the first row — the list is showing its top, so that is where the eye
+   *  is. Esc keeps the old cursor instead. */
+  function listFromTop() {
+    if (newMode) exitNew()
+    else exitSearch()
+    cursor = 0
+  }
   function exitNew() {
     newMode = false
     newResults = []
@@ -666,6 +680,9 @@ FocusScope {
     newField.text = ""
     newField.focus = false
     root.navigationFocusRequested()
+    // The field pushed the list to the top; bring the cursor row back once
+    // the rows have been rebuilt and laid out.
+    Qt.callLater(scrollCursorIntoView)
   }
 
   // Same identity discipline as message search: a stale completion must
@@ -730,6 +747,9 @@ FocusScope {
   }
   function moveNewCursor(dy) {
     if (newResults.length === 0 || dy === 0) return
+    // Up from the first hit brings the field (which already has focus) back
+    // into view, as moveCursor does for the thread list.
+    if (dy < 0 && newCursor <= 0) { threadFlick.contentY = 0; return }
     newCursor = Math.max(0, Math.min(newResults.length - 1, newCursor + dy))
     scrollCursorIntoView()
   }
@@ -751,6 +771,7 @@ FocusScope {
 
   function startSearch() {
     if (inThread && !splitView) return
+    threadFlick.contentY = 0   // the field sits above the rows
     searching = true
     searchResults = []
     searchNote = ""
@@ -769,6 +790,7 @@ FocusScope {
     searchField.text = ""
     searchField.focus = false
     if (!newMode) root.navigationFocusRequested()
+    Qt.callLater(scrollCursorIntoView)   // no-op while the rows are gone
   }
 
   // Instant sidebar preview. search.ts matchConversations ranks the list
@@ -841,6 +863,7 @@ FocusScope {
   }
   function moveSearchCursor(dy) {
     if (searchResults.length === 0 || dy === 0) return
+    if (dy < 0 && searchCursor <= 0) { threadFlick.contentY = 0; return }
     searchCursor = Math.max(0, Math.min(searchResults.length - 1, searchCursor + dy))
     scrollCursorIntoView()
   }
@@ -1339,6 +1362,9 @@ FocusScope {
   // (Omarchy's Dropdown clamps the same way).
   function moveCursor(dy) {
     if (inThread || threads.length === 0 || dy === 0) return
+    // Up from the first row hands focus to the search field above the list,
+    // and Down in an empty field hands it back (Omarchy's SearchableDropdown).
+    if (dy < 0 && cursor <= 0) { startSearch(); return }
     cursor = Math.max(0, Math.min(threads.length - 1, cursor + dy))
     scrollCursorIntoView()
   }
@@ -1609,7 +1635,11 @@ FocusScope {
               onAccepted: root.acceptNewField()
               Keys.onEscapePressed: root.exitNew()
               Keys.onPressed: function(event) {
-                if (event.key === Qt.Key_Down) { root.moveNewCursor(1); event.accepted = true }
+                if (event.key === Qt.Key_Down) {
+                  if (text === "") root.listFromTop()
+                  else root.moveNewCursor(1)
+                  event.accepted = true
+                }
                 else if (event.key === Qt.Key_Up) { root.moveNewCursor(-1); event.accepted = true }
               }
               onVisibleChanged: if (visible) {
@@ -1687,7 +1717,11 @@ FocusScope {
               onActiveFocusChanged: if (activeFocus && !root.searching) root.searching = true
               Keys.onEscapePressed: root.exitSearch()
               Keys.onPressed: function(event) {
-                if (event.key === Qt.Key_Down) { root.moveSearchCursor(1); event.accepted = true }
+                if (event.key === Qt.Key_Down) {
+                  if (text === "") root.listFromTop()
+                  else root.moveSearchCursor(1)
+                  event.accepted = true
+                }
                 else if (event.key === Qt.Key_Up) { root.moveSearchCursor(-1); event.accepted = true }
               }
             }

--- a/BlipWindow.qml
+++ b/BlipWindow.qml
@@ -15,7 +15,8 @@ import qs.Commons
 // (tapbacks, receipts, inline photos, replies, search, composer,
 // attachments). No PanelKeyCatcher here — a normal window keeps normal
 // editor/Tab behavior; Esc unwinds the view (thread → list, search → list)
-// and closes the window only when there is nothing left to unwind.
+// and closes the window only when there is nothing left to unwind. Up/Down
+// and Enter walk the thread list while no editor has focus.
 FloatingWindow {
   id: win
   property var hostWidget: null
@@ -106,6 +107,10 @@ FloatingWindow {
       Keys.priority: Keys.BeforeItem
       Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape && view.catchEscape()) {
+          event.accepted = true
+          return
+        }
+        if (view.catchNavKey(event.key)) {
           event.accepted = true
           return
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,19 @@
 ## Unreleased
 
 - **The keyboard cursor scrolls the list.** j/k and the arrow keys could walk
-  the selection below the visible rows — in the thread list, the search hits and
-  the new-message picker — and the list stayed put. The row that holds the
-  cursor now registers itself, and every cursor move keeps that row inside the
-  viewport: the helper Omarchy's audio and Tailscale panels use, because a
-  multi-section Column has no `positionViewAtIndex`. Rows also answer "am I the
-  cursor?" with one string compare instead of scanning every thread per row per
-  keypress. The app window (SUPER+M) had no list navigation at all — only the
-  bar panel's PanelKeyCatcher did — so Up/Down and Enter now walk the thread
-  list there too, while no editor has focus. The cursor stops at the first and last row
-  instead of wrapping around.
+  the selection below the visible rows — thread list, search hits and the
+  new-message picker alike — while the list stayed put. The cursor row now
+  registers itself and every move keeps it inside the viewport, with the
+  helper Omarchy's audio and Tailscale panels use (a multi-section Column has
+  no `positionViewAtIndex`); rows answer "am I the cursor?" with one string
+  compare instead of scanning every thread per row per keypress. The cursor
+  stops at the first and last row instead of wrapping. Up from the first row
+  scrolls to the top and focuses the search field; Down in an empty search or
+  new-message field returns to the list at its first row; Esc out of a field
+  or a conversation returns to the row you were on. `/` and `n` scroll to the
+  top too — pressed deep in the list they used to focus a field that was out
+  of view. The app window (SUPER+M) had no list navigation at all, so Up/Down
+  and Enter walk the list there as well while no editor has focus.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **The keyboard cursor scrolls the list.** j/k and the arrow keys could walk
+  the selection below the visible rows — in the thread list, the search hits and
+  the new-message picker — and the list stayed put. The row that holds the
+  cursor now registers itself, and every cursor move keeps that row inside the
+  viewport: the helper Omarchy's audio and Tailscale panels use, because a
+  multi-section Column has no `positionViewAtIndex`. Rows also answer "am I the
+  cursor?" with one string compare instead of scanning every thread per row per
+  keypress. The app window (SUPER+M) had no list navigation at all — only the
+  bar panel's PanelKeyCatcher did — so Up/Down and Enter now walk the thread
+  list there too, while no editor has focus.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
   cursor?" with one string compare instead of scanning every thread per row per
   keypress. The app window (SUPER+M) had no list navigation at all — only the
   bar panel's PanelKeyCatcher did — so Up/Down and Enter now walk the thread
-  list there too, while no editor has focus.
+  list there too, while no editor has focus. The cursor stops at the first and last row
+  instead of wrapping around.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -13,6 +13,12 @@ function handleTextKeySource() {
   return panel.slice(start, end);
 }
 
+/** Body of a root-level BlipView function, up to its own closing brace. */
+function qmlFunction(name: string) {
+  const start = panel.indexOf(`function ${name}(`);
+  return panel.slice(start, panel.indexOf("\n  }\n", start));
+}
+
 describe("QML safety invariants", () => {
   test("group sends use the cached AppleScript GUID", () => {
     expect(panel).toContain('["--chat-id", String(root.active.guid)]');
@@ -182,6 +188,55 @@ describe("QML safety invariants", () => {
     expect(panel).toContain("newSearchTimer.restart()");
     expect(panel).not.toContain("forceLayout");
     expect(panel.indexOf("onAccepted: root.acceptNewField()")).toBeGreaterThan(-1);
+  });
+
+  test("every cursor move keeps its row in view and stops at the ends", () => {
+    // The list is a multi-section Column, so there is no ListView to do this;
+    // each move function ends by scrolling its row into the viewport. A modulo
+    // here would bring the wrap-around back.
+    for (const name of ["moveCursor", "moveSearchCursor", "moveNewCursor"]) {
+      const fn = qmlFunction(name);
+      expect(fn).toContain("Math.max(0, Math.min(");
+      expect(fn).not.toContain("%");
+      expect(fn).toContain("scrollCursorIntoView()");
+    }
+    const scroll = qmlFunction("scrollCursorIntoView");
+    expect(scroll).toContain("row.mapToItem(threadFlick.contentItem, 0, 0)");
+    expect(scroll).toContain("Math.min(maxY, bottom + margin - threadFlick.height)");
+  });
+
+  test("rows register themselves as the cursor row instead of scanning threads", () => {
+    // threadIndex() walked every thread per row per keypress; cursorChat is one
+    // string compare, and the row that matches hands itself to cursorRow so
+    // the move functions never translate indexes between the four models.
+    expect(panel).not.toContain("threadIndex(");
+    expect(panel.split("root.cursorChat === String(modelData.chat)").length - 1).toBe(2);
+    expect(panel.split("onHasCursorChanged: if (hasCursor) root.cursorRow = ").length - 1).toBe(4);
+  });
+
+  test("leaving a field or a conversation brings the cursor row back", () => {
+    // startSearch/startNew scroll to the top (the field sits above the rows)
+    // and back() parks a mouse user there; the keyboard cursor is restored
+    // after the rows have been rebuilt, hence the deferral.
+    expect(qmlFunction("startSearch")).toContain("threadFlick.contentY = 0");
+    expect(qmlFunction("startNew")).toContain("threadFlick.contentY = 0");
+    expect(qmlFunction("exitSearch")).toContain("Qt.callLater(scrollCursorIntoView)");
+    expect(qmlFunction("exitNew")).toContain("Qt.callLater(scrollCursorIntoView)");
+    const back = qmlFunction("back");
+    expect(back).toContain("threadFlick.contentY = 0");
+    expect(back.indexOf("threadFlick.contentY = 0")).toBeLessThan(back.indexOf("scrollCursorIntoView()"));
+    // Down in an empty field starts from the first row; Esc keeps the old cursor.
+    expect(panel.split('if (text === "") root.listFromTop()').length - 1).toBe(2);
+    expect(qmlFunction("listFromTop")).toContain("cursor = 0");
+  });
+
+  test("app window walks the list with Up/Down/Enter only while no editor has focus", () => {
+    expect(window).toContain("view.catchNavKey(event.key)");
+    const fn = qmlFunction("catchNavKey");
+    expect(fn.indexOf("if (editorActive) return false")).toBeLessThan(fn.indexOf("Qt.Key_Down"));
+    expect(fn).toContain("moveCursor(1)");
+    expect(fn).toContain("moveCursor(-1)");
+    expect(fn).toContain("activateCursor()");
   });
 
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -211,6 +211,9 @@ describe("QML safety invariants", () => {
     // the move functions never translate indexes between the four models.
     expect(panel).not.toContain("threadIndex(");
     expect(panel.split("root.cursorChat === String(modelData.chat)").length - 1).toBe(2);
+    // the highlight hides while the search field has focus; the cursor itself stays
+    expect(panel).toContain("readonly property bool cursorShown: !searchField.activeFocus");
+    expect(panel.split("(hasCursor && root.cursorShown)").length - 1).toBe(2);
     expect(panel.split("onHasCursorChanged: if (hasCursor) root.cursorRow = ").length - 1).toBe(4);
   });
 


### PR DESCRIPTION
## What

Keyboard navigation of the thread list follows the cursor. Arrow keys and j/k used to walk the selection below the visible rows — in the thread list, the search hits and the new-message picker — while the list stayed put. The list now scrolls to keep the cursor row in view, the cursor stops at the ends instead of wrapping, Up from the first row hands off to the search field and Down in an empty field hands back, and leaving a field or a conversation returns to the row you were on. The app window (SUPER+M) gets Up/Down/Enter list navigation, which it did not have at all.

Four commits, each reviewable on its own; the second and third are behaviour choices you may want to weigh separately.

## Why

`moveCursor`, `moveSearchCursor` and `moveNewCursor` changed an index and nothing else. The rows recoloured themselves, but `threadFlick.contentY` was never touched, so on a list longer than the panel the selection disappeared below the fold after a dozen presses. Once the list follows the cursor, three things around it that were harmless before become visible: the modulo wrap (Down on the last of 300 threads landing on the first now reads as a jump), `/` and `n` pressed deep in the list focusing a field that was scrolled out of view, and `back()` parking the list at the top after Esc regardless of where the cursor was.

The list is a multi-section Column — pinned grid, section headers, three Repeaters in one Flickable — so `ListView.positionViewAtIndex` is not available. That is the shape Omarchy's own audio and Tailscale panels have, and the fix is the helper they use.

## How

**1. `4d91bb7` — Keep the keyboard cursor row scrolled into view; arrows in the window**

- `scrollCursorIntoView()` on the view root: `mapToItem` the cursor row into `threadFlick.contentItem`, clamp `contentY` so the row sits inside the viewport with a `Style.space(6)` margin. Same code as Omarchy's `panels/tailscale/Panel.qml` `scrollItemIntoView`. Called synchronously from the move functions: a cursor move does not change the model, so the row is already laid out.
- Each of the four row delegates (thread row, pinned tile, search hit, contact hit) gets `readonly property bool hasCursor` and `onHasCursorChanged: if (hasCursor) root.cursorRow = <id>`. The move functions never translate indexes between `threads`, `pinnedThreads`, `unpinnedThreads`, `searchResults` and `newResults`; the row that matches says so. `cursorRow` is a `property Item`, so a destroyed row reads back as null.
- `root.cursorChat` (the chat id at `threads[cursor]`) replaces `threadIndex(modelData)` in the two thread-row colour bindings. `threadIndex()` scanned every thread, per row, per keypress — O(n²) on a 300-thread list; a string compare per row is O(n). `threadIndex()` had no other callers and is removed.
- `BlipWindow.qml`: `navCatcher` forwards Up/Down/Enter through a new `view.catchNavKey(key)`, sibling of `catchEscape`/`catchNavText`. It returns false while `editorActive`, so the compose, search and new-message fields keep their own arrow handling — the window's "normal editor behaviour" rule from the header comment is intact. Letters (j/k, Space) are deliberately not added in the window.

**2. `15e56df` — Stop the keyboard cursor at the list ends instead of wrapping**

- All three move functions clamp to `[0, length-1]` instead of `% length`. Omarchy's `Dropdown` clamps; Menu and Clipboard wrap — for a launcher-sized list a loop is fine, for 300 threads it is a jump. The wrap arrived with the `a98f59e` refactor and is not mentioned in the CHANGELOG or docs, so I read it as incidental. Revert this one commit if you prefer the loop.

**3. `d007d6c` — Up from the first row focuses the search field**

- `moveCursor(-1)` on row 0 calls `startSearch()`. `startSearch()` and `startNew()` now set `threadFlick.contentY = 0` themselves — the field sits above the rows, so any way into it (Up, `/`, `n`, IPC `find`) must start with it visible. Before, `/` pressed deep in the list focused a field you could not see.
- Down in an empty search or new-message field calls `listFromTop()`: leaves the mode and puts the cursor on row 0. The list is showing its top, so that is where the eye is. Esc keeps the old cursor instead. That is the `SearchableDropdown` round trip (Up at the top → field, Down from the field → first row).
- `exitSearch()` and `exitNew()` end with `Qt.callLater(scrollCursorIntoView)`: the thread rows are rebuilt when the mode flips, so the scroll is deferred a turn — the reason Omarchy's Bluetooth panel defers `positionViewAtIndex`. A no-op while the rows are gone, so `startNew()` calling `exitSearch()` is unaffected.
- `back()` keeps `threadFlick.contentY = 0` (a mouse user with no cursor lands at the top as before) and then calls `scrollCursorIntoView()` in the same deferred block, so Enter → read → Esc returns to the row you opened.
- Up from the first search hit or contact hit only scrolls the field back into view; their field already holds focus while the arrows walk the hits.

**4. `7e1678a` — ui.test.ts: pin the keyboard-cursor invariants**

- Four source-level checks in the existing "QML safety invariants" style: every move function clamps and ends in `scrollCursorIntoView()` (a modulo fails the test); rows register as `cursorRow` and `threadIndex()` stays gone; `startSearch`/`startNew` scroll to the top while `exitSearch`, `exitNew` and `back()` restore the cursor row in that order; `catchNavKey` yields to a focused editor before touching the arrows. A shared `qmlFunction()` helper slices a root-level function body up to its own closing brace, so the checks do not depend on the order functions appear in the file.

CHANGELOG (Unreleased) has one entry covering all four.

## How it was verified

- [x] `bun test` is green (CI will check) — 352 tests, 351 pass, 0 fail; the four new tests fail when the wrap is reintroduced in a copy
- [x] Any send/receive behaviour was exercised against **my own number only** — this change does not send
- [x] UI change → exercised by hand on a 305-thread list, bar panel and app window: Down/Up through the fold both ways, ends, Up → field → type → clear → Down → row 0, `n` → Esc from a deep cursor, Enter → Esc from a deep cursor, search hits Up past the first
- [ ] Touches an invariant in `CLAUDE.md` → no; the wheel-scroll and Flickable invariants are untouched (`MouseArea.onWheel`, `interactive`, `StopAtBounds` unchanged)

`qmllint` on the two files reports the same warnings as `upstream/main`, nothing new. Bindings re-evaluated per keypress: n string compares plus one `mapToItem`; before, n·n string compares.

Not changed, deliberately: the cursor is still an index into `threads`, as upstream has it, so a push refresh that re-sorts the list moves the highlight to whatever row now sits at that index. An identity-based cursor is the better model and a separate change.
