### PR TITLE
Keep an unsent draft per conversation across thread switches

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -45,6 +45,9 @@ BarWidget {
   property bool healthy: false       // last collector run parsed cleanly
   property string lastError: ""
   property string lastRun: ""
+  // Unsent compose text per chat id, shared by the panel and the app window.
+  // In memory only: message text never lands on disk.
+  property var draftCache: ({})
 
   readonly property bool hasUnread: unread > 0
 

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -344,6 +344,12 @@ FocusScope {
     return /^\+?[0-9]{5,}$/.test(c) || c.indexOf("@") > 0
   }
 
+  // Unsent compose text per chat id. It lives on the host (BarWidget.draftCache)
+  // so the panel and the app window share it, and in memory only: message text
+  // never lands on disk. Written in place: nothing binds to the map, so there
+  // is no copy to make and no change to signal.
+  readonly property var drafts: hostWidget ? hostWidget.draftCache : ({})
+
   /** Back to the list view, scrolled to top — the host calls this on open. */
   function resetToList() {
     active = null
@@ -391,7 +397,8 @@ FocusScope {
     pushPending = false
     note = ""
     loading = true
-    composeField.text = ""
+    composeField.text = drafts[String(t.chat)] || ""   // this conversation's unsent text
+    composeField.cursorPosition = composeField.length
     clearDraft()   // a queued file must never survive into another thread
     requestThreadLoad(String(t.chat))
     Qt.callLater(function() { composeField.forceActiveFocus() })
@@ -2743,6 +2750,12 @@ FocusScope {
               id: composeField
               anchors.fill: parent
               wrapMode: TextEdit.Wrap
+              // Every edit is kept under the open conversation, so switching
+              // threads does not lose it. A send clears the field and with it
+              // the draft; leaving a thread nulls active BEFORE clearing, so the
+              // draft stays. Loading a draft in openThread fires this too and
+              // writes the same text back, which is harmless.
+              onTextChanged: if (root.active) root.drafts[String(root.active.chat)] = text
               // NEVER disabled: this field is the panel's exclusive keyboard-focus
               // holder, and disabling the focused editor dismisses the whole
               // panel (0.7.2 postmortem; Codex design review #8). readOnly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Drafts survive a thread switch.** Text typed but not sent is now kept per
+  conversation as you move between threads and restored when you return; the
+  panel and the app window share the same drafts. In memory only, so no message
+  text lands on disk. Sending, or clearing the field, drops that conversation's
+  draft.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,11 @@ what it is handed. Keep it that way.
   metadata. It is atomic and `0600`; no message bodies are allowed. EXCEPTION
   (Fred, 2026-08-31): fetched MEDIA caches as plain files in
   `~/.cache/blip/att` (0700/0600, 500 MB LRU) — the Linux box's disk is LUKS-encrypted
-  at rest. Message text still never lands on disk. `push-read.log` beside
-  state.json records each read-push's exit code and `imsg-read`'s status
-  line — never content.
+  at rest. Message text still never lands on disk — unsent drafts included:
+  `BarWidget.draftCache` keeps them in memory only, so a shell restart drops
+  them by design; do not persist them. `push-read.log` beside state.json
+  records each read-push's exit code and `imsg-read`'s status line — never
+  content.
 - **The Linux shims' ssh preflight must use `ssh -n`.** A bare
   `ssh <mac> true` connectivity probe EATS STDIN, which silently empties
   `imsg-send --file-stdin` payloads. Fixed 2026-08-31.

--- a/scripts/demo/DemoShell.qml
+++ b/scripts/demo/DemoShell.qml
@@ -25,6 +25,7 @@ ShellRoot {
     property int unread: 0
     property bool healthy: true
     property string lastError: ""
+    property var draftCache: ({})
     // The version, from the same manifest.json the shipped widget reads.
     property string version: ""
     // Clock and date patterns, as BarWidget would supply them (README defaults);

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -346,3 +346,23 @@ test("search queries never ride argv", () => {
   expect(panel).toContain('["bun", root.searchScript, "--stdin", "40"]');
   expect(panel).toContain("searchProc.write(JSON.stringify({ query: q, threads:");
 });
+
+// Drafts: text typed but not sent is kept per conversation across a thread
+// switch, shared by the panel and the app window, in memory only — never on
+// disk (the "message text never lands on disk" invariant).
+describe("per-conversation drafts", () => {
+  test("the host owns one draft map for both surfaces", () => {
+    expect(widget).toContain("property var draftCache: ({})");
+    expect(panel).toContain("readonly property var drafts: hostWidget ? hostWidget.draftCache : ({})");
+  });
+
+  test("every edit is kept under the open chat and restored on open", () => {
+    expect(panel).toContain("onTextChanged: if (root.active) root.drafts[String(root.active.chat)] = text");
+    expect(panel).toContain('composeField.text = drafts[String(t.chat)] || ""');
+  });
+
+  test("drafts never touch disk", () => {
+    expect(panel).not.toContain("drafts.json");
+    expect(widget).not.toContain("drafts.json");
+  });
+});


### PR DESCRIPTION
## What

Text typed but not sent stays with its conversation. Switch to another thread and back, or from the panel to the app window, and the draft is where you left it, caret at the end. Sending, or clearing the field, drops it. Drafts live in memory only; a shell restart drops them by design.

## Why

`openThread()` blanked the compose field on every switch, so glancing at another conversation mid-sentence lost the sentence. Messages on the Mac keeps a per-conversation draft; Blip now does the same within a session.

The obvious next step, persisting drafts to disk, is deliberately **not** taken: CLAUDE.md's invariant is that message text never lands on disk, and an unsent draft is message text. The invariant now says so explicitly, so nobody "improves" this later.

## How

- **`BarWidget.qml`** — `draftCache`, chat id → unsent text. It sits on the host because the panel and the app window are two `BlipView`s under the same widget; one map means one set of drafts. The demo host mirrors the property.
- **`BlipView.qml`** — `drafts` reads the host's map. `composeField.onTextChanged` writes every edit under the open chat; `openThread()` loads the target chat's draft instead of `""` and puts the caret at the end. No copy-on-write: nothing binds to the map, and the load writing the same text back is harmless. `back()`/`resetToList()` already null `active` before clearing the field, so leaving keeps the draft; a send clears the field while `active` is set, so it drops the draft.
- **`ui.test.ts`** — three invariants: the host owns the map, edits are kept per chat and restored on open, and nothing named `drafts.json` exists.
- CLAUDE.md's "no message content on disk" invariant names drafts; CHANGELOG under Unreleased.

14 lines in `BlipView.qml`, 3 in `BarWidget.qml`, 1 in the demo shell.

## How it was verified

- [x] `bun test` is green (CI will check) — 359 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → verified live on Omarchy: type in a thread, switch away and back in the panel; type in the panel, open the same thread in the app window with the window hotkey; send, leave, return (draft gone); close the panel and reopen (draft kept)
- [x] Touches an invariant in `CLAUDE.md` → **"No message content in state.json" exists** — extended to name drafts, not changed

Note: like the other open PRs, this adds a line at the top of the CHANGELOG; whichever lands later gets a one-line rebase from me. No other line overlaps with #37, #38 or #39.
