### PR TITLE
chats: follow Messages for re-keyed group pins and merged DMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: python3 bridge/mac/test_app_cards.py
       - name: unsent messages are tombstones, not empty bubbles (no macOS needed)
         run: python3 bridge/mac/test_unsent.py
+      - name: conversation cluster pins (no macOS needed)
+        run: python3 bridge/mac/test_cluster.py
       - name: shell scripts (bash -n + shellcheck)
         run: |
           bash -n bridge/linux/blip-shim scripts/blip-setup scripts/sync-bridge.sh scripts/demo/blip-shots bridge/mac/install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   second collector. `install.sh` fired the Automation prompt before the
   wizard's "be at the Mac" pause; re-running setup wiped hand-set
   `bridge.conf` keys; setup said "bridge is up" after three failed grants.
+
+- **Pinned groups and merged DMs follow Messages again.** A re-keyed group's
+  pin stays on a retired chat row's `group_id`, so matching only the live row
+  dropped it from Favorites. A merged 1:1 (phone SMS + email iMessage) split
+  into two threads, with the pin stuck on the stale SMS handle. `chats` now
+  matches pins against every id in the cluster, 1:1s that share a `group_id`
+  fold like re-keyed groups, and the thread loader keeps alias rows.
+
 ## 2.3.3 — 2026-09-05 — blue bubbles, and reads that reach your phone
 
 - **The Messages Automation prompt gets the time it needs.** `blip-check` gave

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,13 @@ what it is handed. Keep it that way.
   Likewise `thread.ts` keeps every group row the bridge returns for a
   `thread --chat` — the bridge scoped it to the cluster, and the alias rows
   keep their own ids (9 rows from the Mac, 6 bubbles shown, until 2.3.4).
+- **Pins and merged 1:1s use the whole conversation cluster.** A re-keyed
+  group's pin stays on a retired row's `group_id`; matching only the live
+  row drops it from Favorites. Messages also merges a phone SMS row with an
+  email iMessage row under one `group_id` while keeping two chat_identifiers.
+  `_group_cluster_map` folds those like re-keyed groups, `pin_order_for`
+  sees every id in the cluster, and `selectThread` keeps alias DM rows the
+  way it already keeps group alias rows.
 - **`chat:null` exists.** Use `chatKey()`; never `String(m.chat)`. A row with
   neither chat nor handle is a leftover of a deleted conversation (iCloud keeps
   the row, the chat and the join are gone); `fetchMessages` drops it

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -577,22 +577,31 @@ def _same_chat_id(left: str, right: str) -> bool:
     # Some preference/database versions omit the plus on phone identifiers.
     if re.fullmatch(r"\+?[0-9]{5,}", left) and re.fullmatch(r"\+?[0-9]{5,}", right):
         return left.lstrip("+") == right.lstrip("+")
+    # Pins store a dashed UUID; chat_identifier for newer groups is 32 hex.
+    left_hex = left.replace("-", "")
+    right_hex = right.replace("-", "")
+    if re.fullmatch(r"[0-9a-f]{32}", left_hex) and re.fullmatch(r"[0-9a-f]{32}", right_hex):
+        return left_hex == right_hex
     return False
 
 
-def pin_order_for(pins: list[set[str]], chat_identifier: str, guid: str | None,
-                  group_id: str | None = None, original_group_id: str | None = None) -> int | None:
-    """Return the Messages pin position for one chat, or None.
+def pin_order_for(pins: list[set[str]], *candidates: str | None) -> int | None:
+    """Return the Messages pin position for one conversation, or None.
 
     DMs are pinned by handle (chat_identifier / guid). GROUPS are pinned by
     the chat row's `group_id` (or `original_group_id`) — dashed UUIDs that
     never equal the chat_identifier (chat<digits>) or the guid
     (any;+;chat<digits>), so a pinned group was invisible without them.
+
+    Pass every identifier in the conversation cluster, not just the live
+    row: a re-keyed group's pin stays on a retired row's group_id, and a
+    merged DM (phone + email, same group_id) is pinned by whichever handle
+    was tapped.
     """
-    candidates = [c for c in (chat_identifier, guid, group_id, original_group_id) if c]
-    for index, ids in enumerate(pins):
-        for pin_id in ids:
-            if any(_same_chat_id(pin_id, c) for c in candidates):
+    ids = [c for c in candidates if c]
+    for index, pin_ids in enumerate(pins):
+        for pin_id in pin_ids:
+            if any(_same_chat_id(pin_id, c) for c in ids):
                 return index
     return None
 
@@ -1071,8 +1080,10 @@ def cmd_chats(con, args):
     if args.json:
         pin_ids = pinned_chat_identifiers()
         # One entry per CONVERSATION: a group re-keyed by Messages leaves
-        # several chat rows and used to list once per row.
+        # several chat rows and used to list once per row. A merged DM
+        # (phone + email sharing group_id) is the same shape.
         clusters = _group_cluster_map(con)
+        pin_candidates = _cluster_pin_candidates(con, clusters)
         merged_counts: dict = {}
         for r in rows:
             canon = clusters.get(r["chat_identifier"])
@@ -1083,8 +1094,11 @@ def cmd_chats(con, args):
             canon = clusters.get(r["chat_identifier"])
             if canon and canon != r["chat_identifier"]:
                 continue                 # an older row of a conversation listed under `canon`
-            pin_order = pin_order_for(pin_ids, r["chat_identifier"], r["guid"],
-                                      r["group_id"], r["original_group_id"])
+            extras = pin_candidates.get(r["chat_identifier"], ())
+            pin_order = pin_order_for(
+                pin_ids, r["chat_identifier"], r["guid"],
+                r["group_id"], r["original_group_id"], *extras,
+            )
             last = con.execute(
                 f"""SELECT m.text, m.attributedBody, m.is_from_me, h.id AS handle,
                            m.balloon_bundle_id, m.payload_data
@@ -1225,6 +1239,11 @@ def _group_cluster_map(con) -> dict:
     two different conversations with the same people never collapse. The
     canonical row is the one with the newest message (ties: highest ROWID),
     because that is the row Messages is writing to now.
+
+    1:1 chats that Messages has merged (phone SMS + email iMessage) share a
+    `group_id` while keeping different chat_identifiers. Those are clustered
+    the same way, keyed by group_id, so the sidebar and `thread --chat`
+    agree with Messages.app.
     """
     # The same recovered name cmd_groups uses: a re-sync blanks display_name,
     # and two NAMED groups with the same members then clustered as one (Astra
@@ -1263,6 +1282,36 @@ def _group_cluster_map(con) -> dict:
         canonical = best[key][1]
         for cid in ids:
             out[cid] = canonical
+    # DMs Messages has merged (phone + email, SMS + iMessage) share group_id
+    # across different chat_identifiers. style 43 stays on the name+members
+    # path above — never mix a group with a 1:1.
+    dms = con.execute(
+        f"""
+        SELECT c.ROWID AS rid, c.chat_identifier AS cid, c.group_id AS gid,
+               (SELECT MAX(m.date) FROM chat_message_join j JOIN {MESSAGE_SRC} m ON m.ROWID = j.message_id
+                 WHERE j.chat_id = c.ROWID) AS last_date
+        FROM chat c
+        WHERE c.style != 43 AND c.group_id IS NOT NULL AND TRIM(c.group_id) != ''
+        """
+    ).fetchall()
+    dm_best: dict = {}
+    dm_members: dict = {}
+    for r in dms:
+        if not r["cid"]:
+            continue
+        key = r["gid"]
+        dm_members.setdefault(key, []).append(r["cid"])
+        rank = (r["last_date"] or -1, r["rid"])
+        cur = dm_best.get(key)
+        if cur is None or rank > cur[0]:
+            dm_best[key] = (rank, r["cid"])
+    for key, ids in dm_members.items():
+        uniq = list(dict.fromkeys(ids))
+        if len(uniq) < 2:
+            continue
+        canonical = dm_best[key][1]
+        for cid in uniq:
+            out[cid] = canonical
     return out
 
 
@@ -1270,6 +1319,34 @@ def _group_photo_chat_ids(con, chat_identifier: str) -> tuple[str, ...]:
     clusters = _group_cluster_map(con)
     canon = clusters.get(chat_identifier, chat_identifier)
     return tuple(sorted({c for c, k in clusters.items() if k == canon} | {chat_identifier, canon}))
+
+
+def _cluster_pin_candidates(con, clusters: dict) -> dict:
+    """canon chat_identifier -> identifiers Messages may have stored as a pin.
+
+    A re-keyed group's pin stays on a retired row's group_id. A merged DM is
+    pinned by whichever handle was tapped. Matching only the live row missed
+    both. Look at every chat row, not the sidebar LIMIT, so a quiet alias
+    still donates its ids.
+    """
+    chat_cols = {row[1] for row in con.execute("PRAGMA table_info(chat)")}
+    orig = "original_group_id" if "original_group_id" in chat_cols else "NULL"
+    rows = con.execute(
+        f"SELECT chat_identifier, guid, group_id, {orig} AS original_group_id FROM chat"
+    ).fetchall()
+    seen: dict = {}
+    for r in rows:
+        cid = r["chat_identifier"]
+        if not cid:
+            continue
+        canon = clusters.get(cid, cid)
+        bucket = seen.setdefault(canon, [])
+        have = set(bucket)
+        for v in (cid, r["guid"], r["group_id"], r["original_group_id"]):
+            if v and str(v).strip() and str(v) not in have:
+                have.add(str(v))
+                bucket.append(str(v))
+    return seen
 
 
 def _group_photo_path(con, chat_identifier: str) -> str:

--- a/bridge/mac/test_cluster.py
+++ b/bridge/mac/test_cluster.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Regression: pins and merged DMs must follow the whole conversation cluster."""
+from __future__ import annotations
+
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+IMSG = Path(__file__).with_name("imsg")
+
+
+def load_imsg():
+    loader = SourceFileLoader("blip_imsg", str(IMSG))
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    mod = module_from_spec(spec)
+    sys.modules[loader.name] = mod
+    loader.exec_module(mod)
+    return mod
+
+
+def schema(con: sqlite3.Connection) -> None:
+    con.executescript(
+        """
+        CREATE TABLE chat (
+          ROWID INTEGER PRIMARY KEY,
+          chat_identifier TEXT,
+          guid TEXT,
+          display_name TEXT,
+          style INTEGER,
+          group_id TEXT,
+          original_group_id TEXT
+        );
+        CREATE TABLE message (
+          ROWID INTEGER PRIMARY KEY,
+          date INTEGER,
+          item_type INTEGER
+        );
+        CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+        CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER);
+        CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+        CREATE TABLE chat_recoverable_message_join (message_id INTEGER);
+        """
+    )
+
+
+def add_msg(con, chat_row: int, msg_row: int, date: int) -> None:
+    con.execute("INSERT INTO message (ROWID, date, item_type) VALUES (?, ?, 0)", (msg_row, date))
+    con.execute("INSERT INTO chat_message_join VALUES (?, ?)", (chat_row, msg_row))
+
+
+class ClusterPins(unittest.TestCase):
+    def setUp(self) -> None:
+        self.imsg = load_imsg()
+        self.con = sqlite3.connect(":memory:")
+        self.con.row_factory = sqlite3.Row
+        schema(self.con)
+
+    def test_same_chat_id_treats_dashed_and_plain_uuid_as_equal(self) -> None:
+        dashed = "AB50F3F5-B1B1-42E8-8FC4-39E194755E41"
+        plain = "ab50f3f5b1b142e88fc439e194755e41"
+        self.assertTrue(self.imsg._same_chat_id(dashed, plain))
+        self.assertFalse(self.imsg._same_chat_id(dashed, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+
+    def test_rekeyed_group_pin_on_retired_row_attaches_to_live_id(self) -> None:
+        live = "4b3d072e07b14bf88b4b8fde00deebcf"
+        old = "chat909594254947022019"
+        pin = "84177BB6AEADC8C5ED2A2B2CC89B1D8F47247C23"
+        members = ["+15550100001", "+15550100002"]
+        self.con.execute(
+            "INSERT INTO chat VALUES (1, ?, 'any;+;' || ?, 'Sportsball!', 43, "
+            "'AB50F3F5-B1B1-42E8-8FC4-39E194755E41', 'AB50F3F5-B1B1-42E8-8FC4-39E194755E41')",
+            (live, live),
+        )
+        self.con.execute(
+            "INSERT INTO chat VALUES (2, ?, 'any;+;' || ?, 'Sportsball!', 43, ?, "
+            "'A1322320-8A1A-4F3D-885C-47DD657F556A')",
+            (old, old, pin),
+        )
+        for i, h in enumerate(members, start=1):
+            self.con.execute("INSERT INTO handle VALUES (?, ?)", (i, h))
+            self.con.execute("INSERT INTO chat_handle_join VALUES (1, ?)", (i,))
+            self.con.execute("INSERT INTO chat_handle_join VALUES (2, ?)", (i,))
+        add_msg(self.con, 1, 10, 300)
+        add_msg(self.con, 2, 11, 100)
+
+        clusters = self.imsg._group_cluster_map(self.con)
+        self.assertEqual(clusters[old], live)
+        self.assertEqual(clusters[live], live)
+
+        cands = self.imsg._cluster_pin_candidates(self.con, clusters)
+        pins = [{pin}]
+        self.assertEqual(self.imsg.pin_order_for(pins, *cands[live]), 0)
+        # matching only the live row still misses it — that was the bug
+        self.assertIsNone(self.imsg.pin_order_for(
+            pins, live, f"any;+;{live}",
+            "AB50F3F5-B1B1-42E8-8FC4-39E194755E41",
+            "AB50F3F5-B1B1-42E8-8FC4-39E194755E41",
+        ))
+
+    def test_merged_dm_phone_and_email_share_one_conversation(self) -> None:
+        phone = "+15550100001"
+        email = "pat@example.com"
+        gid = "531E435C-B41F-4494-B08A-9B4F935A52DB"
+        self.con.execute(
+            "INSERT INTO chat VALUES (1, ?, 'any;-;' || ?, '', 45, ?, 'AAAA')",
+            (email, email, gid),
+        )
+        self.con.execute(
+            "INSERT INTO chat VALUES (2, ?, 'any;-;' || ?, '', 45, ?, 'BBBB')",
+            (phone, phone, gid),
+        )
+        add_msg(self.con, 1, 10, 300)   # email is newer → canonical
+        add_msg(self.con, 2, 11, 100)
+
+        clusters = self.imsg._group_cluster_map(self.con)
+        self.assertEqual(clusters[phone], email)
+        self.assertEqual(clusters[email], email)
+
+        cands = self.imsg._cluster_pin_candidates(self.con, clusters)
+        pins = [{phone}]
+        self.assertEqual(self.imsg.pin_order_for(pins, *cands[email]), 0)
+
+    def test_unrelated_dms_are_not_clustered(self) -> None:
+        self.con.execute(
+            "INSERT INTO chat VALUES (1, '+15550100001', 'any;-;+15550100001', '', 45, 'GID-A', 'A')"
+        )
+        self.con.execute(
+            "INSERT INTO chat VALUES (2, '+15550100002', 'any;-;+15550100002', '', 45, 'GID-B', 'B')"
+        )
+        add_msg(self.con, 1, 10, 300)
+        add_msg(self.con, 2, 11, 200)
+        self.assertEqual(self.imsg._group_cluster_map(self.con), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -862,6 +862,20 @@ describe("a re-keyed group is ONE conversation", () => {
       (a, b) => (a < b ? a : b),
     )).toEqual({ chat2244: "2026-02-26 22:26:56" });
   });
+
+  test("a merged DM (phone + email) folds onto the live handle", () => {
+    const phone = "+15550100001";
+    const email = "pat@example.com";
+    const out = foldThreadAliases(
+      [
+        thread(phone, "2026-09-04 21:32:29", 40, 0),
+        thread(email, "2026-09-05 17:24:01", 12, 1),
+      ],
+      { [phone]: email },
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ chat: email, last_ts: "2026-09-05 17:24:01", unread: 1 });
+  });
 });
 
 describe("complete conversation list (mergeChats)", () => {

--- a/thread.test.ts
+++ b/thread.test.ts
@@ -458,6 +458,21 @@ describe("selectThread", () => {
     expect(out[0]!.ts).toBe("2026-08-30 12:00:00");
   });
 
+  test("a merged DM keeps rows from every alias handle, in either direction", () => {
+    const phone = "+15550100001";
+    const email = "pat@example.com";
+    const raw = [
+      msg({ chat: phone, handle: phone, ts: "2026-09-04 21:32:29", text: "sms" }),
+      msg({ chat: email, handle: email, ts: "2026-09-05 17:24:01", text: "imessage" }),
+      msg({ chat: "+15550100002", handle: "+15550100002", ts: "2026-09-05 18:00:00", text: "other" }),
+    ];
+    const aliases = { [phone]: email };
+    expect(selectThread(raw, email, false, 80, [], aliases).map((m) => m.text))
+      .toEqual(["sms", "imessage"]);
+    expect(selectThread(raw, phone, false, 80, [], aliases).map((m) => m.text))
+      .toEqual(["sms", "imessage"]);
+  });
+
   test("loadThread loads a group by EXACT chat id via thread --chat", () => {
     let seen: string[] = [];
     const runner = ((_: string, args: string[]) => { seen = args; return { status: 0, stdout: "[]", stderr: "" }; }) as never;

--- a/thread.ts
+++ b/thread.ts
@@ -338,12 +338,25 @@ export const GROUP_SCAN_WINDOW = 1500;
  * `recent` is newest-first and mixed across chats; `thread` is already
  * oldest-first and single-chat. Both end up oldest-first, last `limit` only.
  */
+/** Chat ids that belong to one Messages conversation (re-keyed group or
+ *  merged DM). `chat` itself is always included so a missing alias map
+ *  still loads that row. */
+export function chatsForThread(chat: string, aliases: Record<string, string> = {}): string[] {
+  const canon = aliases[chat] ?? chat;
+  const ids = new Set<string>([chat, canon]);
+  for (const [alias, target] of Object.entries(aliases)) {
+    if (target === canon) ids.add(alias);
+  }
+  return [...ids];
+}
+
 export function selectThread(
   raw: ImsgMessage[],
   chat: string,
   group: boolean,
   limit: number,
   selfChats: string[] = [],
+  aliases: Record<string, string> = {},
 ): ImsgMessage[] {
   // Exact-filter DMs too: `imsg thread` matches the handle by SUBSTRING, so
   // +15551234567 can pull rows from +995551234567 into the wrong conversation
@@ -354,9 +367,11 @@ export function selectThread(
   // re-key cluster and every row keeps its ORIGINAL chat id, so filtering on
   // the requested id threw the alias rows' history away (9 rows from the Mac,
   // 6 bubbles here — Astra #8). Trust the cluster; keep every group row.
+  // A merged DM (phone + email) is the same shape: keep every alias id.
+  const ids = new Set(chatsForThread(chat, aliases));
   let msgs = group
     ? raw.filter((m) => isGroupChat(chatKey(m)))
-    : raw.filter((m) => chatKey(m) === chat || (m.handle === chat && !isGroupChat(chatKey(m))));
+    : raw.filter((m) => ids.has(chatKey(m)) || (m.handle === chat && !isGroupChat(chatKey(m))));
   msgs = [...msgs].sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
   msgs = dedupeSelfEcho(msgs, selfChats);
   return msgs.length > limit ? msgs.slice(msgs.length - limit) : msgs;
@@ -394,7 +409,10 @@ export function loadThread(
   try {
     const parsed = JSON.parse(res.stdout as string);
     if (!Array.isArray(parsed)) throw new Error("not an array");
-    const msgs = selectThread(parsed as ImsgMessage[], chat, group, limit, loadState().selfChats);
+    const state = loadState();
+    const msgs = selectThread(
+      parsed as ImsgMessage[], chat, group, limit, state.selfChats, state.chatAliases,
+    );
     return { ok: true, online: true, error: "", bubbles: decorate(msgs, today, formats) };
   } catch (e) {
     return { ok: false, online: true, error: `bad JSON from imsg: ${e}`, bubbles: [] };


### PR DESCRIPTION
## What

Favorites and the thread list follow Messages for two conversation shapes that used to split:

1. **A re-keyed group's pin stays visible.** Messages can give a group a new chat row (re-invite, iCloud shuffle) and keep the pin on the *retired* row's `group_id`. `imsg chats` only matched the live row, so that pin slot had no conversation. Pins now match every identifier in the cluster.
2. **A merged 1:1 is one thread.** Messages folds a phone SMS row and an email iMessage row under one `group_id` while keeping two `chat_identifier`s. Blip listed them twice, with the pin stuck on the stale SMS handle. Those rows now cluster like re-keyed groups, and opening the thread keeps both sides' history.

Mac side: copy `imsg` to `~/.blip/bin` (or re-run the install one-liner).

## Why

Messages.app already treats both as one conversation. Blip keyed pins and 1:1s on a single live id, so a pinned group vanished from Favorites and the open 1:1 showed yesterday's SMS while today's iMessages sat in a second, unpinned row.

This is the same cluster idea Astra #8 used for group *history*, applied to pins and to 1:1s that share `group_id`.

## How it was verified

- [x] `bun test` is green (CI will check) — 358 pass, including fold + `selectThread` alias tests
- [x] Mac-side unit tests (`python3 bridge/mac/test_cluster.py`, `python3 bridge/mac/test_group_photo.py`) — no live `chat.db`
- [x] Live `imsg chats` after deploying the Mac tool: every pin slot resolved, a merged 1:1 listed once under the live iMessage handle (metadata only; no conversation contents)
- [ ] Any send/receive behavior was exercised against **my own number only** — never a contact or a group — no send path in this change
- [ ] UI change → screenshot attached — Favorites tiles changed membership, not layout; no screenshot of a real conversation
- [x] Touches an invariant in `CLAUDE.md` → named below, and the doc updated if it changed

Invariants: pins and merged 1:1s use the whole conversation cluster; `thread.ts` already keeps group alias rows (Astra #8) and now keeps merged-DM alias rows the same way; `MESSAGE_SRC` still hides announcements.

Made with [Cursor](https://cursor.com)