### PR TITLE
The window's sidebar previews the thread under the cursor without marking it read

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -391,8 +391,9 @@ BarWidget {
     var p = panelLoader.item
     if (p && p.opened === true && p.inThread === true) return p
     var w = windowLoader.item
-    // the window must be FOCUSED to count as being read (war room #25)
-    if (w && w.visible === true && w.focused === true && w.inThread === true) return w
+    // the window must be FOCUSED to count as being read (war room #25), and
+    // a thread merely peeked from the sidebar cursor is not being read either
+    if (w && w.visible === true && w.focused === true && w.inThread === true && w.peeking !== true) return w
     return null
   }
   function activeReadChat() {

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1804,6 +1804,9 @@ FocusScope {
     if (key === Qt.Key_Down) { moveCursor(1); return true }
     if (key === Qt.Key_Up) { moveCursor(-1); return true }
     if (key === Qt.Key_Return || key === Qt.Key_Enter) { activateCursor(); return true }
+    // Right = into the right pane: focus the compose field of the thread on
+    // screen (which commits a peek). Left in an EMPTY compose field comes back.
+    if (key === Qt.Key_Right && inThread) { composeField.forceActiveFocus(); return true }
     return false
   }
   function catchEscape() {
@@ -3226,7 +3229,7 @@ FocusScope {
 
               TextArea {
                 id: composeField
-              onActiveFocusChanged: if (activeFocus) root.commitPeek()
+                onActiveFocusChanged: if (activeFocus) root.commitPeek()
                 width: composeFlick.width
                 // At least the viewport, so a click in empty space still lands in
                 // the field; taller than it once the text outgrows five lines.
@@ -3265,6 +3268,15 @@ FocusScope {
                 // Esc drops a bubble selection first (back to the bottom), then
                 // leaves the thread — the two-step Esc a text selection gets.
                 Keys.onEscapePressed: if (root.shareUrl !== "") root.closeShare(); else if (root.bubbleCursor >= 0) root.leaveBubbles(); else root.back()
+                // Left from the START of the text (or an empty field) hands focus
+                // back to the sidebar (split view); anywhere else it moves the
+                // caret as usual — the arrows' edge rule. Not while the share
+                // sheet is up: a specific-key handler runs before Keys.onPressed
+                // and counts as accepted, and there Left is the sheet's.
+                Keys.onLeftPressed: function(event) {
+                  if (root.splitView && cursorPosition === 0 && root.shareUrl === "") root.navigationFocusRequested()
+                  else event.accepted = false
+                }
                 // Ctrl+V goes through paste.ts: an image on the clipboard becomes
                 // a draft chip; text falls through to a manual insert. One process
                 // snapshots types AND data — probing then re-reading races.

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -430,17 +430,30 @@ FocusScope {
   // is no copy to make and no change to signal.
   readonly property var drafts: hostWidget ? hostWidget.draftCache : ({})
 
-  /** Back to the list view, scrolled to top — the host calls this on open. */
-  function resetToList() {
-    closeShare()   // the sheet belongs to the link you were looking at
+  /** Drop the thread on screen, peeked or opened: the pane is empty again, a
+   *  load still in flight is ignored when it lands, and a share sheet over it
+   *  goes too (it belonged to the link you were looking at). */
+  function clearThread() {
+    closeShare()
     peekTimer.stop()
     peeking = false
     active = null
     bubbles = []
     note = ""
-    cursor = -1
     loading = false
     pendingThreadChat = ""
+  }
+  /** Leaving the list for the search or new-message field: a thread that was
+   *  only peeked goes; one opened on purpose stays. */
+  function endPeek() {
+    peekTimer.stop()
+    if (peeking) clearThread()
+  }
+
+  /** Back to the list view, scrolled to top — the host calls this on open. */
+  function resetToList() {
+    clearThread()
+    cursor = -1
     composeField.text = ""
     searching = false
     searchResults = []
@@ -457,14 +470,7 @@ FocusScope {
   }
 
   function back() {
-    closeShare()   // ditto: navigating away dismisses the sheet
-    peekTimer.stop()
-    peeking = false
-    active = null
-    bubbles = []
-    note = ""
-    loading = false
-    pendingThreadChat = ""
+    clearThread()
     composeField.text = ""
     clearDraft()   // a queued file must never survive into another thread
     pinToBottom = false
@@ -492,7 +498,7 @@ FocusScope {
    *  Messages' sidebar does, but leave focus in the list and the dot alone. */
   function peekCursor() {
     var t = threads[cursor]
-    if (!t || isShowing(t)) return
+    if (!t || !cursorShown || isShowing(t)) return   // no cursor shown, no peek
     peeking = true
     showThread(t)
   }
@@ -913,6 +919,7 @@ FocusScope {
 
   function startNew() {
     if (inThread && !splitView) return   // split view: the list pane is right there
+    endPeek()
     exitSearch()
     threadFlick.contentY = 0   // the field sits above the rows
     newMode = true
@@ -1039,6 +1046,7 @@ FocusScope {
 
   function startSearch() {
     if (inThread && !splitView) return
+    endPeek()
     threadFlick.contentY = 0   // the field sits above the rows
     searching = true
     searchResults = []

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -315,6 +315,10 @@ FocusScope {
   property string seenTs: ""
   property string note: ""           // transient status line (send result, errors)
   property int cursor: -1            // keyboard row selection in list view
+  // Split view: the thread on screen because the cursor RESTED on its row, not
+  // because the reader chose it. Read marks wait until they commit — Enter, a
+  // click or typing all put focus in the compose field, which clears this.
+  property bool peeking: false
   // Chat of the cursor row, so every row answers "am I the cursor?" with one
   // string compare instead of an O(n) scan of threads per row per keypress.
   readonly property string cursorChat: cursor >= 0 && cursor < threads.length ? String(threads[cursor].chat) : ""
@@ -429,6 +433,8 @@ FocusScope {
   /** Back to the list view, scrolled to top — the host calls this on open. */
   function resetToList() {
     closeShare()   // the sheet belongs to the link you were looking at
+    peekTimer.stop()
+    peeking = false
     active = null
     bubbles = []
     note = ""
@@ -452,6 +458,8 @@ FocusScope {
 
   function back() {
     closeShare()   // ditto: navigating away dismisses the sheet
+    peekTimer.stop()
+    peeking = false
     active = null
     bubbles = []
     note = ""
@@ -468,12 +476,38 @@ FocusScope {
     })
   }
 
+  function isShowing(t) { return inThread && String(active.chat) === String(t.chat) }
   function openThread(t) {
     if (!t) return
     // A sheet opened over the PREVIOUS conversation (an arriving link opens it
     // by itself) otherwise floats over this one, offering a QR for a link that
     // is no longer on screen. Found by driving the live panel, 2026-09-07.
     closeShare()
+    // Enter on the row already peeked commits it (the compose field's focus
+    // handler marks it read) without reloading what is on screen.
+    if (!(peeking && isShowing(t))) { peeking = false; showThread(t) }
+    Qt.callLater(function() { composeField.forceActiveFocus() })
+  }
+  /** peekTimer fired (split view only): show the cursor row's thread the way
+   *  Messages' sidebar does, but leave focus in the list and the dot alone. */
+  function peekCursor() {
+    var t = threads[cursor]
+    if (!t || isShowing(t)) return
+    peeking = true
+    showThread(t)
+  }
+  function commitPeek() {
+    if (!peeking) return
+    peeking = false
+    // A load still running marks it on completion (peeking is false by then).
+    if (!loading) markRead(String(active.chat), seenTs)
+  }
+  /** The one gate for "this thread was looked at": a surface that marks read,
+   *  and not a thread merely peeked. */
+  function markRead(chat, seen) {
+    if (hostWidget && readActive && !peeking) hostWidget.markThreadRead(chat, seen)
+  }
+  function showThread(t) {
     active = t
     activeLastTs = String(t.last_ts || "")
     bubbles = []
@@ -488,7 +522,6 @@ FocusScope {
     composeField.cursorPosition = composeField.length
     clearDraft()   // a queued file must never survive into another thread
     requestThreadLoad(String(t.chat))
-    Qt.callLater(function() { composeField.forceActiveFocus() })
   }
 
   function requestThreadLoad(chat) {
@@ -1390,7 +1423,7 @@ FocusScope {
               // produce identical content; this makes them free.
               root.rendered = true
               root.seenTs = seen
-              if (root.hostWidget && root.readActive) root.hostWidget.markThreadRead(root.threadRunningChat, seen)
+              root.markRead(root.threadRunningChat, seen)
               return
             }
             root.bubblesJson = j
@@ -1404,7 +1437,7 @@ FocusScope {
             Qt.callLater(root.autoFetchImages)
             // A dot means "looked at", so clear it only after content loaded —
             // and only through what loaded, never the sidebar's newer ts.
-            if (root.hostWidget && root.readActive) root.hostWidget.markThreadRead(root.threadRunningChat, seen)
+            root.markRead(root.threadRunningChat, seen)
           } else {
             root.bubbles = []
             root.rendered = false
@@ -1688,6 +1721,11 @@ FocusScope {
       root.runSearch()
     }
   }
+  // A cursor that rests on a row for a beat shows that thread (Messages'
+  // sidebar behaviour). Restarted on every move, so a held arrow key does not
+  // start a load per row; the thread loader's latest-wins queue drops whatever
+  // a fast scroll still managed to start.
+  Timer { id: peekTimer; interval: 250; onTriggered: root.peekCursor() }
   Timer {
     id: reloadTimer
     // Messages usually has the row within a few hundred ms of osascript
@@ -1705,12 +1743,13 @@ FocusScope {
   // press past the last row landing at the top reads as a jump, not a loop
   // (Omarchy's Dropdown clamps the same way).
   function moveCursor(dy) {
-    if (inThread || threads.length === 0 || dy === 0) return
+    if (!listShowing || threads.length === 0 || dy === 0) return
     // Up from the first row hands focus to the search field above the list,
     // and Down in an empty field hands it back (Omarchy's SearchableDropdown).
     if (dy < 0 && cursor <= 0) { startSearch(); return }
     cursor = Math.max(0, Math.min(threads.length - 1, cursor + dy))
     scrollCursorIntoView()
+    if (splitView) peekTimer.restart()
   }
   // Keep the cursor row inside threadFlick's viewport. The list is a
   // multi-section Column (pinned grid, headers, three Repeaters), so there is
@@ -1731,7 +1770,7 @@ FocusScope {
       threadFlick.contentY = Math.min(maxY, bottom + margin - threadFlick.height)
   }
   function activateCursor() {
-    if (!inThread && cursor >= 0) openThread(threads[cursor])
+    if (listShowing && cursor >= 0) openThread(threads[cursor])
   }
   function handleTextKey(text) {
     if (text === "/") { startSearch(); return true }
@@ -3187,6 +3226,7 @@ FocusScope {
 
               TextArea {
                 id: composeField
+              onActiveFocusChanged: if (activeFocus) root.commitPeek()
                 width: composeFlick.width
                 // At least the viewport, so a click in empty space still lands in
                 // the field; taller than it once the text outgrows five lines.

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1929,7 +1929,9 @@ FocusScope {
           ColumnLayout {
             id: listContent
             width: parent.width
-            spacing: root.inThread ? Style.space(2) : Style.space(root.splitView ? 10 : 6)
+            // One spacing in split view: inThread flips there with every preview,
+            // and the sidebar must not shift. The popout tightens up in a thread.
+            spacing: root.splitView ? Style.space(10) : (root.inThread ? Style.space(2) : Style.space(6))
 
             // ------------------------------------------------- OFFLINE
             Text {

--- a/BlipWindow.qml
+++ b/BlipWindow.qml
@@ -43,6 +43,7 @@ FloatingWindow {
   readonly property bool loading: view.loading
   readonly property bool rendered: view.rendered
   readonly property string seenTs: view.seenTs
+  readonly property bool peeking: view.peeking
   readonly property string activeLastTs: view.activeLastTs
   function openThread(t) { view.openThread(t) }
   function shareLink(url) { return view.shareLink(url) }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **The window's sidebar previews on the cursor.** Rest the arrow keys on a row
+  for a beat and the right pane shows that thread, the way Messages' sidebar
+  does — no Enter needed. Focus stays in the list, so the arrows keep walking,
+  and the thread is *not* marked read: only Enter, a click or typing, which put
+  focus in the compose field, commit it. The bar panel is unchanged.
 - **Reading a conversation can now clear it on your phone.** `push_read` in
   `bridge.conf` gained a documented middle setting and a status surface. The
   default, `all`, pushes to the Mac *only* on the mark-all gesture — so reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   does — no Enter needed. Focus stays in the list, so the arrows keep walking,
   and the thread is *not* marked read: only Enter, a click or typing, which put
   focus in the compose field, commit it. `→` steps into the compose field and
-  `←` from the start of the text steps back to the sidebar. The bar panel is unchanged.
+  `←` from the start of the text steps back to the sidebar. Leaving the list for
+  the search or new-message field ends a preview, so the pane is empty again.
+  The bar panel is unchanged.
 - **Reading a conversation can now clear it on your phone.** `push_read` in
   `bridge.conf` gained a documented middle setting and a status surface. The
   default, `all`, pushes to the Mac *only* on the mark-all gesture — so reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   for a beat and the right pane shows that thread, the way Messages' sidebar
   does — no Enter needed. Focus stays in the list, so the arrows keep walking,
   and the thread is *not* marked read: only Enter, a click or typing, which put
-  focus in the compose field, commit it. The bar panel is unchanged.
+  focus in the compose field, commit it. `→` steps into the compose field and
+  `←` from the start of the text steps back to the sidebar. The bar panel is unchanged.
 - **Reading a conversation can now clear it on your phone.** `push_read` in
   `bridge.conf` gained a documented middle setting and a status surface. The
   default, `all`, pushes to the Mac *only* on the mark-all gesture — so reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@
 
 - **The window's sidebar previews on the cursor.** Rest the arrow keys on a row
   for a beat and the right pane shows that thread, the way Messages' sidebar
-  does — no Enter needed. Focus stays in the list, so the arrows keep walking,
-  and the thread is *not* marked read: only Enter, a click or typing, which put
-  focus in the compose field, commit it. `→` steps into the compose field and
-  `←` from the start of the text steps back to the sidebar. Leaving the list for
-  the search or new-message field ends a preview, so the pane is empty again.
-  The bar panel is unchanged.
+  does. Focus stays in the list and the thread is *not* marked read; Enter, a
+  click or typing commits it. `→` steps into the compose field, `←` from the
+  start of the text steps back. Leaving the list for the search or new-message
+  field ends the preview, and the sidebar holds still while the pane fills or
+  empties. The bar panel is unchanged.
 - **Reading a conversation can now clear it on your phone.** `push_read` in
   `bridge.conf` gained a documented middle setting and a status surface. The
   default, `all`, pushes to the Mac *only* on the mark-all gesture — so reading

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,12 @@ what it is handed. Keep it that way.
   send per row. The read watermark (`--seen`) skips pending bubbles: their ts
   is THIS machine's clock. A failed send drops its bubble and restores the
   text. Never go back to "wait 1.5 s, then reload".
+- **A peeked thread is not read.** In the window, the sidebar cursor resting on
+  a row shows that thread (`peeking`); focus stays in the list and neither
+  read path fires — `markRead()` in BlipView (the only caller of the host's
+  `markThreadRead`) and `readingSurface()` in BarWidget both check it. Focus
+  entering the compose field (Enter, click, typing) is the commit. Split view
+  only.
 - **Unread is ledger-backed.** `unreadCounts` and `unreadOldest` persist per-chat
   metadata without message bodies. Catch-up fetches cover new arrivals and the
   oldest outstanding unread so deletions are reconciled; never derive the total

--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ rather than hang:
 |---|---|---|
 | list | `j` / `k` · `↑` / `↓` | move |
 | list | `Enter` · `1`–`9` | open thread (the first nine rows show the digit; Super+M jumps from an empty compose) |
+| list (window) | rest on a row | the right pane shows that thread, like Messages' sidebar — without marking it read; `Enter`, a click or typing commits it |
 | list | `r` | refresh |
 | list | `a` · *mark all read* link | clear every badge and dot — and tell the Mac, so your iPhone catches up too |
 | list | `/` | search conversations by name as you type, then messages; Enter opens the highlight, Esc backs out |

--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ rather than hang:
 | list | `j` / `k` · `↑` / `↓` | move |
 | list | `Enter` · `1`–`9` | open thread (the first nine rows show the digit; Super+M jumps from an empty compose) |
 | list (window) | rest on a row | the right pane shows that thread, like Messages' sidebar — without marking it read; `Enter`, a click or typing commits it |
+| window | `→` · `←` | into the compose field · back to the sidebar (from the start of the text, or an empty field) |
 | list | `r` | refresh |
 | list | `a` · *mark all read* link | clear every badge and dot — and tell the Mac, so your iPhone catches up too |
 | list | `/` | search conversations by name as you type, then messages; Enter opens the highlight, Esc backs out |

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -429,6 +429,8 @@ describe("QML safety invariants", () => {
     expect(qmlFunction("startNew")).toContain("endPeek()");
     expect(qmlFunction("endPeek")).toContain("if (peeking) clearThread()");
     expect(qmlFunction("peekCursor")).toContain("!cursorShown");
+    // The sidebar's spacing must not follow inThread in split view (8px shift).
+    expect(panel).toContain("spacing: root.splitView ? Style.space(10) : (root.inThread ? Style.space(2) : Style.space(6))");
     expect(qmlFunction("moveCursor")).toContain("if (splitView) peekTimer.restart()");
     // one place empties the pane; back() and resetToList() go through it
     expect(qmlFunction("clearThread")).toContain("peekTimer.stop()");

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -329,6 +329,10 @@ describe("QML safety invariants", () => {
     expect(fn).toContain("moveCursor(1)");
     expect(fn).toContain("moveCursor(-1)");
     expect(fn).toContain("activateCursor()");
+    // Right steps into the compose field (committing a peek); Left in an
+    // empty compose field steps back, with text it stays a caret move.
+    expect(fn).toContain("if (key === Qt.Key_Right && inThread) { composeField.forceActiveFocus(); return true }");
+    expect(panel).toContain('if (root.splitView && cursorPosition === 0 && root.shareUrl === "") root.navigationFocusRequested()');
   });
 
   test("Omarchy's shell toggle can find the panel", () => {

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -197,9 +197,11 @@ describe("QML safety invariants", () => {
     // The sheet auto-opens on an ARRIVING link. Without this it survived into
     // the next conversation, and resetToList() (which the host runs on every
     // open) brought a stale sheet back over the list. Found live, 2026-09-07.
-    for (const fn of ["resetToList", "back", "openThread"]) {
-      expect(qmlFunction(fn)).toContain("closeShare()");
-    }
+    // resetToList() and back() empty the pane through clearThread(), which
+    // closes the sheet; openThread() closes it itself before showing the next.
+    expect(qmlFunction("clearThread")).toContain("closeShare()");
+    for (const fn of ["resetToList", "back"]) expect(qmlFunction(fn)).toContain("clearThread()");
+    expect(qmlFunction("openThread")).toContain("closeShare()");
     // Esc still closes the sheet BEFORE it unwinds the view (Astra A#7)
     expect(panel).toContain('if (root.shareUrl !== "") root.closeShare(); else if (root.bubbleCursor >= 0)');
   });
@@ -422,12 +424,16 @@ describe("QML safety invariants", () => {
 
   test("peeking is split-view only, debounced, and cleared on the way out", () => {
     expect(panel).toContain("Timer { id: peekTimer;");
+    // Leaving the list for a field ends a peek; an opened thread stays.
+    expect(qmlFunction("startSearch")).toContain("endPeek()");
+    expect(qmlFunction("startNew")).toContain("endPeek()");
+    expect(qmlFunction("endPeek")).toContain("if (peeking) clearThread()");
+    expect(qmlFunction("peekCursor")).toContain("!cursorShown");
     expect(qmlFunction("moveCursor")).toContain("if (splitView) peekTimer.restart()");
-    for (const name of ["back", "resetToList"]) {
-      const fn = qmlFunction(name);
-      expect(fn).toContain("peekTimer.stop()");
-      expect(fn).toContain("peeking = false");
-    }
+    // one place empties the pane; back() and resetToList() go through it
+    expect(qmlFunction("clearThread")).toContain("peekTimer.stop()");
+    expect(qmlFunction("clearThread")).toContain("peeking = false");
+    for (const name of ["back", "resetToList"]) expect(qmlFunction(name)).toContain("clearThread()");
   });
 
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -219,7 +219,7 @@ describe("QML safety invariants", () => {
     expect(widget).toContain("property var refreshQueue: []");
     expect(widget).not.toContain("property var queued: null");
     const success = panel.indexOf("if (d.ok === true)");
-    const mark = panel.indexOf("markThreadRead(root.threadRunningChat, seen)");
+    const mark = panel.indexOf("markRead(root.threadRunningChat, seen)");
     expect(success).toBeGreaterThan(-1);
     expect(mark).toBeGreaterThan(success);
   });
@@ -403,6 +403,29 @@ describe("QML safety invariants", () => {
     expect(panel).toContain("color: calm ? root.dim : root.urgent");
   });
 
+  test("a peeked thread is not read until the reader commits", () => {
+    // Three read paths, all gated on `peeking`: the two post-load marks in
+    // BlipView and readingSurface() in BarWidget (what the collector is told
+    // is being read). Focus entering the compose field is the commit.
+    expect(qmlFunction("markRead")).toContain("if (hostWidget && readActive && !peeking) hostWidget.markThreadRead(chat, seen)");
+    expect(panel.split("root.markRead(root.threadRunningChat, seen)").length - 1).toBe(2);
+    expect(panel).not.toContain("root.hostWidget.markThreadRead(");
+    expect(panel).toContain("onActiveFocusChanged: if (activeFocus) root.commitPeek()");
+    expect(qmlFunction("commitPeek")).toContain("if (!loading) markRead(String(active.chat), seenTs)");
+    expect(window).toContain("readonly property bool peeking: view.peeking");
+    expect(widget).toContain("w.inThread === true && w.peeking !== true");
+  });
+
+  test("peeking is split-view only, debounced, and cleared on the way out", () => {
+    expect(panel).toContain("Timer { id: peekTimer;");
+    expect(qmlFunction("moveCursor")).toContain("if (splitView) peekTimer.restart()");
+    for (const name of ["back", "resetToList"]) {
+      const fn = qmlFunction(name);
+      expect(fn).toContain("peekTimer.stop()");
+      expect(fn).toContain("peeking = false");
+    }
+  });
+
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {
     // --action=default dies with the notify-send process after eight seconds.
     // The hint is what Omarchy persists, so a row in the notification center
@@ -533,7 +556,7 @@ test("link preview URLs never ride argv", () => {
 // the newest ts in that snapshot — never the sidebar's (Astra A#2, A#3).
 test("reads require a rendered snapshot and carry its own timestamp", () => {
   expect(panel).toContain("property bool rendered: false");
-  expect(panel).toContain("root.hostWidget.markThreadRead(root.threadRunningChat, seen)");
+  expect(panel).toContain("root.markRead(root.threadRunningChat, seen)");   // through the peek gate, same `seen`
   expect(widget).toContain("s.rendered === true");
   expect(widget).toContain('return s ? String(s.seenTs || "") : ""');
   expect(widget).toContain("function markThreadRead(chat, seen)");


### PR DESCRIPTION
## What

In the app window, resting the sidebar cursor on a conversation shows it in the right pane, the way Messages' sidebar does. No Enter needed, focus stays in the list, so the arrows keep walking. A previewed thread is **not** marked read; only Enter, a click or typing, which put focus in the compose field, commit it. `→` steps from the list into the compose field and `←` from the start of the text steps back. Leaving the list for the search or new-message field ends a preview, so the pane is empty again, and the sidebar keeps one spacing whatever the pane shows. The bar panel is unchanged.

## Why

The window has two panes, and the sidebar cursor from #37 walked the left one while the right one stayed on whatever was opened last. Messages shows the highlighted conversation as you move, and that is what the split view is for. But a glance is not a read: Messages keeps the blue dot until you actually land in the conversation, and the phone's read state must not flip because a cursor passed by. So the preview is gated everywhere a read can be recorded.

Two things fell out of using it. `startSearch()` and `startNew()` left a preview up, or let its timer fire after focus had moved, so the pane showed the top thread beside an empty search field. And the sidebar column's spacing followed `inThread`, a rule meant for the popout where `inThread` hides the list; in the window it flipped with every preview, moving the search field 8 px (measured: y 18 with a thread shown, 26 without).

## How

- **`BlipView.qml`** — `peekTimer` (250 ms, restarted on every cursor move) calls `peekCursor()`, which shows the cursor row's thread with `peeking = true`. `markRead(chat, seen)` is the one caller of the host's `markThreadRead` and checks `peeking`; `commitPeek()` (compose field focus) clears the flag and marks read with the rendered snapshot's `seenTs`. `clearThread()` is the one place the pane is emptied; `back()`, `resetToList()` and `endPeek()` go through it. `endPeek()` runs from `startSearch()` and `startNew()`. `Keys.onLeftPressed` on the compose field steps back to the sidebar from the text's start, except while the share sheet is up, where `←` is the sheet's. The sidebar column keeps `Style.space(10)` in split view.
- **`BlipWindow.qml`** — exposes `peeking`; `→` from the list focuses the compose field.
- **`BarWidget.qml`** — `readingSurface()` ignores a window that is only peeking, so the collector is never told a peeked thread is being read.
- **`ui.test.ts`** — the read gate (every read path checks `peeking`), split-view-only + debounced + cleared on the way out, and the two follow-ups. **`CLAUDE.md`** gains the invariant "A peeked thread is not read"; CHANGELOG under Unreleased.

Rebased on today's main, after #39: `markRead` carries the `seen` timestamp #43 introduced, and the compose field's Esc keeps the three-way order from #39 (sheet, bubble selection, thread).

## How it was verified

- [x] `bun test` is green (CI will check) — 397 pass, on each of the four commits
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → verified live on Omarchy with an incoming DM: the dot stays while the thread is previewed, goes on Enter or `→`, and the phone follows (`push_read=thread`); Up from the first row to the search field leaves the pane empty; the search field holds still while previews come and go
- [x] Touches an invariant in `CLAUDE.md` → **new: "A peeked thread is not read"**

Note: like the other open PRs, this adds to the top of the CHANGELOG; whichever lands later gets a one-line rebase from me.
