### PR TITLE
Read the conversation from the keyboard: bubble cursor, actions, paging

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -101,10 +101,12 @@ BarWidget {
   /** Newest arriving link → the share sheet on whichever surface is open. */
   function shareArrivingLink(link) {
     if (!link || !link.url) return
+    // Every link of the message: the sheet steps through them.
+    var urls = Array.isArray(link.urls) && link.urls.length > 0 ? link.urls.map(String) : [String(link.url)]
     var w = windowLoader.item
-    if (w && root.windowVisible && typeof w.shareLink === "function") { w.shareLink(String(link.url)); return }
+    if (w && root.windowVisible && typeof w.shareLink === "function") { w.shareLink(urls); return }
     var p = panelLoader.item
-    if (p && p.opened === true && typeof p.shareLink === "function") p.shareLink(String(link.url))
+    if (p && p.opened === true && typeof p.shareLink === "function") p.shareLink(urls)
   }
 
   function injectPanel() {

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -2916,12 +2916,16 @@ FocusScope {
           }
         }
 
+        // Always one line tall, empty or not: a note that appears and vanishes
+        // must not shove the compose box and the bubbles around. Only failures
+        // are red; progress and confirmations are dim.
         Text {
           Layout.fillWidth: true
-          visible: root.note !== ""
-          text: root.note
+          text: root.note === "" ? " " : root.note
           textFormat: Text.PlainText
-          color: root.note === "sending…" ? root.dim : root.urgent
+          readonly property bool calm: root.note === "copied" || root.note === "sending…"
+            || root.note === "sent to LocalSend" || root.note.indexOf("attached") === 0
+          color: calm ? root.dim : root.urgent
           font.family: root.fontFamily
           font.pixelSize: root.fontCaption
           wrapMode: Text.WordWrap

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -417,17 +417,6 @@ FocusScope {
     flick.contentY = Math.max(0, Math.min(max, flick.contentY + dy))
     flick.stick = flick.contentY >= max - 4
   }
-  /** Pixels a key moves the conversation from the compose field, 0 = not a
-   *  scroll key. PageUp/PageDown always page; Home/End only while the field
-   *  is empty — with text typed they keep moving the caret. */
-  function conversationStep(key, fieldEmpty) {
-    if (key === Qt.Key_PageUp) return -flick.height * 0.9
-    if (key === Qt.Key_PageDown) return flick.height * 0.9
-    if (!fieldEmpty) return 0
-    if (key === Qt.Key_Home) return -flick.contentHeight
-    if (key === Qt.Key_End) return flick.contentHeight
-    return 0
-  }
   /** Up/Down in an empty compose field walk the bubbles, newest first, and
    *  keep the selected one in view. Down past the newest drops the selection
    *  and re-sticks to the bottom, so the conversation follows new messages
@@ -444,6 +433,46 @@ FocusScope {
     } else {
       bubbleCursor = Math.max(0, bubbleCursor + dy)
     }
+    revealBubbleCursor()
+  }
+  /** PgUp/PgDn walk the bubbles a screen at a time, and unlike the arrows
+   *  they work with text in the compose field (they move no caret). PgUp
+   *  selects the topmost visible bubble; already there, it pages up first.
+   *  PgDn mirrors it with the bottommost, and past the newest leaves. */
+  function pageBubbles(dy) {
+    if (bubbles.length === 0) return
+    var edge = edgeVisibleBubble(dy)
+    if (edge === bubbleCursor && bubbleCursorItem) {
+      if (dy > 0 && edge === bubbles.length - 1) { leaveBubbles(); return }
+      // Page so the selected row lands at the OPPOSITE edge — a screen with
+      // one row of overlap, the way a pager turns a page.
+      var it = bubbleCursorItem, margin = Style.space(6)
+      scrollConversation(dy < 0 ? it.y + it.height + margin - flick.height - flick.contentY
+                                : it.y - margin - flick.contentY)
+      edge = edgeVisibleBubble(dy)
+    }
+    if (edge < 0) return
+    bubbleCursor = edge
+    revealBubbleCursor()
+  }
+  /** Index of the topmost (dy < 0) or bottommost (dy > 0) bubble that is
+   *  WHOLLY inside the viewport — a sliver of the neighbour above the
+   *  selection must not count, or the next PgUp steps one row instead of
+   *  paging. Falls back to a partly visible row (a picture taller than the
+   *  view); -1 when nothing is laid out yet. */
+  function edgeVisibleBubble(dy) {
+    var top = flick.contentY, bottom = top + flick.height
+    var n = bubbleRepeater.count, partial = -1
+    for (var k = 0; k < n; k++) {
+      var i = dy < 0 ? k : n - 1 - k
+      var it = bubbleRepeater.itemAt(i)
+      if (!it || it.y >= bottom || it.y + it.height <= top) continue
+      if (partial < 0) partial = i
+      if (dy < 0 ? it.y >= top - 1 : it.y + it.height <= bottom + 1) return i
+    }
+    return partial
+  }
+  function revealBubbleCursor() {
     var it = bubbleCursorItem   // set synchronously by the row's hasCursor binding
     if (!it) return
     var margin = Style.space(6)
@@ -2261,6 +2290,7 @@ FocusScope {
             }
 
             Repeater {
+              id: bubbleRepeater
               model: root.inThread ? root.bubbles : []
               delegate: ColumnLayout {
                 id: bubbleRow
@@ -2869,10 +2899,28 @@ FocusScope {
                 // Reading history without the mouse: the compose field is the
                 // thread's focus holder, so the keys live here. An empty field
                 // has no caret for Up/Down to move; they select bubbles instead.
+                // The arrows are the bubbles' when there is no caret line to
+                // move to: Up from the first line of a draft (or an empty
+                // field), Down from the last line while a bubble is selected.
+                // Omarchy's own lists get this for free from single-line
+                // fields; the compose box is multi-line, hence the edge rule.
                 var empty = text.length === 0
-                if (empty && (event.key === Qt.Key_Up || event.key === Qt.Key_Down)) {
+                var caret = cursorRectangle
+                var onFirstLine = empty || caret.y < topPadding + caret.height * 0.5
+                var onLastLine = empty || caret.y + caret.height > topPadding + contentHeight - caret.height * 0.5
+                if ((event.key === Qt.Key_Up && onFirstLine)
+                    || (event.key === Qt.Key_Down && onLastLine && root.bubbleCursor >= 0)) {
                   event.accepted = true
                   root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)
+                  return
+                }
+                // PgUp/PgDn work with a draft in the field (they move no caret):
+                // a screen at a time, or one bubble at a time with Shift held.
+                if (event.key === Qt.Key_PageUp || event.key === Qt.Key_PageDown) {
+                  event.accepted = true
+                  var dir = event.key === Qt.Key_PageUp ? -1 : 1
+                  if (event.modifiers & Qt.ShiftModifier) root.moveBubbleCursor(dir)
+                  else root.pageBubbles(dir)
                   return
                 }
                 // Actions on the selected bubble. Enter is free here: with no
@@ -2883,10 +2931,20 @@ FocusScope {
                   if (event.matches(StandardKey.Copy)) { event.accepted = true; root.copyBubble(b); return }
                   if (event.key === Qt.Key_R && (event.modifiers & Qt.ControlModifier)) { event.accepted = true; root.quoteBubble(b); return }
                 }
-                var dy = root.conversationStep(event.key, empty)
-                if (dy !== 0) {
+                // Home/End select the oldest / newest bubble from an empty
+                // field, or once the caret already sits at the start / end
+                // of its line — the first press is the caret's, the second
+                // the bubbles' (the arrows' edge rule). Neighbour glyphs on
+                // another line mean a line edge, so wrapped lines count too.
+                var atLineStart = empty || cursorPosition === 0
+                  || positionToRectangle(cursorPosition - 1).y < caret.y - 1
+                var atLineEnd = empty || cursorPosition === length
+                  || positionToRectangle(cursorPosition + 1).y > caret.y + 1
+                if (((event.key === Qt.Key_Home && atLineStart) || (event.key === Qt.Key_End && atLineEnd))
+                    && root.bubbles.length > 0) {
                   event.accepted = true
-                  root.scrollConversation(dy)
+                  root.bubbleCursor = event.key === Qt.Key_Home ? 0 : root.bubbles.length - 1
+                  root.revealBubbleCursor()
                   return
                 }
                 if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter)

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -248,6 +248,12 @@ FocusScope {
   property bool loading: false
   property string note: ""           // transient status line (send result, errors)
   property int cursor: -1            // keyboard row selection in list view
+  // The bubble the arrows have selected in a conversation (-1 = none) and the
+  // delegate drawing it — registered by the row itself, like cursorRow. The
+  // selection is a TARGET for actions (copy, open, reply), not a scroll state.
+  property int bubbleCursor: -1
+  property Item bubbleCursorItem: null
+  onBubblesChanged: clearBubbleCursor()   // a reload renumbers the rows
   property bool pinToBottom: false   // scroll to the newest bubble once layout settles
   property bool bubbleFocused: false // a bubble's TextEdit has focus (text selection in progress)
   property string threadRunningChat: "" // chat owned by the current threadProc
@@ -403,6 +409,56 @@ FocusScope {
    *  Keystroke injection (wtype) proved non-deterministic — a virtual
    *  keyboard's events can land on whatever surface Hyprland favors. */
   /** Clear every badge/dot locally. Read state never goes back to iMessage. */
+  /** Move the conversation by dy pixels — the wheel and the keys share this,
+   *  so the bottom-stick (which gates the deferred push reload) behaves the
+   *  same whichever way the reader moves. */
+  function scrollConversation(dy) {
+    var max = Math.max(0, flick.contentHeight - flick.height)
+    flick.contentY = Math.max(0, Math.min(max, flick.contentY + dy))
+    flick.stick = flick.contentY >= max - 4
+  }
+  /** Pixels a key moves the conversation from the compose field, 0 = not a
+   *  scroll key. PageUp/PageDown always page; Home/End only while the field
+   *  is empty — with text typed they keep moving the caret. */
+  function conversationStep(key, fieldEmpty) {
+    if (key === Qt.Key_PageUp) return -flick.height * 0.9
+    if (key === Qt.Key_PageDown) return flick.height * 0.9
+    if (!fieldEmpty) return 0
+    if (key === Qt.Key_Home) return -flick.contentHeight
+    if (key === Qt.Key_End) return flick.contentHeight
+    return 0
+  }
+  /** Up/Down in an empty compose field walk the bubbles, newest first, and
+   *  keep the selected one in view. Down past the newest drops the selection
+   *  and re-sticks to the bottom, so the conversation follows new messages
+   *  again — the reader is back where they started. */
+  function moveBubbleCursor(dy) {
+    var n = bubbles.length
+    if (n === 0) return
+    if (bubbleCursor < 0) {
+      if (dy > 0) return
+      bubbleCursor = n - 1
+    } else if (dy > 0 && bubbleCursor >= n - 1) {
+      leaveBubbles()
+      return
+    } else {
+      bubbleCursor = Math.max(0, bubbleCursor + dy)
+    }
+    var it = bubbleCursorItem   // set synchronously by the row's hasCursor binding
+    if (!it) return
+    var margin = Style.space(6)
+    if (it.y < flick.contentY + margin)
+      scrollConversation(it.y - margin - flick.contentY)
+    else if (it.y + it.height > flick.contentY + flick.height - margin)
+      scrollConversation(it.y + it.height + margin - flick.height - flick.contentY)
+  }
+  function clearBubbleCursor() { bubbleCursor = -1; bubbleCursorItem = null }
+  /** Out of the selection and back where reading started: newest at the
+   *  bottom, stick re-armed. Down past the newest and Esc both land here. */
+  function leaveBubbles() {
+    clearBubbleCursor()
+    scrollConversation(flick.contentHeight)
+  }
   function markAllRead() {
     if (!root.hostWidget || root.unread === 0) return
     root.hostWidget.markAllRead()
@@ -2117,15 +2173,27 @@ FocusScope {
             acceptedButtons: Qt.NoButton
             onWheel: function(wheel) {
               var d = wheel.pixelDelta.y !== 0 ? wheel.pixelDelta.y * 3.0 : wheel.angleDelta.y * 4.5
-              var max = Math.max(0, flick.contentHeight - flick.height)
-              flick.contentY = Math.max(0, Math.min(max, flick.contentY - d))
-              // the wheel bypasses Flickable movement signals — maintain the
-              // bottom-stick here too
-              flick.stick = flick.contentY >= max - 4
+              // the wheel bypasses Flickable movement signals — the helper
+              // maintains the bottom-stick too
+              root.scrollConversation(-d)
               wheel.accepted = true
             }
           }
 
+          // The bubble cursor: one translucent band behind the selected row,
+          // the list rows' fill. A sibling of `content`, not a child of the
+          // layout, so no delegate carries a background of its own; the row's
+          // y/height are in `content` space, which sits at the origin here.
+          Rectangle {
+            visible: root.bubbleCursorItem !== null
+            width: content.width
+            y: root.bubbleCursorItem ? root.bubbleCursorItem.y - Style.space(2) : 0
+            height: root.bubbleCursorItem ? root.bubbleCursorItem.height + Style.space(4) : 0
+            radius: Style.cornerRadius
+            // Omarchy's cursor fill: the theme's hover-cursor colour and alpha
+            // (foreground at 0.08 by default), not a hard-coded copy of them.
+            color: Style.hoverFillFor(root.foreground, root.accent)
+          }
           ColumnLayout {
             id: content
             width: parent.width
@@ -2147,7 +2215,10 @@ FocusScope {
               delegate: ColumnLayout {
                 id: bubbleRow
                 required property var modelData
+                required property int index
                 readonly property bool mine: modelData.from_me === true
+                readonly property bool hasCursor: root.bubbleCursor === index
+                onHasCursorChanged: if (hasCursor) root.bubbleCursorItem = bubbleRow
 
                 Layout.fillWidth: true
                 spacing: Style.space(2)
@@ -2732,7 +2803,9 @@ FocusScope {
                 borderSpec: composeField._composeBorder
                 radius: Style.cornerRadius
               }
-              Keys.onEscapePressed: root.back()
+              // Esc drops a bubble selection first (back to the bottom), then
+              // leaves the thread — the two-step Esc a text selection gets.
+              Keys.onEscapePressed: if (root.bubbleCursor >= 0) root.leaveBubbles(); else root.back()
               // Ctrl+V goes through paste.ts: an image on the clipboard becomes
               // a draft chip; text falls through to a manual insert. One process
               // snapshots types AND data — probing then re-reading races.
@@ -2741,6 +2814,21 @@ FocusScope {
                 if (event.matches(StandardKey.Paste)) {
                   event.accepted = true
                   root.startPaste()
+                  return
+                }
+                // Reading history without the mouse: the compose field is the
+                // thread's focus holder, so the keys live here. An empty field
+                // has no caret for Up/Down to move; they select bubbles instead.
+                var empty = text.length === 0
+                if (empty && (event.key === Qt.Key_Up || event.key === Qt.Key_Down)) {
+                  event.accepted = true
+                  root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)
+                  return
+                }
+                var dy = root.conversationStep(event.key, empty)
+                if (dy !== 0) {
+                  event.accepted = true
+                  root.scrollConversation(dy)
                   return
                 }
                 if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter)

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -453,6 +453,24 @@ FocusScope {
       scrollConversation(it.y + it.height + margin - flick.height - flick.contentY)
   }
   function clearBubbleCursor() { bubbleCursor = -1; bubbleCursorItem = null }
+  function selectedBubble() {
+    return bubbleCursor >= 0 && bubbleCursor < bubbles.length ? bubbles[bubbleCursor] : null
+  }
+  /** Enter on the selected bubble: its first attachment, else its link card,
+   *  else the first URL in its text — the same handlers a click reaches. */
+  function openBubble(b) {
+    if (b.attachments && b.attachments.length > 0) { openAttachment(b.attachments[0]); return }
+    var u = b.link && b.link.url ? String(b.link.url) : firstUrl(b.text)
+    if (u !== "") openLink(u)
+  }
+  /** Ctrl+R: quote the selected bubble into the compose field. iMessage's
+   *  inline reply is not reachable through the bridge (no message GUID leaves
+   *  the Mac and AppleScript has no reply-to), so this is a plain "> quote". */
+  function quoteBubble(b) {
+    composeField.text = "> " + String(b.text || "").replace(/\s+/g, " ").slice(0, 200) + "\n"
+    composeField.cursorPosition = composeField.length
+    leaveBubbles()
+  }
   /** Out of the selection and back where reading started: newest at the
    *  bottom, stick re-armed. Down past the newest and Esc both land here. */
   function leaveBubbles() {
@@ -2824,6 +2842,14 @@ FocusScope {
                   event.accepted = true
                   root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)
                   return
+                }
+                // Actions on the selected bubble. Enter is free here: with no
+                // text and no queued file, send() would do nothing anyway.
+                var b = empty && root.draftPath === "" ? root.selectedBubble() : null
+                if (b) {
+                  if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { event.accepted = true; root.openBubble(b); return }
+                  if (event.matches(StandardKey.Copy)) { event.accepted = true; root.copyText(String(b.text || "")); return }
+                  if (event.key === Qt.Key_R && (event.modifiers & Qt.ControlModifier)) { event.accepted = true; root.quoteBubble(b); return }
                 }
                 var dy = root.conversationStep(event.key, empty)
                 if (dy !== 0) {

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -453,6 +453,12 @@ FocusScope {
       scrollConversation(it.y + it.height + margin - flick.height - flick.contentY)
   }
   function clearBubbleCursor() { bubbleCursor = -1; bubbleCursorItem = null }
+  /** Out of the selection and back where reading started: newest at the
+   *  bottom, stick re-armed. Down past the newest and Esc both land here. */
+  function leaveBubbles() {
+    clearBubbleCursor()
+    scrollConversation(flick.contentHeight)
+  }
   function selectedBubble() {
     return bubbleCursor >= 0 && bubbleCursor < bubbles.length ? bubbles[bubbleCursor] : null
   }
@@ -463,6 +469,16 @@ FocusScope {
     var u = b.link && b.link.url ? String(b.link.url) : firstUrl(b.text)
     if (u !== "") openLink(u)
   }
+  /** Ctrl+C on the selected bubble: its text, or — for a bubble that is only
+   *  a picture — the first image attachment, as an image. */
+  function copyBubble(b) {
+    var t = String(b.text || "")
+    if (t !== "") { copyText(t); return }
+    var atts = b.attachments || []
+    for (var i = 0; i < atts.length; i++) {
+      if (isImageMime(atts[i].mime)) { copyAttachment(atts[i]); return }
+    }
+  }
   /** Ctrl+R: quote the selected bubble into the compose field. iMessage's
    *  inline reply is not reachable through the bridge (no message GUID leaves
    *  the Mac and AppleScript has no reply-to), so this is a plain "> quote". */
@@ -470,12 +486,6 @@ FocusScope {
     composeField.text = "> " + String(b.text || "").replace(/\s+/g, " ").slice(0, 200) + "\n"
     composeField.cursorPosition = composeField.length
     leaveBubbles()
-  }
-  /** Out of the selection and back where reading started: newest at the
-   *  bottom, stick re-armed. Down past the newest and Esc both land here. */
-  function leaveBubbles() {
-    clearBubbleCursor()
-    scrollConversation(flick.contentHeight)
   }
   function markAllRead() {
     if (!root.hostWidget || root.unread === 0) return
@@ -623,29 +633,31 @@ FocusScope {
            m === "application/pdf" || m === "text/plain" || m === "text/vcard" || m === "text/calendar"
   }
 
-  function enqueueFetch(att, openWhenDone, auto) {
+  /** action: "" = just cache it, "open" = xdg-open when it lands, "copy" =
+   *  put it on the clipboard when it lands. */
+  function enqueueFetch(att, action, auto) {
     var id = String(att.id || "")
     if (id === "" || fetchingId === id) return
-    if (attFiles[id] !== undefined && !openWhenDone) return
+    if (attFiles[id] !== undefined && !action) return
     for (var i = 0; i < fetchQueue.length; i++) {
       if (fetchQueue[i].id === id) {
-        if (openWhenDone) fetchQueue[i].open = true
+        if (action) fetchQueue[i].action = action
         return
       }
     }
     fetchQueue.push({ id: id, name: String(att.name || "file"),
-                      mime: String(att.mime || ""), open: openWhenDone === true,
+                      mime: String(att.mime || ""), action: action || "",
                       auto: auto === true })
     pumpFetch()
   }
 
-  property bool fetchJobOpen: false
+  property string fetchJobAction: ""
   property string fetchJobMime: ""
   function pumpFetch() {
     if (fetchProc.running || fetchQueue.length === 0) return
     var job = fetchQueue.shift()
     fetchingId = job.id
-    fetchJobOpen = job.open === true
+    fetchJobAction = job.action
     fetchJobMime = job.mime
     // Auto-pulls carry a hard transfer cap: claimed metadata is not the limit.
     fetchProc.command = ["bun", root.fetchScript, job.id, job.name, job.mime, job.auto ? "5242880" : ""]
@@ -670,11 +682,11 @@ FocusScope {
         // iPhone photos were rejected at both ends and simply never appeared.
         var b = atts[j].bytes
         if (isImageMime(atts[j].mime) && typeof b === "number" && b > 0 && b <= root.autoFetchMaxSource)
-          enqueueFetch(atts[j], false, true)
+          enqueueFetch(atts[j], "", true)
       }
       // link-card preview PNGs are small; the auto-fetch transfer cap bounds them
       var l = bubbles[i].link
-      if (l && l.image_id) enqueueFetch({ id: String(l.image_id), name: "preview.png", mime: "image/png", bytes: 0 }, false, true)
+      if (l && l.image_id) enqueueFetch({ id: String(l.image_id), name: "preview.png", mime: "image/png", bytes: 0 }, "", true)
     }
   }
 
@@ -687,7 +699,13 @@ FocusScope {
     if (attFiles[id] === "") {   // failed marker — clear it so a retry runs
       var m = Object.assign({}, attFiles); delete m[id]; attFiles = m
     }
-    enqueueFetch(att, true)
+    enqueueFetch(att, "open")
+  }
+  /** Ctrl+C on an image bubble: fetch-then-clipboard, the same round trip as
+   *  a click, ending in wl-copy with the image's own MIME type. */
+  function copyAttachment(att) {
+    if (String(att.id || "") === "") return
+    enqueueFetch(att, "copy")
   }
 
   // ------------------------------------------------------ compose attachment
@@ -1197,8 +1215,12 @@ FocusScope {
         var id = root.fetchingId
         try {
           var d = JSON.parse(text.trim())
+          // A copy fetches the ORIGINAL for the clipboard; the bubble keeps
+          // the preview it already draws. Swapping its source and metrics
+          // re-decodes and re-lays out the picture under the reader's eyes.
+          var keepInline = root.fetchJobAction === "copy" && !!root.attFiles[id]
           var m = Object.assign({}, root.attFiles)
-          m[id] = d.ok === true ? String(d.url || "") : ""
+          if (!keepInline) m[id] = d.ok === true ? String(d.url || "") : ""
           root.attFiles = m
           var ratio = Number(d.pixelRatio)
           var pixelWidth = Number(d.pixelWidth)
@@ -1206,10 +1228,20 @@ FocusScope {
           if (!isFinite(ratio) || ratio < 1 || ratio > 4) ratio = 1
           if (!isFinite(pixelWidth) || pixelWidth < 1 || pixelWidth > 100000) pixelWidth = 0
           if (!isFinite(pixelHeight) || pixelHeight < 1 || pixelHeight > 100000) pixelHeight = 0
-          var metrics = Object.assign({}, root.attMetrics)
-          metrics[id] = { pixelRatio: ratio, pixelWidth: pixelWidth, pixelHeight: pixelHeight }
-          root.attMetrics = metrics
-          if (d.ok === true && root.fetchJobOpen) {
+          if (!keepInline) {
+            var metrics = Object.assign({}, root.attMetrics)
+            metrics[id] = { pixelRatio: ratio, pixelWidth: pixelWidth, pixelHeight: pixelHeight }
+            root.attMetrics = metrics
+          }
+          if (d.ok === true && root.fetchJobAction === "copy") {
+            // The Mac converts HEIC/HEIF to JPEG on the way (fetch.ts wantsJpeg),
+            // so the clipboard type must say what the bytes are. Path and type
+            // travel as arguments, never interpolated into the script.
+            var mime = root.fetchJobMime === "image/heic" || root.fetchJobMime === "image/heif" ? "image/jpeg" : root.fetchJobMime
+            Quickshell.execDetached(["sh", "-c", 'wl-copy --type "$1" < "$2"', "sh", mime, String(d.path || "")])
+            root.note = "copied"
+            noteTimer.restart()
+          } else if (d.ok === true && root.fetchJobAction === "open") {
             if (root.openableMime(root.fetchJobMime)) {
               Quickshell.execDetached(["xdg-open", String(d.url || "")])
             } else {
@@ -2848,7 +2880,7 @@ FocusScope {
                 var b = empty && root.draftPath === "" ? root.selectedBubble() : null
                 if (b) {
                   if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { event.accepted = true; root.openBubble(b); return }
-                  if (event.matches(StandardKey.Copy)) { event.accepted = true; root.copyText(String(b.text || "")); return }
+                  if (event.matches(StandardKey.Copy)) { event.accepted = true; root.copyBubble(b); return }
                   if (event.key === Qt.Key_R && (event.modifiers & Qt.ControlModifier)) { event.accepted = true; root.quoteBubble(b); return }
                 }
                 var dy = root.conversationStep(event.key, empty)

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -183,11 +183,38 @@ FocusScope {
   /** Open the share sheet for one http(s) URL. Anything else is ignored. The
    *  URL is message content: it reaches qrencode and the LocalSend temp file
    *  on STDIN, never argv (CLAUDE.md: message text never rides argv). */
-  function openShare(u) {
-    u = String(u || "")
-    if (!/^https?:\/\//i.test(u)) return
-    shareUrl = u
+  property var shareUrls: []       // the links the sheet was opened on
+  property int shareIndex: 0       // which of them it shows; ←/→ and ‹ › step
+  property int shareCursor: 0      // highlighted action (mouse and keys agree)
+  property real shareKeysFrom: 0   // Enter and digits act from this time on
+  /** Open the sheet on one URL or a list (a message's links, first showing).
+   *  `auto`: it opened by itself — a link you sent, a link that arrived, IPC.
+   *  The sheet is the warning either way (host, full URL, a button that says
+   *  what Enter does), but for 700 ms after an auto sheet appears Enter and
+   *  digits still belong to the draft, so a link landing as Enter is pressed
+   *  to send is never opened by it. False when nothing in `u` is http(s). */
+  function openShare(u, auto) {
+    var urls = (Array.isArray(u) ? u : [u]).map(function(x) { return String(x || "") })
+      .filter(function(x) { return /^https?:\/\//i.test(x) })
+    if (urls.length === 0) return false
+    shareUrls = urls
+    shareIndex = 0
+    shareCursor = 0
+    shareKeysFrom = Date.now() + (auto === true ? 700 : 0)
     shareQr = ""
+    showShareUrl(urls[0])
+    return true
+  }
+  function shareStep(d) {
+    var n = shareUrls.length
+    if (n < 2) return
+    shareIndex = (shareIndex + d + n) % n
+    showShareUrl(shareUrls[shareIndex])
+  }
+  /** The QR for `u`. The box keeps the previous code until this one is
+   *  written, so stepping swaps the image instead of re-flowing the card. */
+  function showShareUrl(u) {
+    shareUrl = u
     var out = shareDir + "/qr-" + Date.now() + ".png"
     qrProc.outFile = out
     qrProc.command = ["sh", "-c", 'mkdir -p "$1" && chmod 700 "$1" && umask 077 && exec qrencode -o "$2" -s 6 -m 2 -l M', "blip", shareDir, out]
@@ -196,18 +223,29 @@ FocusScope {
     qrProc.write(u)
     qrProc.stdinEnabled = false
   }
-  function closeShare() { shareUrl = ""; shareQr = "" }
+  function closeShare() { shareUrl = ""; shareQr = ""; shareUrls = [] }
   /** First http(s) URL in a string, or "" — mirrors collector.firstUrl. */
   function firstUrl(t) {
     var m = /https?:\/\/[^\s<>"']+/i.exec(String(t || ""))
     return m ? m[0].replace(/[.,;:!?)\]}'"]+$/, "") : ""
   }
-  /** IPC `share <url>` (host gates it behind automation=on). */
+  /** Every link in a message, in order, exactly as linkify() anchors them
+   *  (same pattern, same trailing-punctuation rule, www. gets https://). */
+  function allUrls(t) {
+    var re = /\bhttps?:\/\/[^\s<>"']+|\bwww\.[^\s<>"']+\.[^\s<>"']+/gi, out = [], m
+    while ((m = re.exec(String(t || ""))) !== null) {
+      var u = m[0].replace(/[.,;:!?\]]+$/, "")
+      while (u.endsWith(")") && u.split("(").length < u.split(")").length) u = u.slice(0, -1)
+      u = u.replace(/[.,;:!?\]]+$/, "")
+      if (/^www\./i.test(u)) u = "https://" + u
+      if (out.indexOf(u) < 0) out.push(u)
+    }
+    return out
+  }
+  /** IPC `share <url>` (host gates it behind automation=on), and the host's
+   *  arriving-link path, which hands over every link of the message. */
   function shareLink(u) {
-    u = String(u || "")
-    if (!/^https?:\/\//i.test(u)) return "not an http(s) url"
-    openShare(u)
-    return "share sheet"
+    return openShare(u, true) ? "share sheet" : "not an http(s) url"
   }
   /** The full app window. The host owns creation (Quickshell never re-maps a
    *  hidden FloatingWindow), so this asks the widget, exactly like SUPER+M.
@@ -218,6 +256,23 @@ FocusScope {
     if (!hostWidget) return
     if (typeof hostWidget.close === "function") hostWidget.close()
     if (typeof hostWidget.showApp === "function") hostWidget.showApp()
+  }
+  /** The sheet's keys: Esc closes, ←/→ step links, ↑/↓ move the highlight,
+   *  Enter takes it, 1/2/3 pick directly. Anything else falls through to the
+   *  field (a sheet over a draft never blocks typing); see openShare for
+   *  the grace on an auto sheet. True when the key was the sheet's. */
+  function shareKey(key) {
+    if (shareUrl === "") return false
+    var acts = [shareOpen, shareCopy, shareSend]
+    if (key === Qt.Key_Escape) { closeShare(); return true }
+    // ←/→ are the sheet's only when there is something to step through; a
+    // draft keeps its caret keys otherwise.
+    if ((key === Qt.Key_Left || key === Qt.Key_Right) && shareUrls.length > 1) { shareStep(key === Qt.Key_Right ? 1 : -1); return true }
+    if (key === Qt.Key_Up || key === Qt.Key_Down) { shareCursor = Math.max(0, Math.min(2, shareCursor + (key === Qt.Key_Down ? 1 : -1))); return true }
+    if (Date.now() < shareKeysFrom) return false
+    if (key === Qt.Key_Return || key === Qt.Key_Enter) { acts[shareCursor](); return true }
+    if (key >= Qt.Key_1 && key <= Qt.Key_3) { acts[key - Qt.Key_1](); return true }
+    return false
   }
   function shareOpen() { var u = shareUrl; closeShare(); openLink(u) }
   function shareCopy() { var u = shareUrl; closeShare(); copyText(u) }
@@ -495,8 +550,11 @@ FocusScope {
    *  else the first URL in its text — the same handlers a click reaches. */
   function openBubble(b) {
     if (b.attachments && b.attachments.length > 0) { openAttachment(b.attachments[0]); return }
-    var u = b.link && b.link.url ? String(b.link.url) : firstUrl(b.text)
-    if (u !== "") openLink(u)
+    // A link goes to the share sheet, not straight to the browser: the sheet
+    // shows the host and the URL and makes opening a deliberate second step.
+    var urls = allUrls(b.text)
+    if (b.link && b.link.url && urls.indexOf(String(b.link.url)) < 0) urls.unshift(String(b.link.url))
+    openShare(urls, false)
   }
   /** Ctrl+C on the selected bubble: its text, or — for a bubble that is only
    *  a picture — the first image attachment, as an image. */
@@ -1218,8 +1276,8 @@ FocusScope {
       if (code === 0) {
         // A URL you just SHARED opens the sheet too (Fred, 2.3.0): send it,
         // then offer the QR / LocalSend / copy for the same link.
-        var sentUrl = root.firstUrl(completedText)
-        if (belongsHere && sentUrl !== "") Qt.callLater(function() { root.openShare(sentUrl) })
+        var sentUrls = root.allUrls(completedText)
+        if (belongsHere && sentUrls.length > 0) Qt.callLater(function() { root.openShare(sentUrls, true) })
         if (belongsHere) {
           root.note = ""
           // Never erase a newer draft typed after this send began.
@@ -2885,12 +2943,13 @@ FocusScope {
               }
               // Esc drops a bubble selection first (back to the bottom), then
               // leaves the thread — the two-step Esc a text selection gets.
-              Keys.onEscapePressed: if (root.bubbleCursor >= 0) root.leaveBubbles(); else root.back()
+              Keys.onEscapePressed: if (root.shareUrl !== "") root.closeShare(); else if (root.bubbleCursor >= 0) root.leaveBubbles(); else root.back()
               // Ctrl+V goes through paste.ts: an image on the clipboard becomes
               // a draft chip; text falls through to a manual insert. One process
               // snapshots types AND data — probing then re-reading races.
               // Enter sends (iMessage); Shift+Enter inserts a newline.
               Keys.onPressed: (event) => {
+                if (root.shareKey(event.key)) { event.accepted = true; return }
                 if (event.matches(StandardKey.Paste)) {
                   event.accepted = true
                   root.startPaste()
@@ -3020,7 +3079,9 @@ FocusScope {
     Rectangle {
       anchors.fill: parent
       color: Qt.rgba(0, 0, 0, 0.45)
-      TapHandler { onTapped: root.closeShare() }
+      // ReleaseWithinBounds takes an exclusive grab on press: the tap ends
+      // here instead of also reaching the row, bubble or link underneath.
+      TapHandler { gesturePolicy: TapHandler.ReleaseWithinBounds; onTapped: root.closeShare() }
     }
     Rectangle {
       id: shareCard
@@ -3031,17 +3092,33 @@ FocusScope {
       color: Color.background
       border.color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
       border.width: 1
-      TapHandler { }   // swallow clicks on the card so they never reach the scrim
+      TapHandler { gesturePolicy: TapHandler.ReleaseWithinBounds }   // clicks on the card stop here
       ColumnLayout {
         id: shareCol
         anchors.left: parent.left; anchors.right: parent.right; anchors.top: parent.top
         anchors.margins: Style.space(14)
         spacing: Style.space(8)
-        Text {
+        RowLayout {
           Layout.fillWidth: true
-          text: "SHARE LINK"
-          color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.6)
-          font.family: root.fontFamily; font.pixelSize: root.fontCaption; font.letterSpacing: 1
+          spacing: Style.space(10)
+          Text {
+            Layout.fillWidth: true
+            text: "SHARE LINK" + (root.shareUrls.length > 1 ? "  ·  " + (root.shareIndex + 1) + " of " + root.shareUrls.length : "")
+            color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.6)
+            font.family: root.fontFamily; font.pixelSize: root.fontCaption; font.letterSpacing: 1
+          }
+          // ‹ › step through the message's links (the keyboard's ←/→)
+          Repeater {
+            model: root.shareUrls.length > 1 ? [-1, 1] : []
+            delegate: Text {
+              required property var modelData
+              text: modelData < 0 ? "‹" : "›"
+              color: root.foreground
+              font.family: root.fontFamily; font.pixelSize: root.fontBody; font.bold: true
+              HoverHandler { cursorShape: Qt.PointingHandCursor }
+              TapHandler { gesturePolicy: TapHandler.ReleaseWithinBounds; onTapped: root.shareStep(modelData) }
+            }
+          }
         }
         Text {
           Layout.fillWidth: true
@@ -3065,7 +3142,8 @@ FocusScope {
           width: Style.space(176); height: width
           radius: Style.cornerRadius
           color: "white"
-          visible: root.shareQr !== ""
+          // shown while a code is being made too; hidden only when qrencode failed
+          visible: root.shareQr !== "" || qrProc.running
           Image {
             anchors.fill: parent; anchors.margins: Style.space(8)
             source: root.shareQr
@@ -3082,10 +3160,11 @@ FocusScope {
           ]
           delegate: Rectangle {
             required property var modelData
+            required property int index
             Layout.fillWidth: true
             height: Style.space(40)
             radius: Style.cornerRadius
-            color: shareHover.hovered
+            color: shareHover.hovered || index === root.shareCursor
               ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
               : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.06)
             Text {
@@ -3094,8 +3173,9 @@ FocusScope {
               color: root.foreground
               font.family: root.fontFamily; font.pixelSize: root.fontBodySmall
             }
-            HoverHandler { id: shareHover; cursorShape: Qt.PointingHandCursor }
+            HoverHandler { id: shareHover; cursorShape: Qt.PointingHandCursor; onHoveredChanged: if (hovered) root.shareCursor = index }
             TapHandler {
+              gesturePolicy: TapHandler.ReleaseWithinBounds
               onTapped: {
                 if (modelData.act === "open") root.shareOpen()
                 else if (modelData.act === "copy") root.shareCopy()
@@ -3107,7 +3187,7 @@ FocusScope {
         Text {
           Layout.fillWidth: true
           horizontalAlignment: Text.AlignHCenter
-          text: "Esc closes"
+          text: (root.shareUrls.length > 1 ? "← → link  ·  " : "") + "1–3 or ↑↓ Enter  ·  Esc closes"
           color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.45)
           font.family: root.fontFamily; font.pixelSize: root.fontCaption
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Read history from the keyboard.** In a conversation, `↑`/`↓` with an empty
+  compose field select a bubble — newest first, kept in view, drawn with the
+  list rows' fill — and `↓` past the newest or `Esc` drops the selection and
+  returns to the bottom;
+  `PgUp`/`PgDn` page, `Home`/`End` jump to the ends. The mouse wheel and the
+  keys share one helper, so the bottom-stick that gates the deferred push
+  reload behaves the same either way. With text typed the arrows and Home/End
+  keep moving the caret. The selection is the target for keyboard actions to
+  come (copy, open, reply).
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
   keys share one helper, so the bottom-stick that gates the deferred push
   reload behaves the same either way. With text typed the arrows and Home/End
   keep moving the caret. On the selected bubble, `Enter` opens its attachment
-  or link, `Ctrl+C` copies its text and `Ctrl+R` quotes it into the compose
-  field as `> …` — iMessage's inline reply is not reachable through the
-  bridge, so the quote is a plain one.
+  or link, `Ctrl+C` copies its text — or the picture itself, with its own
+  MIME type, when the bubble is only a picture — and `Ctrl+R` quotes it into
+  the compose field as `> …`; iMessage's inline reply is not reachable
+  through the bridge, so the quote is a plain one.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
   or link, `Ctrl+C` copies its text — or the picture itself, with its own
   MIME type, when the bubble is only a picture — and `Ctrl+R` quotes it into
   the compose field as `> …`; iMessage's inline reply is not reachable
-  through the bridge, so the quote is a plain one.
+  through the bridge, so the quote is a plain one. The status line under the
+  compose box keeps its height when empty, so "copied" and "sending…" no
+  longer shove the conversation, and only failures are red.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
   `PgUp`/`PgDn` page, `Home`/`End` jump to the ends. The mouse wheel and the
   keys share one helper, so the bottom-stick that gates the deferred push
   reload behaves the same either way. With text typed the arrows and Home/End
-  keep moving the caret. The selection is the target for keyboard actions to
-  come (copy, open, reply).
+  keep moving the caret. On the selected bubble, `Enter` opens its attachment
+  or link, `Ctrl+C` copies its text and `Ctrl+R` quotes it into the compose
+  field as `> …` — iMessage's inline reply is not reachable through the
+  bridge, so the quote is a plain one.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 ## Unreleased
 
-- **Read history from the keyboard.** In a conversation, `↑`/`↓` with an empty
-  compose field select a bubble — newest first, kept in view, drawn with the
+- **Read history from the keyboard.** In a conversation, `↑`/`↓` from an empty
+  compose field — or from the first / last line of a draft — select a bubble:
+  newest first, kept in view, drawn with the
   list rows' fill — and `↓` past the newest or `Esc` drops the selection and
-  returns to the bottom;
-  `PgUp`/`PgDn` page, `Home`/`End` jump to the ends. The mouse wheel and the
+  returns to the bottom; `PgUp`/`PgDn` select the topmost or bottommost visible
+  bubble and then move a screen per press, with text in the compose field too
+  (`Shift+PgUp`/`Shift+PgDn` for one bubble at a time);
+  `Home`/`End` select the oldest and newest bubble (from a draft, once the
+  caret sits at its line's edge). The mouse wheel and the
   keys share one helper, so the bottom-stick that gates the deferred push
   reload behaves the same either way. With text typed the arrows and Home/End
-  keep moving the caret. On the selected bubble, `Enter` opens its attachment
+  keep moving the caret inside the draft. On the selected bubble, `Enter` opens its attachment
   or link, `Ctrl+C` copies its text — or the picture itself, with its own
   MIME type, when the bubble is only a picture — and `Ctrl+R` quotes it into
   the compose field as `> …`; iMessage's inline reply is not reachable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@
   the compose field as `> …`; iMessage's inline reply is not reachable
   through the bridge, so the quote is a plain one. The status line under the
   compose box keeps its height when empty, so "copied" and "sending…" no
-  longer shove the conversation, and only failures are red.
+  longer shove the conversation, and only failures are red. Enter on a link
+  opens the share sheet, not the browser: the sheet names the host, and it
+  takes the keyboard (1–3, arrows, Enter). A sheet that opened by itself waits
+  a moment before Enter counts, so an Enter meant to send never opens the link
+  that just landed. A message with several links offers them all, whether
+  sent, received or opened with Enter, and ←/→ step through them.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,10 @@ what it is handed. Keep it that way.
   without logging: async image growth ABOVE the viewport cancels wheel motion
   (chipRow compensates contentY by its own height delta), and model
   reassignment rebuilds Repeaters and resets scroll (skip identical
-  assignments; restore contentY after a list rebuild).
+  assignments; restore contentY after a list rebuild). Every writer of the
+  conversation's `contentY` — wheel, arrows, paging, Esc — goes through
+  `scrollConversation()`, the one owner of the bottom-stick that gates the
+  deferred push reload.
 - **The app window is RECREATED on show, never re-mapped.** Quickshell does
   not re-map a `FloatingWindow` after `visible` has been false once: the
   property flips true, no client appears (SUPER+M "did nothing", 1.8.3).

--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ rather than hang:
 | thread | `Ctrl+V` | paste — an image on the clipboard becomes a queued file, text pastes normally |
 | thread | `/attach <path>` + `Enter` | queue any file on this machine; drag-and-drop works too |
 | thread | `↑` / `↓` (empty compose) | select a bubble, newest first, and keep it in view; `↓` past the newest or `Esc` drops the selection and returns to the bottom |
+| thread | `Enter` · `Ctrl+C` · `Ctrl+R` (bubble selected) | open its attachment or link · copy its text · quote it into the compose field (`> …`) |
 | thread | `PgUp` / `PgDn` · `Home` / `End` (empty compose) | page through history · jump to the ends; with text typed the arrows and Home/End move the caret |
 | thread | `Esc` | back to list (or clear a text selection first) |
 | anywhere | `Esc` | close |

--- a/README.md
+++ b/README.md
@@ -486,6 +486,8 @@ rather than hang:
 | thread | `Enter` | send (text, or the queued file with the text as caption) |
 | thread | `Ctrl+V` | paste — an image on the clipboard becomes a queued file, text pastes normally |
 | thread | `/attach <path>` + `Enter` | queue any file on this machine; drag-and-drop works too |
+| thread | `↑` / `↓` (empty compose) | select a bubble, newest first, and keep it in view; `↓` past the newest or `Esc` drops the selection and returns to the bottom |
+| thread | `PgUp` / `PgDn` · `Home` / `End` (empty compose) | page through history · jump to the ends; with text typed the arrows and Home/End move the caret |
 | thread | `Esc` | back to list (or clear a text selection first) |
 | anywhere | `Esc` | close |
 

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ rather than hang:
 | thread | `Ctrl+V` | paste — an image on the clipboard becomes a queued file, text pastes normally |
 | thread | `/attach <path>` + `Enter` | queue any file on this machine; drag-and-drop works too |
 | thread | `↑` / `↓` (empty compose) | select a bubble, newest first, and keep it in view; `↓` past the newest or `Esc` drops the selection and returns to the bottom |
-| thread | `Enter` · `Ctrl+C` · `Ctrl+R` (bubble selected) | open its attachment or link · copy its text · quote it into the compose field (`> …`) |
+| thread | `Enter` · `Ctrl+C` · `Ctrl+R` (bubble selected) | open its attachment or link · copy its text, or the picture itself when the bubble is only a picture · quote it into the compose field (`> …`) |
 | thread | `PgUp` / `PgDn` · `Home` / `End` (empty compose) | page through history · jump to the ends; with text typed the arrows and Home/End move the caret |
 | thread | `Esc` | back to list (or clear a text selection first) |
 | anywhere | `Esc` | close |

--- a/README.md
+++ b/README.md
@@ -486,9 +486,11 @@ rather than hang:
 | thread | `Enter` | send (text, or the queued file with the text as caption) |
 | thread | `Ctrl+V` | paste — an image on the clipboard becomes a queued file, text pastes normally |
 | thread | `/attach <path>` + `Enter` | queue any file on this machine; drag-and-drop works too |
-| thread | `↑` / `↓` (empty compose) | select a bubble, newest first, and keep it in view; `↓` past the newest or `Esc` drops the selection and returns to the bottom |
+| thread | `↑` / `↓` | select a bubble, newest first, and keep it in view — from an empty compose field, or from the first / last line of a draft; `↓` past the newest or `Esc` drops the selection and returns to the bottom |
 | thread | `Enter` · `Ctrl+C` · `Ctrl+R` (bubble selected) | open its attachment or link · copy its text, or the picture itself when the bubble is only a picture · quote it into the compose field (`> …`) |
-| thread | `PgUp` / `PgDn` · `Home` / `End` (empty compose) | page through history · jump to the ends; with text typed the arrows and Home/End move the caret |
+| thread | `PgUp` / `PgDn` (Fn+`↑`/`↓` on a Mac keyboard) | select the topmost / bottommost visible bubble, then a screen further each press — also with text in the compose field, since they move no caret |
+| thread | `Shift+PgUp` / `Shift+PgDn` | one bubble at a time from anywhere in a draft, without moving the caret first |
+| thread | `Home` / `End` | select the oldest / newest bubble — from an empty compose field, or once the caret already sits at the start / end of its line |
 | thread | `Esc` | back to list (or clear a text selection first) |
 | anywhere | `Esc` | close |
 

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -794,6 +794,14 @@ describe("a link that just arrived opens the share sheet", () => {
     expect(out.every((l) => l.key.startsWith("link:"))).toBe(true);
   });
 
+  test("every link of a message rides along; url stays the first", () => {
+    const out = selectIncomingLinks([
+      msg({ ts: "2026-09-02 12:30:00", from_me: false, text: "two: https://a.test/1, and https://b.test/2." }),
+    ], WM, []);
+    expect(out[0]!.url).toBe("https://a.test/1");
+    expect(out[0]!.urls).toEqual(["https://a.test/1", "https://b.test/2"]);
+  });
+
   test("a link fires once — its key suppresses the next poll", () => {
     const m = msg({ ts: "2026-09-02 12:30:00", from_me: false, text: "https://a.test/1" });
     const first = selectIncomingLinks([m], WM, []);

--- a/collector.ts
+++ b/collector.ts
@@ -668,9 +668,22 @@ export function firstUrl(text: string | null | undefined): string {
   return m[0].replace(/[.,;:!?)\]}'"]+$/, "");
 }
 
+/** Every http(s) URL in a text, in order, trailing punctuation dropped like firstUrl(). */
+export function allUrls(text: string | null | undefined): string[] {
+  const out: string[] = [];
+  for (const m of String(text ?? "").matchAll(/https?:\/\/[^\s<>"']+/gi)) {
+    const u = m[0].replace(/[.,;:!?)\]}'"]+$/, "");
+    if (u && !out.includes(u)) out.push(u);
+  }
+  return out;
+}
+
 export interface IncomingLink {
   chat: string;
+  /** The first link, `urls[0]`. */
   url: string;
+  /** Every link of the message, first included: the share sheet steps through them. */
+  urls: string[];
   ts: string;
   key: string;
 }
@@ -699,12 +712,13 @@ export function selectIncomingLinks(
     if (m.ts <= watermark) continue;
     const chat = chatKey(m);
     if (self.has(chat)) continue;
-    const url = firstUrl(m.text);
-    if (!url) continue;
+    const urls = allUrls(m.text);
+    if (urls.length === 0) continue;
+    const url = urls[0]!;
     const key = "link:" + toastKey(m);
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push({ chat, url, ts: m.ts, key });
+    out.push({ chat, url, urls, ts: m.ts, key });
   }
   return out.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
 }

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -236,6 +236,10 @@ describe("QML safety invariants", () => {
     expect(panel).toContain('var keepInline = root.fetchJobAction === "copy" && !!root.attFiles[id]');
     expect(panel).not.toContain("fetchJobOpen");
     expect(qmlFunction("quoteBubble")).toContain("leaveBubbles()");
+    // the status line never collapses (no layout shift) and only failures are red
+    expect(panel).toContain('text: root.note === "" ? " " : root.note');
+    expect(panel).not.toContain('visible: root.note !== ""');
+    expect(panel).toContain("color: calm ? root.dim : root.urgent");
   });
 
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -13,6 +13,12 @@ function handleTextKeySource() {
   return panel.slice(start, end);
 }
 
+/** Body of a root-level BlipView function, up to its own closing brace. */
+function qmlFunction(name: string) {
+  const start = panel.indexOf(`function ${name}(`);
+  return panel.slice(start, panel.indexOf("\n  }\n", start));
+}
+
 describe("QML safety invariants", () => {
   test("group sends use the cached AppleScript GUID", () => {
     expect(panel).toContain('["--chat-id", String(root.active.guid)]');
@@ -182,6 +188,34 @@ describe("QML safety invariants", () => {
     expect(panel).toContain("newSearchTimer.restart()");
     expect(panel).not.toContain("forceLayout");
     expect(panel.indexOf("onAccepted: root.acceptNewField()")).toBeGreaterThan(-1);
+  });
+
+  test("keys and wheel scroll the conversation through one stick-aware helper", () => {
+    // Two writers of flick.contentY would drift on the bottom-stick, which
+    // gates the deferred push reload; the wheel handler must go through it.
+    expect(qmlFunction("scrollConversation")).toContain("flick.stick = flick.contentY >= max - 4");
+    expect(panel).toContain("root.scrollConversation(-d)");
+    expect(panel.split("flick.stick = flick.contentY >= max - 4").length - 1).toBe(1);
+    const step = qmlFunction("conversationStep");
+    // paging always; Home/End only when the field is empty (caret otherwise)
+    expect(step.indexOf("Qt.Key_PageDown")).toBeLessThan(step.indexOf("if (!fieldEmpty) return 0"));
+    expect(step.indexOf("if (!fieldEmpty) return 0")).toBeLessThan(step.indexOf("Qt.Key_Home"));
+    expect(panel).toContain("root.conversationStep(event.key, empty)");
+  });
+
+  test("arrows in an empty compose field select bubbles, and the selection clears cleanly", () => {
+    // The selection is a target for actions; it must never outlive the rows
+    // it indexes (a reload renumbers them) and Esc must drop it before leaving.
+    expect(panel).toContain("onBubblesChanged: clearBubbleCursor()");
+    // the band takes the theme's hover-cursor colour/alpha, like Omarchy's own rows
+    expect(panel).toContain("color: Style.hoverFillFor(root.foreground, root.accent)");
+    expect(panel).toContain("onHasCursorChanged: if (hasCursor) root.bubbleCursorItem = bubbleRow");
+    expect(panel).toContain("if (root.bubbleCursor >= 0) root.leaveBubbles(); else root.back()");
+    const move = qmlFunction("moveBubbleCursor");
+    expect(move).toContain("bubbleCursor = n - 1");            // Up from nothing = newest
+    expect(move).toContain("leaveBubbles()");                  // Down past newest = same exit as Esc
+    expect(qmlFunction("leaveBubbles")).toContain("scrollConversation(flick.contentHeight)");
+    expect(panel).toContain("root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)");
   });
 
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -218,6 +218,17 @@ describe("QML safety invariants", () => {
     expect(panel).toContain("root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)");
   });
 
+  test("bubble actions reuse the click handlers and never steal a real send", () => {
+    // Enter/Ctrl+C/Ctrl+R act on the selection only with an empty field and
+    // no queued file — a queued file's Enter is a send, and must stay one.
+    expect(panel).toContain('var b = empty && root.draftPath === "" ? root.selectedBubble() : null');
+    const open = qmlFunction("openBubble");
+    expect(open).toContain("openAttachment(b.attachments[0])");
+    expect(open).toContain("openLink(u)");
+    expect(panel).toContain("root.copyText(String(b.text || \"\"))");
+    expect(qmlFunction("quoteBubble")).toContain("leaveBubbles()");
+  });
+
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {
     // --action=default dies with the notify-send process after eight seconds.
     // The hint is what Omarchy persists, so a row in the notification center

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -225,7 +225,16 @@ describe("QML safety invariants", () => {
     const open = qmlFunction("openBubble");
     expect(open).toContain("openAttachment(b.attachments[0])");
     expect(open).toContain("openLink(u)");
-    expect(panel).toContain("root.copyText(String(b.text || \"\"))");
+    expect(panel).toContain("root.copyBubble(b)");
+    const copy = qmlFunction("copyBubble");
+    expect(copy.indexOf("copyText(t)")).toBeLessThan(copy.indexOf("copyAttachment("));  // text wins
+    // the image reaches wl-copy as an argument, never interpolated into the shell script
+    expect(panel).toContain(`'wl-copy --type "$1" < "$2"', "sh", mime, String(d.path || "")`);
+    // HEIC arrives as JPEG (fetch.ts wantsJpeg): the clipboard type must say so
+    expect(panel).toContain('root.fetchJobMime === "image/heic" || root.fetchJobMime === "image/heif" ? "image/jpeg"');
+    // the inline preview stays put while the original is fetched for the clipboard
+    expect(panel).toContain('var keepInline = root.fetchJobAction === "copy" && !!root.attFiles[id]');
+    expect(panel).not.toContain("fetchJobOpen");
     expect(qmlFunction("quoteBubble")).toContain("leaveBubbles()");
   });
 

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -196,11 +196,19 @@ describe("QML safety invariants", () => {
     expect(qmlFunction("scrollConversation")).toContain("flick.stick = flick.contentY >= max - 4");
     expect(panel).toContain("root.scrollConversation(-d)");
     expect(panel.split("flick.stick = flick.contentY >= max - 4").length - 1).toBe(1);
-    const step = qmlFunction("conversationStep");
-    // paging always; Home/End only when the field is empty (caret otherwise)
-    expect(step.indexOf("Qt.Key_PageDown")).toBeLessThan(step.indexOf("if (!fieldEmpty) return 0"));
-    expect(step.indexOf("if (!fieldEmpty) return 0")).toBeLessThan(step.indexOf("Qt.Key_Home"));
-    expect(panel).toContain("root.conversationStep(event.key, empty)");
+    // Home/End select the ends only from an empty field (caret otherwise)
+    expect(panel).toContain("(event.key === Qt.Key_Home && atLineStart) || (event.key === Qt.Key_End && atLineEnd)");
+    expect(panel).toContain("var atLineStart = empty || cursorPosition === 0");
+    expect(panel).toContain("root.bubbleCursor = event.key === Qt.Key_Home ? 0 : root.bubbles.length - 1");
+    expect(panel).not.toContain("conversationStep");
+    // PgUp/PgDn select the edge bubble regardless of text, and page when already there
+    expect(panel).toContain("if (event.modifiers & Qt.ShiftModifier) root.moveBubbleCursor(dir)");
+    expect(panel).toContain("else root.pageBubbles(dir)");
+    const page = qmlFunction("pageBubbles");
+    expect(page.indexOf("if (edge === bubbleCursor && bubbleCursorItem)")).toBeLessThan(page.indexOf("scrollConversation(dy < 0 ?"));
+    // only a WHOLLY visible row counts as the edge, else a sliver of the row above turns paging into single steps
+    expect(qmlFunction("edgeVisibleBubble")).toContain("it.y >= top - 1 : it.y + it.height <= bottom + 1");
+    expect(page).toContain("leaveBubbles()");
   });
 
   test("arrows in an empty compose field select bubbles, and the selection clears cleanly", () => {
@@ -216,6 +224,10 @@ describe("QML safety invariants", () => {
     expect(move).toContain("leaveBubbles()");                  // Down past newest = same exit as Esc
     expect(qmlFunction("leaveBubbles")).toContain("scrollConversation(flick.contentHeight)");
     expect(panel).toContain("root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)");
+    // the edge rule: Up leaves a draft only from its first line, Down only from
+    // its last and only while a bubble is selected (otherwise the caret keeps it)
+    expect(panel).toContain("var onFirstLine = empty || caret.y < topPadding + caret.height * 0.5");
+    expect(panel).toContain("(event.key === Qt.Key_Down && onLastLine && root.bubbleCursor >= 0)");
   });
 
   test("bubble actions reuse the click handlers and never steal a real send", () => {

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -68,12 +68,14 @@ describe("QML safety invariants", () => {
   test("an arriving link opens the sheet only on a surface already open", () => {
     expect(widget).toContain("function shareArrivingLink(link)");
     expect(widget).toContain("d.links[d.links.length - 1]");          // newest only, never a queue
+    expect(widget).toContain("link.urls.map(String) : [String(link.url)]");   // all of that message's links
     expect(widget).toContain("p.opened === true");                    // panel must already be open
     expect(widget).toContain("root.windowVisible");                   // or the app window
   });
 
   test("a link you SEND opens the sheet too, and the app button asks the host", () => {
-    expect(panel).toContain("var sentUrl = root.firstUrl(completedText)");
+    expect(panel).toContain("var sentUrls = root.allUrls(completedText)");   // every link of the message
+    expect(panel).toContain("root.openShare(sentUrls, true)");
     expect(panel).toContain("function openApp()");
     expect(panel).toContain('hostWidget.showApp()');
     // the popout gets out of the way, and closes BEFORE the window is shown
@@ -109,7 +111,7 @@ describe("QML safety invariants", () => {
   });
 
   test("share sheet: right-click a link, URL on stdin, never argv", () => {
-    expect(panel).toContain("function openShare(u)");
+    expect(panel).toContain("function openShare(u, auto)");
     expect(panel).toContain("qrProc.write(u)");
     expect(panel).toContain("sendShareProc.write(u)");
     expect(panel).toContain('localsend --headless send "$2"');
@@ -236,7 +238,7 @@ describe("QML safety invariants", () => {
     expect(panel).toContain('var b = empty && root.draftPath === "" ? root.selectedBubble() : null');
     const open = qmlFunction("openBubble");
     expect(open).toContain("openAttachment(b.attachments[0])");
-    expect(open).toContain("openLink(u)");
+    expect(open).toContain("openShare(urls, false)");   // a link goes to the sheet, never straight to the browser
     expect(panel).toContain("root.copyBubble(b)");
     const copy = qmlFunction("copyBubble");
     expect(copy.indexOf("copyText(t)")).toBeLessThan(copy.indexOf("copyAttachment("));  // text wins
@@ -378,4 +380,41 @@ test("link preview URLs never ride argv", () => {
   expect(panel).toContain('["bun", root.previewScript, "--stdin"]');
   expect(panel).toContain("previewProc.write(previewProc.url)");
   expect(panel).not.toContain("root.previewScript, previewProc.url]");
+});
+
+// Enter on a selected link bubble opens the share sheet, never the browser
+// directly; the sheet takes the keyboard, and its keys run before send().
+test("a selected link opens the share sheet, and the sheet has keys", () => {
+  expect(qmlFunction("openBubble")).not.toContain("openLink(u)");
+  expect(qmlFunction("shareKey")).toContain("var acts = [shareOpen, shareCopy, shareSend]");
+  expect(qmlFunction("shareKey")).toContain("if (key === Qt.Key_Return || key === Qt.Key_Enter) { acts[shareCursor](); return true }");
+  // A sheet that opened by itself (sent / arrived / IPC) keeps Enter and digits
+  // with the draft for a short grace: a link landing as Enter is pressed to
+  // send must not be opened by that Enter.
+  expect(qmlFunction("shareKey")).toContain("if (Date.now() < shareKeysFrom) return false");
+  expect(qmlFunction("openShare")).toContain("shareKeysFrom = Date.now() + (auto === true ? 700 : 0)");
+  expect(panel).toContain("root.openShare(sentUrls, true)");
+  expect(qmlFunction("shareLink")).toContain("openShare(u, true)");
+  const compose = panel.slice(panel.indexOf("id: composeField"));
+  expect(compose.indexOf("if (root.shareKey(event.key)) { event.accepted = true; return }")).toBeLessThan(compose.indexOf("root.send()"));
+  expect(compose).toContain('Keys.onEscapePressed: if (root.shareUrl !== "") root.closeShare(); else if (root.bubbleCursor >= 0)');
+});
+
+// A message with several links: Enter offers them all in the sheet, ←/→ step,
+// and the keyboard finds exactly the links linkify() anchors for the mouse.
+test("the share sheet steps through a message's links", () => {
+  expect(qmlFunction("openBubble")).toContain("var urls = allUrls(b.text)");
+  expect(qmlFunction("openBubble")).toContain("openShare(urls, false)");
+  expect(qmlFunction("allUrls")).toContain('if (/^www\\./i.test(u)) u = "https://" + u');
+  expect(qmlFunction("shareKey")).toContain("if ((key === Qt.Key_Left || key === Qt.Key_Right) && shareUrls.length > 1) { shareStep(key === Qt.Key_Right ? 1 : -1); return true }");
+  expect(panel).toContain('" of " + root.shareUrls.length');
+  // The sheet's taps stop in the sheet: an exclusive grab on press, or the
+  // row, bubble or link underneath would act on the same click.
+  const sheet = panel.slice(panel.indexOf("id: shareSheet"), panel.indexOf("id: shareSheet") + 6000);
+  expect(sheet).toContain("TapHandler { gesturePolicy: TapHandler.ReleaseWithinBounds; onTapped: root.closeShare() }");
+  expect(sheet).not.toMatch(/TapHandler \{ onTapped:/);
+  // The QR box keeps its place while a code is being made, so stepping links
+  // swaps the image instead of collapsing and re-growing the card.
+  expect(sheet).toContain('visible: root.shareQr !== "" || qrProc.running');
+  expect(qmlFunction("showShareUrl")).not.toContain('shareQr = ""');
 });


### PR DESCRIPTION
## What

Reading and acting on a conversation from the keyboard. Inside a thread the compose field holds focus, so until now the arrows only moved its caret and older messages meant the mouse wheel. Now, with the compose field empty:

- `↑` / `↓` select a bubble — newest first, kept in view, drawn with the theme's hover fill — from an empty compose field, or from the first / last line of a draft (the edge rule Omarchy's single-line list fields get for free). `↓` past the newest, or `Esc`, drops the selection and returns to the bottom with the bottom-stick re-armed.
- `Enter` on the selected bubble opens its first attachment, else its link card, else the first URL in its text. `Ctrl+C` copies its text — or, for a bubble that is only a picture, the picture itself as an image. `Ctrl+R` quotes it into the compose field as `> …`.
- `PgUp` / `PgDn` (Fn+`↑`/`↓` on a Mac keyboard) select the topmost / bottommost visible bubble, and page a screen further when the selection is already there — with text in the compose field too, since they move no caret. `Shift+PgUp` / `Shift+PgDn` step one bubble at a time. `Home` / `End` select the oldest / newest bubble — from an empty field, or once the caret already sits at its line's start / end.

With text typed, the arrows and Home/End keep moving the caret; Enter keeps sending; a queued file's Enter stays a send. The status line under the compose box no longer collapses, so "copied" and "sending…" do not shove the conversation, and only failures are red.

Five commits, each on its own.

## Why

A keyboard user could open a thread with `Enter` and then had to reach for the mouse to read anything above the fold, and for every action on a message. Omarchy's own panels are driven from the keyboard end to end, and the list side of Blip already is; the conversation side was not.

The selection is deliberately a *target* rather than a scroll position: it gives copy, open and quote something to act on, and it costs one index into `bubbles` — no model change, no new state on the Mac.

## How

**1. `5bbbcef` — a bubble cursor, paging, Home/End**
- `bubbleCursor` (index into `bubbles`) and `bubbleCursorItem`, registered by the row itself (`hasCursor` → `bubbleCursorItem = bubbleRow`), the pattern the thread list uses. `onBubblesChanged` clears it: a reload renumbers the rows.
- The highlight is one `Rectangle` beside `content` in the Flickable, positioned from the row's `y`/`height`. Bubbles are several parts (text, link card, attachment images), so a band behind the whole row beats a ring on each part, and no delegate carries a background. Its fill is `Style.hoverFillFor(foreground, accent)` — the theme's `hover-cursor-color` / `hover-cursor-fill-alpha`, which Omarchy's own rows use — rather than a hard-coded foreground at 0.08 (the thread list's rows still hard-code that; a follow-up).
- `scrollConversation(dy)` is now the one writer of `flick.contentY` — the wheel handler goes through it too — and therefore the one owner of the bottom-stick that gates the deferred push reload (invariant added to CLAUDE.md).
- `Esc` drops the selection first and leaves the thread second: the same two-step Esc a text selection in a bubble already has.

**2. `221f9f7` — Enter, Ctrl+C, Ctrl+R on the selected bubble**
- Only with an empty field and no queued file (`draftPath === ""`): a queued file's Enter is a send. Enter is otherwise free here — `send()` already returns on empty text.
- `openBubble()` reaches the same `openAttachment()` / `openLink()` a click does. `Ctrl+C` matches `StandardKey.Copy`, so Omarchy's universal `SUPER+C` (which the compositor forwards as Ctrl+C) works too, exactly like the existing `StandardKey.Paste`.
- The quote is plain text on purpose: iMessage's inline reply is not reachable through the bridge — no message GUID leaves the Mac in a bubble, and Messages' AppleScript dictionary has no reply-to.

**3. `c6ee163` — Ctrl+C on a picture bubble copies the picture**
- `copyBubble()`: text wins; a picture-only bubble copies its first image attachment. That rides the existing fetch queue (the Mac round trip a click makes): `enqueueFetch`'s boolean "open when done" becomes an action string (`""` / `"open"` / `"copy"`), and a copy job ends in `wl-copy --type <mime> < <file>` with path and type as arguments, never interpolated into the script.
- The copy fetches the *original* while the bubble draws the 1600 px preview the auto-fetch made; the inline source and metrics are left alone for a copy job, otherwise the picture re-decoded and re-laid-out under the reader's eyes (seen). HEIC/HEIF arrive as JPEG (`fetch.ts` `wantsJpeg`), so the clipboard type says `image/jpeg` for those.

**4. `7e2b625` — the status line keeps its height; only failures are red**
- The note renders a single space when empty, so nothing moves when "copied" appears. Progress and confirmations are dim; failures red — before, everything but "sending…" was red.

**5. `3e51720` — walk the bubbles with a draft in the field: edge rule, PgUp/PgDn, Shift**
- Edge rule: Up leaves the draft from its first line, Down from its last while a bubble is selected; the caret rectangle decides, since the compose box is multi-line. PgUp selects the topmost bubble with any part in view and, when the selection is already there, pages up a screen first; PgDn mirrors it with the bottommost, and past the newest leaves like Down. Only a wholly visible row counts as the edge (a sliver of the row above otherwise turned the next PgUp into a single step), and the page lands the selected row at the opposite edge — one row of overlap. `Shift+PgUp`/`Shift+PgDn` step one bubble at a time, draft or not. They move no caret, so this is the one way to walk the bubbles while a reply is half-typed (Fn+Up/Down on a Mac keyboard). `edgeVisibleBubble()` scans the Repeater's items, at most 80.

README rows, CHANGELOG (Unreleased), four invariant tests in `ui.test.ts` (`qmlFunction()` helper — same one #37 adds; whichever lands second gets a one-line conflict there).

## How it was verified

- [x] `bun test` is green (CI will check) — 350 pass
- [x] Any send/receive behaviour was exercised against **my own number only** — this change does not send
- [x] UI change → exercised by hand on Omarchy, panel and window: arrows up through a long thread and back down past the newest, Esc, Enter on a picture (opened), Ctrl+C on text then paste, Super+C on a picture-only bubble then paste into an image editor, Ctrl+R quote, PgUp/PgDn/Home/End, and the status line holding still through "copied"
- [x] Touches an invariant in `CLAUDE.md` → extends the wheel-scrolling invariant: every writer of the conversation's `contentY` goes through `scrollConversation()`

## Addendum (sixth commit): Enter on a link opens the share sheet, and the sheet takes the keyboard

Enter on a selected bubble whose text is a link went straight to the browser. A single keypress that opens an arbitrary URL, with no chance to see where it goes, is the wrong default for a messaging client. The share sheet already exists for exactly this: it names the host, shows the full URL, and offers Open / Copy / Send as a deliberate choice. Enter now goes there; a picture still opens directly (it is local).

The sheet was mouse-only, so it takes the keyboard: `1`/`2`/`3` pick, `↑`/`↓` move the highlight, Enter takes it, Esc closes. Hovering moves the same highlight, so mouse and keys agree. Any other key falls through to the compose field, so a sheet over a draft never blocks typing. **A sheet that opened by itself behaves the same** (a link you sent, a link that arrived while Blip was open, IPC): the sheet is the warning, with the host, the full URL and a button that says what Enter does. The one difference is a 700 ms grace after it appears, when Enter and digits still belong to the draft, so a link landing in the same instant as the Enter meant to send is never opened by it.

**Several links in one message.** Enter used to reach only the first. The sheet now takes every link of the message, in order, found with the same pattern and punctuation rule `linkify()` uses for the anchors the mouse clicks (plus Apple's card URL when the text lacks it). The same list arrives after a send and from the collector (`IncomingLink.urls` beside `url`; readers of `url` are untouched), through `BarWidget` and `shareLink()`, which takes one URL or a list. `←`/`→` and `‹ ›` step through them, the header counts "1 of 2", host / URL / QR follow. Stepping opens nothing, so it works on an auto-opened sheet too, but only with more than one link, so a draft keeps its caret keys.

**Found on the way, upstream's:** the sheet's `TapHandler`s took only a passive grab, so a click on the scrim, the card or a button also reached whatever lay under it (a thread row, a text selection, a link in a bubble). `gesturePolicy: TapHandler.ReleaseWithinBounds` takes an exclusive grab on press, so the tap now ends in the sheet. The compose field's Esc closes the sheet before it drops a bubble selection or leaves the thread (the audit's `shareUrl` check, on this branch too, so the rebase merges cleanly).

- [x] `bun test` — 353 pass; `collector.test.ts` covers `urls`
- [x] Verified live in the panel and the window: Enter on a link → sheet with the host; `2` copies; Esc leaves the draft untouched; a two-link message, sent and received, shows "1 of 2" and `←`/`→` / `‹ ›` step
