### PR TITLE
Omarchy's panel hotkeys reach Blip: expose opened on the bar widget

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -172,6 +172,10 @@ BarWidget {
   // the user, and a plain toggle would HIDE it ("SUPER+M doesn't load the
   // app"). Hyprland ≥0.56 dispatch takes Lua; classic focuswindow is rejected.
   function showApp() {
+    // The popout gets out of the way first: the window is the same view,
+    // larger. Here, once, so double-click, the ⇱ button and IPC `app` (a
+    // SUPER+M bind) all agree — `app` used to leave the popout open.
+    root.close()
     ensureWindow()
     if (!windowLoader.item) return
     // Fire-and-forget on purpose: a Process object silently ignores
@@ -200,7 +204,6 @@ BarWidget {
     }
     if (dblClick.running) {
       dblClick.stop()
-      root.close()
       root.showApp()
       return
     }

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -678,7 +678,7 @@ BarWidget {
     // one is recorded — so a body with the code put the code on disk (Astra
     // #1). The toast says a code arrived; click copies it from memory.
     var body = (pendingCode.domain !== "" ? "For " + pendingCode.domain + " · " : "")
-             + "Click to copy · Super+Shift+V types it"
+             + "Click to copy"
     fireToasts([{ chat: "", name: "Security code from " + who, text: body, ts: pendingCode.ts, key: "", code: pendingCode.code }])
   }
   // sh reads the code from its environment, hands it to the tool on stdin.

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -75,6 +75,11 @@ BarWidget {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
+  // Omarchy's panel hotkeys (`omarchy-shell shell toggle nixfred.blip`,
+  // SUPER+CTRL+<n> by bar position) find a bar widget's panel through open(),
+  // close() AND this property — without it the shell logs "summon: no live
+  // bar widget" and does nothing. Same line as Omarchy's clock widget.
+  readonly property bool opened: panelLoader.item ? panelLoader.item.opened === true : false
   function open() { if (panelLoader.item) panelLoader.item.open() }
   function close() { if (panelLoader.item) panelLoader.item.close() }
   function toggle() { if (panelLoader.item) panelLoader.item.toggle() }

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1530,7 +1530,7 @@ FocusScope {
               PanelActionButton {
                 visible: !root.newMode && !root.searchShowing && !root.splitView
                 iconText: "⇱"
-                tooltipText: "Open the app window (SUPER+M)"
+                tooltipText: "Open the app window"
                 bordered: true
                 foreground: root.foreground
                 hoverColor: root.accent

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -216,7 +216,6 @@ FocusScope {
   function openApp() {
     closeShare()
     if (!hostWidget) return
-    if (typeof hostWidget.close === "function") hostWidget.close()
     if (typeof hostWidget.showApp === "function") hostWidget.showApp()
   }
   function shareOpen() { var u = shareUrl; closeShare(); openLink(u) }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Omarchy's panel hotkeys reach Blip.** `omarchy-shell shell toggle
+  nixfred.blip` and `SUPER+CTRL+<n>` did nothing — the shell logged "summon:
+  no live bar widget": the bar looks a panel up through `open()`, `close()`
+  and an `opened` property, and the widget had no `opened`. One readonly
+  property, the same line Omarchy's clock and weather widgets carry; the
+  README shows the stock `o.bind` for it.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   no live bar widget": the bar looks a panel up through `open()`, `close()`
   and an `opened` property, and the widget had no `opened`. One readonly
   property, the same line Omarchy's clock and weather widgets carry; the
-  README shows the stock `o.bind` for it.
+  README shows the stock `o.bind` for it. The ⇱ tooltip and the security-code
+  toast no longer name SUPER+M and Super+Shift+V: both are bindings the README
+  asks you to add yourself, and Omarchy's own tooltips name no keys.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   property, the same line Omarchy's clock and weather widgets carry; the
   README shows the stock `o.bind` for it. The ⇱ tooltip and the security-code
   toast no longer name SUPER+M and Super+Shift+V: both are bindings the README
-  asks you to add yourself, and Omarchy's own tooltips name no keys.
+  asks you to add yourself, and Omarchy's own tooltips name no keys. Opening
+  the app through IPC `app` (the SUPER+M bind) now closes the popout the way
+  double-click and ⇱ always did; the two surfaces are the same view.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ Linux side. If the Mac is asleep, the widget dims and says so.
   box focused (the Omarchy daemon renders no action buttons, so click IS
   the reply path)
 
+**Hotkey for the panel**
+- `omarchy-shell shell toggle nixfred.blip` opens and closes the panel the way
+  Omarchy's own panels do, so a stock binding in `~/.config/hypr/bindings.lua`
+  is all it takes — `o.bind("SUPER + CTRL + M", "Blip", "omarchy-shell shell toggle nixfred.blip")`.
+  Omarchy's `SUPER+CTRL+<n>` (panel *n* in the bar's right section) reaches
+  it too. On a multi-monitor bar the panel lives on the first screen's copy.
+
 **The app**
 - double-click the bar icon, press `SUPER+M`, or IPC `app` for a
   Messages-style window (IPC `window` is a plain toggle). For the keybind, add
@@ -492,6 +499,7 @@ rather than hang:
 IPC, for scripts and other plugins:
 
 ```sh
+omarchy-shell shell toggle nixfred.blip                                # open/close the panel (Omarchy's standard path)
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip status
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip goto 15551234567   # bare digits
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip read               # mark all read

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -184,6 +184,14 @@ describe("QML safety invariants", () => {
     expect(panel.indexOf("onAccepted: root.acceptNewField()")).toBeGreaterThan(-1);
   });
 
+  test("Omarchy's shell toggle can find the panel", () => {
+    // Bar.findPanelWidget wants open(), close() and `opened` on the widget
+    // item; drop `opened` and every SUPER+CTRL panel hotkey silently skips Blip.
+    expect(widget).toContain("readonly property bool opened: panelLoader.item ? panelLoader.item.opened === true : false");
+    expect(widget).toContain("function open() {");
+    expect(widget).toContain("function close() {");
+  });
+
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {
     // --action=default dies with the notify-send process after eight seconds.
     // The hint is what Omarchy persists, so a row in the notification center

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -70,9 +70,11 @@ describe("QML safety invariants", () => {
     expect(panel).toContain("var sentUrl = root.firstUrl(completedText)");
     expect(panel).toContain("function openApp()");
     expect(panel).toContain('hostWidget.showApp()');
-    // the popout gets out of the way, and closes BEFORE the window is shown
-    expect(panel).toContain('hostWidget.close()');
-    expect(panel.indexOf("hostWidget.close()")).toBeLessThan(panel.indexOf("hostWidget.showApp()"));
+    // the popout gets out of the way, and closes BEFORE the window is shown —
+    // inside showApp(), so double-click, ⇱ and IPC `app` (SUPER+M) all agree
+    const showApp = widget.slice(widget.indexOf("function showApp()"), widget.indexOf("function anySurfaceOpen"));
+    expect(showApp.indexOf("root.close()")).toBeLessThan(showApp.indexOf("ensureWindow()"));
+    expect(showApp.indexOf("root.close()")).toBeGreaterThan(-1);
     // The tooltip names the action, not a key: SUPER+M is an optional
     // binding from the README, and Omarchy's own tooltips name no keys.
     expect(panel).toContain('tooltipText: "Open the app window"');

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -73,7 +73,10 @@ describe("QML safety invariants", () => {
     // the popout gets out of the way, and closes BEFORE the window is shown
     expect(panel).toContain('hostWidget.close()');
     expect(panel.indexOf("hostWidget.close()")).toBeLessThan(panel.indexOf("hostWidget.showApp()"));
-    expect(panel).toContain('tooltipText: "Open the app window (SUPER+M)"');
+    // The tooltip names the action, not a key: SUPER+M is an optional
+    // binding from the README, and Omarchy's own tooltips name no keys.
+    expect(panel).toContain('tooltipText: "Open the app window"');
+    expect(panel).not.toContain("SUPER+M)");
   });
 
   test("group rows and tiles show the GROUP's photo, never the last speaker's", () => {


### PR DESCRIPTION
## What

Omarchy's own panel hotkeys reach Blip. `omarchy-shell shell toggle nixfred.blip` opens and closes the panel like it does for audio, network and the rest, and the stock `SUPER+CTRL+<n>` "panel n in the right section" binds count Blip too. One readonly property on the bar widget, plus two small follow-ups around the same hotkeys: tooltips stop naming keys the plugin does not bind, and opening the app from any path closes the popout.

## Why

`omarchy-shell shell toggle nixfred.blip` returned 0 and did nothing; the shell log said why on every press:

```
WARN qml: summon: no live bar widget for: nixfred.blip
```

`Bar.findPanelWidget` accepts a bar widget as a panel only when its item has `open()`, `close()` **and** an `opened` property (`plugins/bar/Bar.qml`, the `item.opened === undefined` check). BarWidget had the two functions but not the property, so to the shell Blip was a widget without a panel. That is also why the README needs a bespoke `sh -c` snippet for a hotkey where Omarchy's panels get a one-line `o.bind`.

## How

- **`BarWidget.qml`** — `readonly property bool opened: panelLoader.item ? panelLoader.item.opened === true : false`, the same line Omarchy's clock and weather widgets carry. `Panel.qml` already exposes `opened`; nothing else changes.
- **README** — a "Hotkey for the panel" note next to the SUPER+M snippet with the stock `o.bind("SUPER + CTRL + M", "Blip", "omarchy-shell shell toggle nixfred.blip")`, and the command in the IPC list.
- **`ui.test.ts`** — pins the property, in the "QML safety invariants" style.
- **Second commit** — the ⇱ tooltip ("Open the app window (SUPER+M)") and the security-code toast ("Super+Shift+V types it") stop naming keys: both are optional `o.bind`s the README asks you to add, so on a stock install they promised chords that do nothing. Omarchy's own widgets (53 tooltips) name no keys; the README keeps the bindings. The `ui.test.ts` line that pinned the old tooltip text now pins the new one.
- **Third commit** — `showApp()` closes the popout itself. Double-click and ⇱ each closed it before calling `showApp()`; IPC `app` (what the README's SUPER+M bind calls) did not, so SUPER+CTRL+M followed by SUPER+M left the panel and the window up together. The window is the same BlipView, larger, and both mark read while focused. The two callers drop their own close; `ui.test.ts` pins the order inside `showApp()` instead of in BlipView.
- CHANGELOG (Unreleased).

Not changed: on a multi-monitor bar the panel lives on the first screen's copy (`leader`), and a follower's `open()` stays a no-op. Omarchy prefers the focused screen's copy when it picks a slot, so on a second monitor the hotkey still does nothing — that is the existing leader design, noted in the README line.

## How it was verified

- [x] `bun test` is green (CI will check) — 348 pass
- [x] Any send/receive behaviour was exercised against **my own number only** — this change does not send
- [x] UI change → live on Omarchy: `omarchy-shell shell toggle nixfred.blip` twice from a shell; the panel opened on the first call and closed on the second (full-screen captures before/after), and the shell log has zero `summon: no live bar widget` lines since the restart, against five for five presses before
- [ ] Touches an invariant in `CLAUDE.md` → no
