### PR TITLE
Duplicate Contacts cards resolve; sending is instant

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -268,6 +268,15 @@ FocusScope {
   property string pendingThreadChat: "" // latest chat requested while it runs
   property string sendChat: ""          // immutable context for the current send
   property string sendText: ""
+  property string sendStamp: ""         // local "YYYY-MM-DD HH:mm:ss" the current send was typed at
+  // Text sends queue instead of refusing while one is on the wire; each gets
+  // its bubble the instant Enter is pressed (see pendingSends).
+  property var sendQueue: []
+  // Sends the Mac has not written a row for yet, {chat, text, ts}. Every
+  // thread reload carries them to thread.ts (--pending-stdin, never argv),
+  // which keeps their bubbles until the real row lands. Memory only.
+  property var pendingSends: []
+  property int reloadTries: 0            // post-send reloads still waiting for the row
   property string reloadChat: ""
 
   function threadIndex(thread) {
@@ -406,11 +415,22 @@ FocusScope {
     if (threadProc.running || pendingThreadChat === "") return
     threadRunningChat = pendingThreadChat
     pendingThreadChat = ""
+    var pending = root.pendingSends.filter(function(p) { return p.chat === threadRunningChat })
     threadProc.command = ["bun", root.threadScript, threadRunningChat, "80",
                           "--time-format", root.timeFormat,
                           "--date-format", root.dateFormat,
                           "--date-format-with-year", root.dateFormatWithYear]
-    threadProc.running = true
+                         .concat(pending.length ? ["--pending-stdin"] : [])
+    if (pending.length) {
+      // In-flight sends ride stdin (message text never in argv) so their
+      // bubbles survive the reload until the Mac has the row.
+      threadProc.stdinEnabled = true
+      threadProc.running = true
+      threadProc.write(JSON.stringify(pending))
+      threadProc.stdinEnabled = false
+    } else {
+      threadProc.running = true
+    }
   }
 
   /** IPC test hook: drive the exact user send path minus the keyboard.
@@ -979,19 +999,19 @@ FocusScope {
     }
 
     if (draftPath === "" && trimmed === "") return
-    if (sendProc.running || fileSendProc.running) {
-      note = "a message is already sending"
-      return
-    }
     if (!isSendable(root.active)) {
       note = "Read-only — group id unknown — send from your phone"
       return
     }
-    note = "sending…"
-    sendChat = String(root.active.chat)
-    sendText = text
 
     if (draftPath !== "") {
+      if (sendProc.running || fileSendProc.running) {
+        note = "a message is already sending"
+        return
+      }
+      note = "sending…"
+      sendChat = String(root.active.chat)
+      sendText = text
       // send-file.ts owns target resolution (group guid or DM handle).
       sendDraftPath = draftPath
       // caption on stdin — never in this process's argv (audit #4, war room #1/#13)
@@ -1004,18 +1024,70 @@ FocusScope {
       return
     }
 
-    // Body on STDIN (--text-stdin), never argv: argv is readable by every
-    // process on this machine and travels through ssh into the Mac's ps.
+    // The bubble appears NOW; the Mac round trip (ssh, osascript, Messages
+    // writing the row) happens behind it. The field clears at once, so a
+    // second message can follow without waiting — sends queue in order.
+    var chat = String(root.active.chat)
+    var stamp = root.localStamp()
     var target = root.activeIsGroup
       ? ["--chat-id", String(root.active.guid)]
-      : ["--to", sendChat]
+      : ["--to", chat]
     // green-bubble (SMS/RCS) threads send on their own service (war room #2)
     var svc = String(root.active.service || "")
     if (!root.activeIsGroup && /^(SMS|RCS)$/i.test(svc)) target = target.concat(["--service", svc.toUpperCase()])
-    sendProc.command = [root.home + "/bin/imsg-send"].concat(target).concat(["--yes", "--text-stdin", "--keep-dashes"])
+    root.pendingSends = root.pendingSends.concat([{ chat: chat, text: text, ts: stamp }])
+    root.bubbles = root.appendPendingBubble(root.bubbles, text, stamp)
+    root.pinToBottom = true
+    composeField.text = ""
+    note = ""
+    root.sendQueue = root.sendQueue.concat([{ chat: chat, text: text, stamp: stamp, target: target }])
+    pumpSend()
+  }
+
+  /** Local wall clock as a chat.db-style stamp; the pending bubble's ts. */
+  function localStamp() {
+    return Qt.formatDateTime(new Date(), "yyyy-MM-dd HH:mm:ss")
+  }
+
+  /** The instant echo: thread.ts's pendingBubble() in miniature — enough to
+   *  draw the bubble in the right run with the right clock. Every reload
+   *  replaces it with the TypeScript version until the real row lands. */
+  function appendPendingBubble(list, text, stamp) {
+    var out = (list || []).slice()
+    var prev = out.length ? out[out.length - 1] : null
+    var newDay = !prev || String(prev.ts || "").slice(0, 10) !== stamp.slice(0, 10)
+    var gapMin = prev ? (Date.parse(stamp.replace(" ", "T")) - Date.parse(String(prev.ts || "").replace(" ", "T"))) / 60000 : Infinity
+    var start = !prev || newDay || prev.from_me !== true || !(gapMin <= 15)
+    if (!start) { var p = Object.assign({}, prev); p.groupEnd = false; p.time = ""; out[out.length - 1] = p }
+    out.push({ ts: stamp, from_me: true, name: "", text: String(text).trim(), day: newDay ? "Today" : "",
+               groupStart: start, groupEnd: true, time: Qt.formatTime(new Date(), root.timeFormat),
+               receipt: "", tapbacks: [], attachments: [], replyText: "", replyMine: false, edited: false,
+               link: null, retracted: false, effect: "", audio: false, html: "", failed: false, pending: true })
+    return out
+  }
+
+  /** Drop one in-flight send (by chat + stamp) from the ledger and the view. */
+  function dropPending(chat, stamp) {
+    root.pendingSends = root.pendingSends.filter(function(p) { return !(p.chat === chat && p.ts === stamp) })
+    if (root.inThread && String(root.active.chat) === chat)
+      root.bubbles = root.bubbles.filter(function(b) { return !(b.pending === true && String(b.ts) === stamp) })
+  }
+
+  /** Start the next queued text send when the wire is free. */
+  function pumpSend() {
+    if (sendProc.running || root.sendQueue.length === 0) return
+    var job = root.sendQueue[0]
+    root.sendQueue = root.sendQueue.slice(1)
+    root.sendChat = job.chat
+    root.sendText = job.text
+    root.sendStamp = job.stamp
+    root.reloadTries = 0
+    // Body on STDIN (--text-stdin), never argv: argv is readable by every
+    // process on this machine and travels through ssh into the Mac's ps.
+    sendProc.command = [root.home + "/bin/imsg-send"].concat(job.target).concat(["--yes", "--text-stdin", "--keep-dashes"])
     sendProc.stdinEnabled = true
     sendProc.running = true
-    sendProc.write(text)
+    sendProc.write(job.text)
     sendProc.stdinEnabled = false
   }
 
@@ -1068,9 +1140,27 @@ FocusScope {
           if (d.ok === true) {
             var list = Array.isArray(d.bubbles) ? d.bubbles : []
             var j = JSON.stringify(list)
-            // What the eye can now see: the newest ts in THIS snapshot.
+            // What the eye can now see: the newest ts in THIS snapshot — of
+            // real rows; a pending bubble carries this machine's clock.
             var seen = ""
-            for (var k = 0; k < list.length; k++) { var ts = String(list[k].ts || ""); if (ts > seen) seen = ts }
+            for (var k = 0; k < list.length; k++) {
+              if (list[k].pending === true) continue
+              var ts = String(list[k].ts || ""); if (ts > seen) seen = ts
+            }
+            // thread.ts hands back the sends it is still waiting on for this
+            // chat; keep asking for a few seconds, then leave it to the next
+            // ordinary reload (the bubble stays up either way).
+            if (Array.isArray(d.pending)) {
+              var chat = root.threadRunningChat
+              root.pendingSends = root.pendingSends.filter(function(p) { return p.chat !== chat }).concat(d.pending)
+              if (d.pending.length > 0 && root.reloadTries < 8) {
+                root.reloadTries++
+                root.reloadChat = chat
+                reloadTimer.restart()
+              } else {
+                root.reloadTries = 0
+              }
+            }
             if (j === root.bubblesJson) {
               // Nothing changed — do NOT rebuild the Repeater (a rebuild
               // resets scroll and re-decodes every image). Push pings mostly
@@ -1123,27 +1213,31 @@ FocusScope {
     onExited: function(code, status) {
       var completedChat = root.sendChat
       var completedText = root.sendText
+      var completedStamp = root.sendStamp
       var belongsHere = root.inThread && String(root.active.chat) === completedChat
       root.sendChat = ""
       root.sendText = ""
+      root.sendStamp = ""
       if (code === 0) {
         // A URL you just SHARED opens the sheet too (Fred, 2.3.0): send it,
         // then offer the QR / LocalSend / copy for the same link.
         var sentUrl = root.firstUrl(completedText)
         if (belongsHere && sentUrl !== "") Qt.callLater(function() { root.openShare(sentUrl) })
-        if (belongsHere) {
-          root.note = ""
-          // Never erase a newer draft typed after this send began.
-          if (composeField.text === completedText) composeField.text = ""
-        }
-        // Give Messages.app a beat to write the row, then reload the thread.
+        // The bubble is already up; reload to swap it for the real row.
         root.reloadChat = completedChat
         reloadTimer.restart()
-      } else if (belongsHere) {
-        if (code === 69 || code === 255) root.note = "not sent — Mac unreachable"
-        else root.note = (sendProc.lastErr !== "" ? "send failed: " + sendProc.lastErr : "send failed (exit " + code + ")")
+      } else {
+        // The bubble comes down, the words go back in the field (unless a
+        // newer draft is there), and the reason is on the status line.
+        root.dropPending(completedChat, completedStamp)
+        if (belongsHere) {
+          if (composeField.text === "") composeField.text = completedText
+          if (code === 69 || code === 255) root.note = "not sent — Mac unreachable"
+          else root.note = (sendProc.lastErr !== "" ? "send failed: " + sendProc.lastErr : "send failed (exit " + code + ")")
+        }
       }
       if (belongsHere) composeField.forceActiveFocus()
+      Qt.callLater(root.pumpSend)
     }
   }
 
@@ -1175,6 +1269,11 @@ FocusScope {
             }
           }
           if (d.ok !== true && d.online === false) root.note = "fetch failed — Mac unreachable"
+          // A click deserves the reason (a photo Messages in iCloud has not
+          // brought to the Mac yet reads as "no such attachment" otherwise);
+          // auto-pulls stay quiet so a scroll through old media is not a toast storm.
+          else if (d.ok !== true && root.fetchJobOpen)
+            root.note = "fetch failed — " + String(d.error || "unknown error").replace(/^error:\s*/, "")
         } catch (e) {
           var m2 = Object.assign({}, root.attFiles)
           m2[id] = ""
@@ -1354,9 +1453,12 @@ FocusScope {
   }
   Timer {
     id: reloadTimer
-    interval: 1500
+    // Messages usually has the row within a few hundred ms of osascript
+    // returning; a reload that beats it keeps the pending bubble (thread.ts)
+    // and tries again. No `loading` flag: the bubble is already on screen,
+    // and a "loading…" flash after every send is the thing we are removing.
+    interval: 600
     onTriggered: if (root.inThread && String(root.active.chat) === root.reloadChat) {
-      root.loading = true
       root.requestThreadLoad(root.reloadChat)
     }
   }
@@ -2626,14 +2728,14 @@ FocusScope {
                   Layout.fillWidth: true
                   visible: String(modelData.time || "") !== "" ||
                            modelData.edited === true || String(modelData.effect || "") !== "" ||
-                           modelData.failed === true
+                           modelData.failed === true || modelData.pending === true
                   spacing: 0
                   Item { Layout.fillWidth: true; visible: bubbleRow.mine }
                   Text {
                     Layout.rightMargin: bubbleRow.mine ? Style.space(6) : 0
                     Layout.leftMargin: bubbleRow.mine ? 0 : Style.space(6)
                     text: [modelData.failed === true ? "⚠ Not Delivered" : "",
-                           String(modelData.time || ""),
+                           modelData.pending === true ? "Sending…" : String(modelData.time || ""),
                            modelData.edited === true ? "Edited" : "",
                            String(modelData.effect || "") !== "" ? "sent with " + modelData.effect : ""]
                           .filter(function(s) { return s !== "" }).join(" · ")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   says why. Post-send reloads no longer flash "loading…".
 - **One card saved twice is one person.** Two Contacts cards in the same
   source sharing a number are still two people when their names differ — but
-  "Wifey ❤️" and "Wifey❤️" (a space, a capital, a compatibility form) are a
+  "Mom ❤️" and "Mom❤️" (a space, a capital, a compatibility form) are a
   duplicate, and the bridge read them as ambiguity: the most talked-to
   conversation in the list was a bare number with no photo. Names now compare
   spelling-insensitively within a source, and every duplicate is a photo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+- **Sending is instant.** Enter used to mean "sending…" under an unchanged
+  compose field for about three seconds: the ssh hop, osascript, a fixed
+  1.5 s wait for Messages to write the row, then a thread reload. Now the
+  bubble is drawn as Enter is pressed, captioned "Sending…", the field clears
+  at once, and a second message can follow without waiting (text sends
+  queue). The in-flight sends ride every reload on stdin (`--pending-stdin`,
+  never argv); `thread.ts` keeps each bubble until its row appears and
+  resolves it by text and time, so an early reload cannot make it blink.
+  A failed send takes its bubble down, puts the words back in the field and
+  says why. Post-send reloads no longer flash "loading…".
+- **One card saved twice is one person.** Two Contacts cards in the same
+  source sharing a number are still two people when their names differ — but
+  "Wifey ❤️" and "Wifey❤️" (a space, a capital, a compatibility form) are a
+  duplicate, and the bridge read them as ambiguity: the most talked-to
+  conversation in the list was a bare number with no photo. Names now compare
+  spelling-insensitively within a source, and every duplicate is a photo
+  candidate. A stranger's SMS that Messages filed under "Filter Unknown
+  Senders" showed its chat id, `+1818…(filtered)`; the list shows the number.
+  A photo Messages in iCloud has not brought to the Mac yet (`filename` NULL
+  in chat.db) said "no such visible attachment"; the Mac now says it is not
+  downloaded yet, and a clicked chip shows that reason.
 - **Bug hunt (Codex, gpt-6-astra), fourteen fixes.** A 2FA code was written
   to Omarchy's on-disk notification history — the daemon persists every
   displayed toast regardless of the `transient` hint — so the toast now says a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,14 @@ what it is handed. Keep it that way.
   inbound exists. Refreshes carry `activeReadChat()` so a message landing in
   the conversation being READ is counted read in the same run — never
   flashed. Same-chat read refreshes coalesce in the queue.
+- **Sends are optimistic.** `send()` draws the bubble (`pending: true`,
+  "Sending…") and clears the field BEFORE imsg-send runs; text sends queue.
+  `pendingSends` (BarWidget memory, never disk) rides every thread reload on
+  stdin (`--pending-stdin`) and `withPendingSends()` in thread.ts keeps each
+  bubble until a real from-me row with the same text lands, resolving one
+  send per row. The read watermark (`--seen`) skips pending bubbles: their ts
+  is THIS machine's clock. A failed send drops its bubble and restores the
+  text. Never go back to "wait 1.5 s, then reload".
 - **Unread is ledger-backed.** `unreadCounts` and `unreadOldest` persist per-chat
   metadata without message bodies. Catch-up fetches cover new arrivals and the
   oldest outstanding unread so deletions are reconciled; never derive the total

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -32,6 +32,7 @@ import re
 import sqlite3
 import struct
 import sys
+import unicodedata
 from glob import glob
 
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
@@ -219,13 +220,45 @@ def _same_number(handle: Phone, card: Phone) -> bool:
     return False
 
 
+def _card_name(first, last, org, nick) -> str:
+    """The name a ZABCDRECORD row shows: first + last, else organisation, else nickname."""
+    return " ".join(filter(None, [first, last])).strip() or org or nick or ""
+
+
+def _name_key(name: str) -> str:
+    """Spelling-insensitive identity of a name WITHIN one source. Two cards in
+    one book sharing a number are two people when their names differ, but
+    "Mom ❤️" and "Mom❤️" — a space, a capital, a compatibility form — are
+    one card saved twice. Treating those as strangers left the most talked-to
+    person in the list as a bare number, with no photo."""
+    return "".join(unicodedata.normalize("NFKC", name or "").casefold().split())
+
+
+def _one_person(con: sqlite3.Connection, pks: set) -> list[int]:
+    """The records in `pks`, oldest first, when they are one person under
+    _name_key; [] when they are two (or nameless). Photos follow the rule
+    names follow: the first of the duplicates carrying a picture wins."""
+    if not pks:
+        return []
+    if len(pks) == 1:
+        return list(pks)
+    marks = ",".join("?" * len(pks))
+    rows = con.execute(
+        f"SELECT Z_PK, ZFIRSTNAME, ZLASTNAME, ZORGANIZATION, ZNICKNAME "
+        f"FROM ZABCDRECORD WHERE Z_PK IN ({marks})", sorted(pks)
+    ).fetchall()
+    keys = {_name_key(_card_name(*r[1:])) for r in rows}
+    return sorted(pks) if len(rows) == len(pks) and len(keys) == 1 and "" not in keys else []
+
+
 def _vote(local: dict, key, name: str) -> None:
     """One source's answer for a key: the single name it gives, or None once two
     names have collided — and None STAYS None. The old one-liner let a third
     card with the same number resurrect a name after two had cancelled out
-    (Alice, Bob → ambiguous; Carol → "Carol") (Astra #2)."""
+    (Alice, Bob → ambiguous; Carol → "Carol") (Astra #2). The same name spelled
+    twice (_name_key) is not a collision; the first spelling stays."""
     if key in local:
-        if local[key] != name:
+        if local[key] is not None and _name_key(local[key]) != _name_key(name):
             local[key] = None
     else:
         local[key] = name
@@ -292,8 +325,7 @@ def name_for(handle: str | None) -> str | None:
                 con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
                 con.row_factory = sqlite3.Row
                 names = {
-                    r["pk"]: " ".join(filter(None, [r["first"], r["last"]])).strip()
-                    or r["org"] or r["nick"] or ""
+                    r["pk"]: _card_name(r["first"], r["last"], r["org"], r["nick"])
                     for r in con.execute(
                         "SELECT Z_PK AS pk, ZFIRSTNAME AS first, ZLASTNAME AS last, "
                         "ZORGANIZATION AS org, ZNICKNAME AS nick FROM ZABCDRECORD"
@@ -1496,16 +1528,19 @@ def _avatar_candidates(handle: str) -> list[tuple[str, int]]:
                     exact.add(pk)
                 elif parsed and (card := _parse_phone(v or "")) and _same_number(parsed, card):
                     near.add(pk)
+            # Several records inside ONE source: ambiguous there — skip that
+            # source only — unless they are one person saved twice (_one_person).
+            exact_pks = _one_person(con2, exact)
+            near_pks = _one_person(con2, near)
             con2.close()
         except sqlite3.DatabaseError:
             continue
-        # len > 1 inside ONE source: ambiguous there — skip that source only
         if exact:
             exact_any = True
-        if len(exact) == 1:
-            exact_cands.append((path, exact.pop()))
-        elif not exact and len(near) == 1:
-            near_cands.append((path, near.pop()))
+        if exact_pks:
+            exact_cands.extend((path, pk) for pk in exact_pks)
+        elif not exact and near_pks:
+            near_cands.extend((path, pk) for pk in near_pks)
     # The exact key decides whenever ANY source has it — the rule name_for
     # applies globally. Per-source `exact or near` let a nearer source's
     # suffix card put its photo on a conversation named after another source's
@@ -1543,8 +1578,15 @@ def cmd_attachment(con, args):
             LIMIT 1""",
         (int(args.id),),
     ).fetchone()
-    if not row or not row["filename"]:
+    if not row:
         sys.exit("error: no such visible attachment")
+    if not row["filename"]:
+        # The row is real but Messages in iCloud has not brought the bytes to
+        # this Mac (filename NULL, transfer_state 0): a headless gateway that
+        # syncs through CloudKit gets metadata first and media only when the
+        # Mac decides to pull it. Say so — "no such attachment" sent people
+        # hunting for a Blip bug.
+        sys.exit("error: attachment not downloaded on the Mac yet (Messages in iCloud)")
 
     raw = os.path.expanduser(row["filename"])
     outbox = os.path.realpath(OUTBOX_ROOT)

--- a/bridge/mac/test_phone_match.py
+++ b/bridge/mac/test_phone_match.py
@@ -202,6 +202,36 @@ class Ambiguity(Base):
         self.assertIsNone(self.imsg.name_for("shared@example.com"))
 
 
+class OneCardSavedTwice(Base):
+    home = "1"
+
+    def test_spellings_that_differ_only_in_spacing_are_one_person(self) -> None:
+        # The same person twice in ONE source, "Mom ❤️" and "Mom❤️" — a
+        # duplicate card, not two people. They were a bare number with no photo.
+        a = self.book.card("Mom ❤️", "", phones=["5550100200"])
+        b = self.book.card("Mom❤️", "", phones=["+15550100200"], photo=JPEG)
+        self.assertEqual(self.imsg.name_for("+15550100200"), "Mom ❤️")
+        # Both records are photo candidates, oldest first; the first with a picture wins.
+        self.assertEqual(self.imsg._avatar_candidates("+15550100200"), [(self.book.path, a), (self.book.path, b)])
+
+    def test_case_and_compatibility_forms_are_one_person_too(self) -> None:
+        self.book.card("ＡLEX", "rivera", phones=["+15550100201"])
+        self.book.card("Alex", "Rivera", phones=["+15550100201"])
+        self.assertEqual(self.imsg.name_for("+15550100201"), "ＡLEX rivera")
+
+    def test_two_different_names_on_one_number_are_still_nobody(self) -> None:
+        # A married name kept beside the old one is two cards Contacts shows separately.
+        self.book.card("Dana", "Park", phones=["+15550100202"], photo=JPEG)
+        self.book.card("Dana", "Reyes", phones=["+15550100202"], photo=JPEG)
+        self.assertIsNone(self.imsg.name_for("+15550100202"))
+        self.assertEqual(self.imsg._avatar_candidates("+15550100202"), [])
+
+    def test_nameless_duplicates_stay_ambiguous(self) -> None:
+        self.book.card("", "", phones=["+15550100202"], photo=JPEG)
+        self.book.card("", "", phones=["+15550100202"], photo=JPEG)
+        self.assertEqual(self.imsg._avatar_candidates("+15550100202"), [])
+
+
 class AmbiguousExactNeverFallsThrough(Base):
     def test_an_ambiguous_exact_card_blocks_the_suffix_match(self) -> None:
         # Alice and Bob share the exact number; Carol's local-format card would

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -264,6 +264,12 @@ describe("displayName", () => {
     // `imsg chats` returns name:null, and unknown numbers never resolve.
     expect(displayName([msg({ name: null, chat: "878478" })])).toBe("878478");
   });
+  test("a filtered stranger's SMS shows the number, not the chat suffix", () => {
+    expect(displayName([msg({ name: null, chat: "+18184632606(filtered)", handle: "+18184632606(filtered)" })])).toBe("+18184632606");
+    // isGroupChat() files that shape as not-a-DM, so the list labels it through groupName.
+    expect(isGroupChat("+18184632606(filtered)")).toBe(true);
+    expect(groupName("+18184632606(filtered)", undefined, new Map())).toBe("+18184632606");
+  });
 });
 
 describe("selectToasts", () => {

--- a/collector.ts
+++ b/collector.ts
@@ -319,7 +319,15 @@ export function loadMutelist(path = MUTELIST_PATH): string[] {
 /** Display name for a chat, falling back to the raw handle for unknown numbers. */
 export function displayName(msgs: ImsgMessage[]): string {
   for (const m of msgs) if (m.name) return m.name;
-  return chatKey(msgs[0]);
+  return prettyHandle(chatKey(msgs[0]));
+}
+
+/** Messages' "Filter Unknown Senders" files a stranger's SMS under a chat whose
+ *  id is the number with "(filtered)" appended (`any;-;+1818…(filtered)`). The
+ *  id stays the key — sending and reading need it — but the person is the
+ *  number, so the list shows that. */
+export function prettyHandle(id: string): string {
+  return id.replace(/\(filtered\)$/i, "");
 }
 
 /**
@@ -456,7 +464,9 @@ export function hasIdentity(m: ImsgMessage): boolean {
 export function groupName(chat: string, info: GroupInfo | undefined, byHandle: Map<string, string>): string {
   if (info?.name) return info.name;
   const members = (info?.participants ?? []).map((h) => byHandle.get(h) || h);
-  return members.length ? members.join(", ") : chat;
+  // A "(filtered)" stranger is not a phone/email shape, so it lands here (the
+  // never-a-DM-target rule stands: nothing sends to it); its label is the number.
+  return members.length ? members.join(", ") : prettyHandle(chat);
 }
 
 export type SendService = "iMessage" | "SMS" | "RCS";

--- a/thread.test.ts
+++ b/thread.test.ts
@@ -13,9 +13,13 @@ import {
   loadThread,
   localToday,
   minutesBetween,
+  parsePendingSends,
+  pendingBubble,
   receiptLabel,
   selectThread,
+  withPendingSends,
 } from "./thread";
+import type { Bubble, PendingSend } from "./thread";
 import { cliChatArg } from "./thread";
 
 function msg(over: Partial<ImsgMessage> = {}): ImsgMessage {
@@ -596,5 +600,107 @@ describe("cliChatArg (CLI / IPC bare-digit convenience)", () => {
     expect(cliChatArg("someone@example.com")).toBe("someone@example.com");
     expect(cliChatArg("ce5a593a78af408282d61461ade89135")).toBe("ce5a593a78af408282d61461ade89135");
     expect(cliChatArg("chat123456")).toBe("chat123456");
+  });
+});
+
+describe("pending sends (the bubble drawn before the Mac writes the row)", () => {
+  const today = "2026-08-30";
+  const now = Date.parse("2026-08-30T12:00:30");
+  const real = (over: Partial<Bubble> = {}): Bubble =>
+    ({ ...decorate([msg({ from_me: true, text: "on my way", ts: "2026-08-30 11:59:00" })], today)[0]!, ...over });
+  const send = (over: Partial<PendingSend> = {}): PendingSend => ({ chat: "+15551234567", text: "see you soon", ts: "2026-08-30 12:00:00", ...over });
+
+  test("an unresolved send is appended as a pending bubble that joins your run", () => {
+    const r = withPendingSends([real()], [send()], today, DEFAULT_FORMATS, now);
+    expect(r.bubbles).toHaveLength(2);
+    const [prev, mine] = r.bubbles;
+    expect(mine!.pending).toBe(true);
+    expect(mine!.from_me).toBe(true);
+    expect(mine!.text).toBe("see you soon");
+    expect(mine!.time).toBe("12:00 PM");
+    expect(mine!.day).toBe("");                  // same day as the bubble before it
+    expect(mine!.groupStart).toBe(false);
+    expect(prev!.groupEnd).toBe(false);          // the run continues, so the older bubble loses its time
+    expect(prev!.time).toBe("");
+    expect(r.pending).toEqual([send()]);
+  });
+
+  test("the first bubble of an empty thread opens the day", () => {
+    const r = withPendingSends([], [send()], today, DEFAULT_FORMATS, now);
+    expect(r.bubbles[0]!.day).toBe("Today");
+    expect(r.bubbles[0]!.groupStart).toBe(true);
+  });
+
+  test("a reply from them starts a new run", () => {
+    const theirs = decorate([msg({ from_me: false, text: "where are you", ts: "2026-08-30 11:59:00" })], today)[0]!;
+    const r = withPendingSends([theirs], [send()], today, DEFAULT_FORMATS, now);
+    expect(r.bubbles[1]!.groupStart).toBe(true);
+    expect(r.bubbles[0]!.time).toBe("11:59 AM");
+  });
+
+  test("the real row resolves the send and nothing is appended", () => {
+    const landed = real({ text: "see you soon", ts: "2026-08-30 12:00:01" });
+    const r = withPendingSends([real(), landed], [send()], today, DEFAULT_FORMATS, now);
+    expect(r.bubbles).toHaveLength(2);
+    expect(r.bubbles.some((b) => b.pending)).toBe(false);
+    expect(r.pending).toEqual([]);
+  });
+
+  test("the same text sent twice waits for two rows", () => {
+    const landed = real({ text: "ok", ts: "2026-08-30 12:00:01" });
+    const twice = [send({ text: "ok", ts: "2026-08-30 12:00:00" }), send({ text: "ok", ts: "2026-08-30 12:00:05" })];
+    const r = withPendingSends([landed], twice, today, DEFAULT_FORMATS, now);
+    expect(r.bubbles).toHaveLength(2);
+    expect(r.bubbles[1]!.pending).toBe(true);
+    expect(r.pending).toEqual([twice[1]]);
+  });
+
+  test("an identical message from yesterday does not resolve today's send", () => {
+    const old = real({ text: "see you soon", ts: "2026-08-29 12:00:00" });
+    const r = withPendingSends([old], [send()], today, DEFAULT_FORMATS, now);
+    expect(r.bubbles).toHaveLength(2);
+    expect(r.bubbles[1]!.pending).toBe(true);
+  });
+
+  test("a Mac timestamp a little behind the Linux clock still resolves", () => {
+    const landed = real({ text: "see you soon", ts: "2026-08-30 11:58:30" });
+    const r = withPendingSends([landed], [send()], today, DEFAULT_FORMATS, now);
+    expect(r.pending).toEqual([]);
+  });
+
+  test("a send two minutes old without a row is given up on, quietly", () => {
+    const stale = send({ ts: "2026-08-30 11:58:00" });
+    const r = withPendingSends([real()], [stale], today, DEFAULT_FORMATS, now);
+    expect(r.bubbles).toHaveLength(1);
+    expect(r.pending).toEqual([]);
+  });
+
+  test("a retracted or already-pending bubble never resolves a send", () => {
+    const gone = real({ text: "see you soon", ts: "2026-08-30 12:00:01", retracted: true });
+    const r = withPendingSends([gone], [send()], today, DEFAULT_FORMATS, now);
+    expect(r.pending).toHaveLength(1);
+    const again = withPendingSends(r.bubbles, [send()], today, DEFAULT_FORMATS, now);
+    expect(again.bubbles.filter((b) => b.pending)).toHaveLength(2);   // the old pending bubble is not a row
+  });
+
+  test("a URL in a pending bubble is already clickable", () => {
+    const { bubble } = pendingBubble(undefined, send({ text: "look https://example.com" }), today);
+    expect(bubble.html).toContain('<a href="https://example.com">');
+  });
+
+  test("parsePendingSends accepts only well-formed entries", () => {
+    expect(parsePendingSends("nope")).toEqual([]);
+    expect(parsePendingSends(JSON.stringify([{ chat: "a", text: "b", ts: "c" }, { chat: 1 }, null]))).toEqual([{ chat: "a", text: "b", ts: "c" }]);
+  });
+
+  test("loadThread --pending-stdin runs end to end through the CLI", async () => {
+    const proc = Bun.spawn(["bun", "thread.ts", "+15550100001", "5", "--pending-stdin"], {
+      stdin: new TextEncoder().encode(JSON.stringify([{ chat: "+15550100001", text: "hi", ts: localToday() + " 00:00:00" }])),
+      env: { ...process.env, HOME: "/nonexistent-blip-home" },   // no ~/bin/imsg: offline, pending echoed back
+      stdout: "pipe",
+    });
+    const out = JSON.parse(await new Response(proc.stdout).text());
+    expect(out.ok).toBe(false);
+    expect(out.pending).toEqual([{ chat: "+15550100001", text: "hi", ts: localToday() + " 00:00:00" }]);
   });
 });

--- a/thread.ts
+++ b/thread.ts
@@ -12,6 +12,7 @@
 
 import { homedir } from "node:os";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import {
   chatKey,
   dedupeSelfEcho,
@@ -87,13 +88,22 @@ export interface Bubble {
   /** A message of yours that Messages could not deliver (chat.db error≠0) —
    *  rendered as a red "Not Delivered" tag. */
   failed: boolean;
+  /** Drawn the moment Enter was pressed, before the Mac has written the row;
+   *  "Sending…" replaces the time. Absent on every real bubble. */
+  pending?: boolean;
 }
+
+/** A send in flight: what was typed, where, and when Enter was pressed
+ *  (local "YYYY-MM-DD HH:MM:SS"). Lives in BarWidget memory only. */
+export interface PendingSend { chat: string; text: string; ts: string }
 
 export interface ThreadOutput {
   ok: boolean;
   online: boolean;
   error: string;
   bubbles: Bubble[];
+  /** Sends for this chat the Mac has not written yet (`--pending-stdin`). */
+  pending?: PendingSend[];
 }
 
 // ---------------------------------------------------------------- formatting
@@ -314,6 +324,102 @@ export function linkify(text: string): string {
   return out.replace(/\n/g, "<br>");
 }
 
+// ------------------------------------------------------------ pending sends
+//
+// A send used to be: osascript on the Mac, a 1.5 s "beat" for Messages to
+// write the row, a thread reload — three seconds of "sending…" under an
+// unchanged compose field. Now the view draws the bubble as Enter is pressed
+// and hands every reload the list of sends still in flight; this is where a
+// provisional bubble is kept until its real row appears, or resolved by it.
+
+/** A send older than this without a row is given up on (never marked failed:
+ *  imsg-send exited 0, so it most likely went; the next real reload shows it). */
+export const PENDING_MAX_AGE_MS = 2 * 60 * 1000;
+/** A real row may carry a Mac timestamp a little BEHIND the Linux clock. */
+const PENDING_SKEW_MS = 5 * 60 * 1000;
+
+function stampMs(ts: string): number {
+  return Date.parse(String(ts).replace(" ", "T"));
+}
+
+/** The bubble for a send in flight, decorated against the bubble before it
+ *  the way decorate() would: same run when it follows one of yours within
+ *  the gap (that bubble then loses its time), a day divider when it starts one. */
+export function pendingBubble(prev: Bubble | undefined, send: PendingSend, today: string, formats = DEFAULT_FORMATS): { bubble: Bubble; prev: Bubble | undefined } {
+  const ts = send.ts;
+  const newDay = !prev || prev.ts.slice(0, 10) !== ts.slice(0, 10);
+  const groupStart = !prev || newDay || !prev.from_me || minutesBetween(prev.ts, ts) > GROUP_GAP_MINUTES;
+  const bubble: Bubble = {
+    ts,
+    from_me: true,
+    name: "",
+    text: send.text.trim(),
+    day: newDay ? dayLabel(ts, today, formats) : "",
+    groupStart,
+    groupEnd: true,
+    time: clockLabel(ts, formats.time),
+    receipt: "",
+    tapbacks: [],
+    attachments: [],
+    replyText: "",
+    replyMine: false,
+    edited: false,
+    link: null,
+    retracted: false,
+    effect: "",
+    audio: false,
+    html: linkify(send.text.trim()),
+    failed: false,
+    pending: true,
+  };
+  return { bubble, prev: prev && !groupStart ? { ...prev, groupEnd: false, time: "" } : prev };
+}
+
+/**
+ * Fold sends in flight into a freshly loaded thread. A pending send is
+ * RESOLVED by a real bubble of yours with the same text that is not older
+ * than the send (minus clock skew) — each real bubble resolves one send, so
+ * "ok" twice waits for two rows. Unresolved sends are appended as pending
+ * bubbles, oldest first; ones older than PENDING_MAX_AGE_MS are dropped.
+ * Returns the merged list and what is still outstanding.
+ */
+export function withPendingSends(bubbles: Bubble[], pending: PendingSend[], today: string, formats = DEFAULT_FORMATS, now = Date.now()): { bubbles: Bubble[]; pending: PendingSend[] } {
+  const live = pending
+    .filter((p) => Number.isFinite(stampMs(p.ts)) && now - stampMs(p.ts) <= PENDING_MAX_AGE_MS)
+    .sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  if (live.length === 0) return { bubbles, pending: [] };
+  const taken = new Set<number>();
+  const open: PendingSend[] = [];
+  for (const p of live) {
+    const want = p.text.trim();
+    let hit = -1;
+    for (let i = bubbles.length - 1; i >= 0; i--) {
+      const b = bubbles[i]!;
+      if (taken.has(i) || !b.from_me || b.retracted || b.pending) continue;
+      if (b.text !== want || stampMs(b.ts) < stampMs(p.ts) - PENDING_SKEW_MS) continue;
+      hit = i; break;
+    }
+    if (hit >= 0) taken.add(hit); else open.push(p);
+  }
+  const out = bubbles.slice();
+  for (const p of open) {
+    const { bubble, prev } = pendingBubble(out[out.length - 1], p, today, formats);
+    if (prev && out.length) out[out.length - 1] = prev;
+    out.push(bubble);
+  }
+  return { bubbles: out, pending: open };
+}
+
+/** `--pending-stdin`: the view's in-flight sends, JSON on stdin (message
+ *  text never rides argv). Anything malformed reads as "none". */
+export function parsePendingSends(raw: string): PendingSend[] {
+  try {
+    const v = JSON.parse(raw);
+    if (!Array.isArray(v)) return [];
+    return v.filter((p) => p && typeof p.chat === "string" && typeof p.text === "string" && typeof p.ts === "string");
+  } catch { return []; }
+}
+
 /** "Read 4:42 PM" today, "Read Yesterday 9:03 AM" otherwise. */
 export function receiptLabel(readAt: string, today: string, formats = DEFAULT_FORMATS): string {
   const clock = clockLabel(readAt, formats.time);
@@ -418,7 +524,19 @@ if (import.meta.main) {
   const limit = Number(process.argv[3] ?? 80) || 80;
   const today = localToday();
   try {
-    console.log(JSON.stringify(loadThread(chat, limit, today, formatsFromArgv(process.argv))));
+    const formats = formatsFromArgv(process.argv);
+    const result = loadThread(chat, limit, today, formats);
+    if (process.argv.includes("--pending-stdin")) {
+      const mine = parsePendingSends(readFileSync(0, "utf8")).filter((p) => p.chat === chat);
+      if (result.ok) {
+        const merged = withPendingSends(result.bubbles, mine, today, formats);
+        result.bubbles = merged.bubbles;
+        result.pending = merged.pending;
+      } else {
+        result.pending = mine;
+      }
+    }
+    console.log(JSON.stringify(result));
   } catch (e) {
     console.log(JSON.stringify({ ok: false, online: false, error: String(e), bubbles: [] }));
   }

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -16,7 +16,7 @@ function handleTextKeySource() {
 describe("QML safety invariants", () => {
   test("group sends use the cached AppleScript GUID", () => {
     expect(panel).toContain('["--chat-id", String(root.active.guid)]');
-    expect(panel).toContain('["--to", sendChat]');
+    expect(panel).toContain('["--to", chat]');
   });
 
   test("thread results are accepted only for the active chat", () => {
@@ -41,12 +41,26 @@ describe("QML safety invariants", () => {
 
   test("send completion owns immutable chat and draft context", () => {
     expect(panel).toContain("var completedChat = root.sendChat");
-    expect(panel).toContain("if (composeField.text === completedText) composeField.text = \"\"");
+    expect(panel).toContain("var completedStamp = root.sendStamp");
+    // the field clears as Enter is pressed; a failure puts the words back
+    // only when nothing newer has been typed
+    expect(panel).toContain("if (composeField.text === \"\") composeField.text = completedText");
+  });
+
+  test("a send shows its bubble at once and reloads carry the in-flight ledger on stdin", () => {
+    expect(panel).toContain("root.bubbles = root.appendPendingBubble(root.bubbles, text, stamp)");
+    expect(panel).toContain("root.pendingSends = root.pendingSends.concat([{ chat: chat, text: text, ts: stamp }])");
+    expect(panel).toContain('"--pending-stdin"');
+    expect(panel).toContain("threadProc.write(JSON.stringify(pending))");
+    expect(panel).toContain("root.dropPending(completedChat, completedStamp)");
+    expect(panel).toContain('modelData.pending === true ? "Sending…"');
+    // the read watermark never takes a pending bubble's local-clock stamp
+    expect(panel).toContain("if (list[k].pending === true) continue");
   });
 
   test("message text leaves this machine on stdin, never in argv (audit #4)", () => {
     expect(panel).toContain('"--text-stdin"');
-    expect(panel).toContain("sendProc.write(text)");
+    expect(panel).toContain("sendProc.write(job.text)");
     expect(panel).not.toContain('["--yes", "--", text]');
   });
 


### PR DESCRIPTION
Two things found while running Blip against a real Mac: a heavily used conversation in the list was a bare number with no photo, and every send sat under "sending…" for about three seconds.

## Contacts: one card saved twice is one person

The bridge treats two cards in **one** source sharing a number as ambiguity and names nobody. That is the right call when the names differ, but `Mom ❤️` and `Mom❤️` are the same card saved twice, and a duplicate like that cost a conversation its name and photo.

- `name_for` now compares names within a source through `_name_key` (NFKC, casefold, whitespace stripped) before calling a collision ambiguous. The first spelling wins. Two genuinely different names on one number still resolve to nobody.
- `_avatar_candidates` follows the same rule: every duplicate is a photo candidate, oldest first, so the first with a picture wins.
- A stranger's SMS that Messages filed under Filter Unknown Senders carries a chat id ending in `(filtered)`. It stays not-a-DM (nothing sends to it), but the list now shows the number instead of the raw id.
- `imsg attachment` on a row Messages in iCloud has not brought to the Mac (`filename` NULL) said "no such visible attachment". It now says the attachment is not on the Mac yet, and a clicked chip shows that reason.

## Send: the bubble appears as Enter is pressed

A send was ssh, osascript, a fixed 1.5 s wait for Messages to write the row, then a thread reload.

- `send()` draws the bubble at once (`pending: true`, captioned "Sending…"), clears the field, and queues text sends so a second message need not wait.
- In-flight sends live in `pendingSends` (memory only) and ride every thread reload on stdin (`--pending-stdin`, never argv). `withPendingSends()` in `thread.ts` keeps each bubble until a real from-me row with the same text lands. One row resolves one send; a row older than the send, minus clock skew, does not. An early reload cannot make the bubble blink.
- Post-send reloads fire after 600 ms, retry quietly a few times, and no longer flash "loading…".
- A failed send drops its bubble, puts the text back unless something newer was typed, and says why.
- The read watermark (`--seen`) skips pending bubbles, since their timestamp is the Linux clock.

The rule is written up as a new invariant in `CLAUDE.md` ("Sends are optimistic").

## Verification

- `bun test`: 370 pass. Twelve new tests cover the reconciliation rules; `ui.test.ts` contracts updated to the new send shape.
- Mac-side `unittest`: 44 pass, four new for duplicate cards.
- Live on macOS 26.5.2: the name and photo resolve, a self-thread send had its bubble in the model 81 ms after the call, and the Mac's row replaced it on the next reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
