### PR TITLE
Size pinned avatars through Layout hints so they do not grow on the first cursor move

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1726,9 +1726,11 @@ FocusScope {
                     Rectangle {
                       id: pinnedAvatar
                       Layout.alignment: Qt.AlignHCenter
-                      width: Math.min(88, Math.max(56,
+                      // A layout sizes its children from Layout hints; a width:
+                      // binding here loses to the layout's first measurement.
+                      Layout.preferredWidth: Math.min(88, Math.max(56,
                         (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3 * 0.62))
-                      height: width
+                      Layout.preferredHeight: Layout.preferredWidth
                       radius: width / 2
                       color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
                       readonly property string avatarHandle: root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Pinned avatars no longer grow on the first cursor move.** The tiles were
+  measured before the grid had its width, and the layout kept that small size
+  until the next relayout; the size is now a layout hint, so they render at
+  full size from the first frame.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -346,3 +346,14 @@ test("search queries never ride argv", () => {
   expect(panel).toContain('["bun", root.searchScript, "--stdin", "40"]');
   expect(panel).toContain("searchProc.write(JSON.stringify({ query: q, threads:");
 });
+
+// The pinned avatar sits in a ColumnLayout, which sizes it from Layout hints;
+// a width: binding there is overridden by the layout's first measurement.
+test("pinned avatars size through Layout hints, not width bindings", () => {
+  const start = panel.indexOf("id: pinnedAvatar");
+  expect(start).toBeGreaterThan(-1);
+  const avatar = panel.slice(start, start + 600);
+  expect(avatar).toContain("Layout.preferredWidth: Math.min(88, Math.max(56,");
+  expect(avatar).toContain("Layout.preferredHeight: Layout.preferredWidth");
+  expect(avatar).not.toContain(" width: Math.min(88");
+});


### PR DESCRIPTION
## What

The pinned avatars in the panel render at their full size from the first frame. They used to come up small and grow on the first arrow press.

## Why

The avatar is a direct child of a `ColumnLayout` but sized itself with a `width:` binding. A layout sizes its children from their size hints, and with no hint it took the item's width at first measurement: 56, the clamp floor, because the tiles are built before the grid has its width. Every relayout then forced 56 back. The binding's real value, about 63 at the panel's width, only stuck when a relayout happened after the binding re-evaluated, which in practice was the first cursor move onto a tile.

Measured on the running panel with temporary geometry logging: grid width 19 → 320, avatar 56 → 62.8 → back to 56, grid height 166 until the first arrow press, then 180.

## How

- **`BlipView.qml`** — the avatar binds `Layout.preferredWidth` / `Layout.preferredHeight` instead of `width` / `height`. Same formula, same clamp; the layout and the binding now agree from the first frame. Two lines.
- **`ui.test.ts`** — one invariant: the pinned avatar sizes through Layout hints, and no `width: Math.min(88` binding is left on it.
- CHANGELOG under Unreleased.

The three other layout children in the file that set `width:` themselves use constants from `Style.space`, so the first measurement equals the value forever and nothing jumps. Left as they are.

## How it was verified

- [x] `bun test` is green (CI will check) — 357 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → verified live on Omarchy with the same logging, before and after: after the fix the avatars are 62.8 and the grid 180 before any key is pressed, and unchanged over some sixty cursor moves; tiles rebuilt on a list refresh come in at 62.8 directly. In the app window the sidebar is narrower (grid 284), the formula clamps to 56 there by design, and it is stable.
- [ ] Touches an invariant in `CLAUDE.md` → no

Note: like the other open PRs, this adds a line at the top of the CHANGELOG; whichever lands later gets a one-line rebase from me. No other line overlaps with #37, #38, #39 or #41.
