### PR TITLE
blip-setup pins the dedicated key to the enrolling machine over Tailscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **`blip-setup` pins the dedicated key to this machine over Tailscale.** The
+  key was confined to the bridge tools but accepted from any address, so a copy
+  of the key file still reached your messages. Over Tailscale the enrolled line
+  now carries `from=<this node's Tailscale addresses>` beside `restrict` and
+  `command=`, and a leaked key file is refused from anywhere else. Over a LAN,
+  where an address can change, the key stays unpinned (`docs/SECURITY.md` shows
+  the manual pin). A re-run replaces the key's line, so a changed address is one
+  re-run away.
 - **Reading a conversation can now clear it on your phone.** `push_read` in
   `bridge.conf` gained a documented middle setting and a status surface. The
   default, `all`, pushes to the Mac *only* on the mark-all gesture — so reading

--- a/README.md
+++ b/README.md
@@ -202,9 +202,10 @@ Linux side. If the Mac is asleep, the widget dims and says so.
 
 No server, no telemetry, no accounts. **Everything between the two machines
 travels inside ssh** — message text, attachment bytes, the push ping — on a
-dedicated key the Mac confines to Blip's five tools; nothing is ever sent in
-the clear. The full inventory of what touches
-disk on both machines is in [docs/PRIVACY.md](docs/PRIVACY.md) — short
+dedicated key the Mac confines to Blip's bridge tools — and, over Tailscale,
+to this machine's address; nothing is ever sent in the clear. The full
+inventory of what touches disk on both machines is in
+[docs/PRIVACY.md](docs/PRIVACY.md) — short
 version: message text never lands on disk; only attachments in conversations
 you open are cached (inline images ≤ 5 MB and link previews fetch when the
 thread does). The threat model and the findings of the 2026-08-31 security audit
@@ -320,8 +321,12 @@ It writes `~/.config/blip/bridge.conf`, adds an ssh ControlMaster block
 `~/bin/imsg`, `~/bin/imsg-send`, `~/bin/contacts`, copies the Mac tools to
 `~/.blip/bin` on the Mac and runs `install.sh` there, generates a
 **dedicated ssh key** (`~/.ssh/blip_ed25519`) that the Mac confines to the
-four bridge tools and nothing else, then smoke-tests the bridge without
-printing any message content.
+bridge tools and nothing else, then smoke-tests the bridge without printing
+any message content. Over Tailscale the key is also pinned to this machine's
+addresses (`from=`), so a copy of the key file is useless from anywhere else;
+over a LAN, where an address can change, it is not pinned —
+[docs/SECURITY.md](docs/SECURITY.md) shows the one-line manual pin. Re-run
+`blip-setup` if the machine's Tailscale address ever changes.
 
 **3. Two grants on the Mac** (macOS won't let a script do these — the
 wizard pauses here and re-checks when you press Enter)

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1473,5 +1474,29 @@ describe("the read-push policy is reported, not just applied", () => {
     expect(pushReadArgs("thread", dm)).toEqual(["--chat", "+15550100001"]);
     // mark-all is never gated: it is an explicit gesture, not a side effect
     expect(pushReadArgs("all", { markRead: true, readChat: "", clearedUnread: false })).toEqual(["--all"]);
+  });
+});
+
+// The dedicated key is confined to blip-dispatch AND, over Tailscale, pinned to
+// the enrolling machine's addresses: a leaked private key is useless from
+// anywhere else. blip_key_from() runs for real (PATH without tailscale).
+describe("blip-setup: the key's from= pin", () => {
+  const setup = new URL("./scripts/blip-setup", import.meta.url).pathname;
+  const keyFrom = (seen: string) => spawnSync("bash",
+    ["-c", 'source <(sed -n "/^blip_key_from()/,/^}/p" "$1"); blip_key_from "$2"', "_", setup, seen],
+    { encoding: "utf8", env: { PATH: "/usr/bin:/bin" } }).stdout;
+  test("a Tailscale address is pinned, IPv4 and IPv6", () => {
+    expect(keyFrom("100.64.7.8")).toBe('from="100.64.7.8",');
+    expect(keyFrom("100.127.255.1")).toBe('from="100.127.255.1",');
+    expect(keyFrom("fd7a:115c:a1e0::1")).toBe('from="fd7a:115c:a1e0::1",');
+  });
+  test("anything else is left unpinned rather than stranded", () => {
+    for (const seen of ["192.168.1.5", "100.63.1.1", "100.128.0.1", "10.0.0.2", "", "mac.local"]) expect(keyFrom(seen)).toBe("");
+  });
+  test("a re-run replaces the key's line; the tool count is gone from the prose", () => {
+    const src = readFileSync(setup, "utf8");
+    expect(src).toContain("grep -vF -- '$pub' ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.blip.tmp");
+    expect(src).not.toContain("five bridge tools");
+    expect(src).not.toContain("key_from=");   // no config knob: the pin follows the transport
   });
 });

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -16,7 +16,7 @@ message bodies, names), a corrupted or stale local state file, a bad
 | # | Severity | Finding | Status |
 |---|---|---|---|
 | 1 | critical | A hostile Mac is unsatisfiable as a threat | **Documented** above — by design |
-| 2 | critical | Any ssh login to the Mac account inherits Full Disk Access + Automation | **Fixed** 1.10.0 — `blip-setup` enrols `~/.ssh/blip_ed25519` on the Mac as `restrict,command="$HOME/.blip/bin/blip-dispatch"`; that key can run only the five bridge tools (no shell, no forwarding, no pty), with its own ssh mux so it never rides the general key's master |
+| 2 | critical | Any ssh login to the Mac account inherits Full Disk Access + Automation | **Fixed** 1.10.0 — `blip-setup` enrols `~/.ssh/blip_ed25519` on the Mac as `restrict,command="$HOME/.blip/bin/blip-dispatch"`; that key can run only the bridge tools (no shell, no forwarding, no pty), with its own ssh mux so it never rides the general key's master |
 | 3 | critical | `qs ipc … compose --yes` / `goto` / `bubbles` let any local process send or read | **Mitigated** 1.10.0 — `goto`/`compose`/`bubbles`/`threads`/`find`/`newchat`/`windowgoto`/`read` require `automation=on` in `bridge.conf` (default off; live-reloaded). Honest scope: this closes the *shell-IPC* deputy only. Any process running as you can still call `~/bin/imsg-send` directly, exactly as it could run `ssh` — that boundary is your user account, not Blip. `status`/`open`/`close`/`toggle`/`window`/`app` expose nothing and stay open |
 | 4 | high | Bodies travel in argv (Linux `/proc`, Mac `osascript -e`) and `imsg-send` echoed 120 chars of body to stderr | **Fixed** 1.9.4 (stderr) + 1.11.0: bodies ride stdin end to end — `--text-stdin` / `--text-stdin-bytes N` (caption ahead of file bytes), and `osascript` reads its script from stdin. Only `notify-send` toasts still carry a preview in argv, by the daemon's design — and a link you CLICK reaches `xdg-open` and your browser as an argument, because that is the only way to open one |
 | 5 | high | Stale contact/search result shown as clickable rows under a newer query | **Fixed** 1.9.4 — generation bumps when a query is queued, results cleared |
@@ -27,6 +27,7 @@ message bodies, names), a corrupted or stale local state file, a bad
 | 10 | medium | Clicked attachments went straight to `xdg-open` regardless of type | **Fixed** 1.9.4 — only image/video/audio/pdf/text/vcard/ics open; others are saved and named |
 | 11 | medium | Symlink in cache followed; `window.json.tmp` could be 0644 | **Fixed** 1.9.4 — `lstat`+regular-file check; `umask 077` |
 | 12 | medium | Catch-up fetch doubled without bound | **Fixed** 1.9.4 — capped at 8192 rows |
+| 13 | medium | A copy of `blip_ed25519` works from any machine — the confinement protects the Mac, not the messages | **Fixed** Unreleased — over Tailscale `blip-setup` pins the key with `from=<this node's addresses>` (both families); a leaked key file is refused from anywhere else. A LAN address is not an identity, so there the key is left unpinned (manual pin below). The Blip key cannot re-enrol itself: `blip-setup` needs the everyday key, which is a shell anyway |
 
 Your everyday ssh key to the Mac still carries Full Disk Access (that grant is per
 `sshd-keygen-wrapper`, not per key) — Blip just no longer *needs* it.
@@ -51,3 +52,15 @@ a test fixture. Deferred items are listed in ROADMAP.md.
 Still open and honest about it: drafts in `$XDG_RUNTIME_DIR/blip` are swept
 lazily rather than deleted on cancel; cache file names include the Mac
 attachment ROWID.
+
+## Hardening by hand
+
+- **Pin the Blip key on a LAN.** `blip-setup` pins the key (`from=`) only when
+  the Mac is reached over Tailscale, where the address is a stable per-node
+  identity (finding 13). On a LAN, give the Linux box a reserved address and
+  prepend `from="192.168.1.0/24",` (or the one address) to the key's line in
+  `~/.ssh/authorized_keys` on the Mac; a re-run of `blip-setup` rewrites that
+  line, so re-add it afterwards.
+- **Or close port 22 one layer down.** On a tailnet, an ACL that lets only the
+  Blip node reach the Mac's port 22 protects every key on that Mac, not just
+  Blip's, and needs no `from=` at all.

--- a/scripts/blip-setup
+++ b/scripts/blip-setup
@@ -102,6 +102,28 @@ for t in imsg imsg-send imsg-read contacts; do
 done
 echo "✓ shims installed: ~/bin/imsg ~/bin/imsg-send ~/bin/imsg-read ~/bin/contacts"
 
+# The from= option for the Blip key's authorized_keys line. $1 = the address
+# this machine reached the Mac from. Over Tailscale that address is a stable
+# per-node identity, so the key is pinned to it — to BOTH of this node's
+# addresses when tailscale is here, since MagicDNS hands out either family.
+# Any other address (a LAN, DHCP) prints nothing: an unpinned key beats a
+# stranded one, and docs/SECURITY.md shows the one-line manual pin.
+blip_key_from() {
+  local seen="$1" v="" second
+  case "$seen" in
+    100.*) second="${seen#100.}"; second="${second%%.*}"
+           [[ "$second" =~ ^[0-9]+$ ]] && (( second >= 64 && second <= 127 )) && v="$seen" ;;   # 100.64.0.0/10
+    fd7a:115c:a1e0:*) v="$seen" ;;                                                            # Tailscale IPv6
+  esac
+  [[ -n "$v" ]] || return 0
+  if command -v tailscale >/dev/null 2>&1; then
+    local ips; ips="$(tailscale ip 2>/dev/null | paste -sd, -)"
+    case ",$ips," in *",$seen,"*) v="$ips" ;; esac
+  fi
+  [[ "$v" =~ ^[0-9A-Fa-f.:,]+$ ]] || return 0
+  printf 'from="%s",' "$v"
+}
+
 # 4. Mac install (needs ssh to already work — key-based)
 if ssh -n -o ConnectTimeout=6 -o BatchMode=yes -- "$host" true 2>/dev/null; then
   ssh -- "$host" 'mkdir -p ~/.blip/src'
@@ -117,18 +139,23 @@ if ssh -n -o ConnectTimeout=6 -o BatchMode=yes -- "$host" true 2>/dev/null; then
   fi
 
   # 4b. Dedicated key, confined on the Mac to blip-dispatch (restrict = no
-  # shell, no forwarding, no pty). Your everyday key is untouched; Blip's key
-  # cannot do anything but run the five bridge tools.
+  # shell, no forwarding, no pty) and, over Tailscale, pinned to this
+  # machine's addresses (from=): sshd refuses it from anywhere else, even
+  # with the private key in hand. A re-run REPLACES the key's line, so a
+  # changed address is one re-run away. Your everyday key is untouched.
   key="$HOME/.ssh/blip_ed25519"
   [[ -f "$key" ]] || ssh-keygen -q -t ed25519 -N "" -C "blip@$(hostname)" -f "$key"
   pub="$(cut -d" " -f1,2 < "$key.pub")"
+  seen="$(ssh -- "$host" 'printf %s "${SSH_CONNECTION%% *}"')"
+  from_opt="$(blip_key_from "$seen")"
   ssh "$host" "umask 077; mkdir -p ~/.ssh; touch ~/.ssh/authorized_keys; \
-    if [ -s ~/.ssh/authorized_keys ] && [ \"\$(tail -c1 ~/.ssh/authorized_keys)\" != '' ]; then echo >> ~/.ssh/authorized_keys; fi; \
-    grep -qF -- '$pub' ~/.ssh/authorized_keys || \
-    printf '%s\n' 'restrict,command=\"\$HOME/.blip/bin/blip-dispatch\" $pub' >> ~/.ssh/authorized_keys"
+    grep -vF -- '$pub' ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.blip.tmp || true; \
+    printf '%s\n' '${from_opt}restrict,command=\"\$HOME/.blip/bin/blip-dispatch\" $pub' >> ~/.ssh/authorized_keys.blip.tmp; \
+    mv ~/.ssh/authorized_keys.blip.tmp ~/.ssh/authorized_keys"
   if [[ "$(ssh -i "$key" -o IdentitiesOnly=yes -o BatchMode=yes -o ControlPath=none "$host" ping 2>/dev/null)" == pong ]] \
      && ! ssh -i "$key" -o IdentitiesOnly=yes -o BatchMode=yes -o ControlPath=none "$host" true >/dev/null 2>&1; then
-    echo "✓ dedicated key enrolled: $key can run only the Blip tools on $host"
+    if [[ -n "$from_opt" ]]; then echo "✓ dedicated key enrolled: $key can run only the Blip tools on $host, and only from ${from_opt#from=}"
+    else echo "✓ dedicated key enrolled: $key can run only the Blip tools on $host (not pinned to an address: $host is not reached over Tailscale — docs/SECURITY.md shows the manual pin)"; fi
   else
     echo "✗ dedicated key did not confine as expected — check ~/.ssh/authorized_keys on the Mac" >&2; exit 1
   fi


### PR DESCRIPTION
## What

`blip-setup` pins the dedicated Blip key to the machine it is enrolled from, when that machine reaches the Mac over Tailscale. The `authorized_keys` line reads `from="<this node's Tailscale addresses>",restrict,command="…/blip-dispatch"`, so the key is refused from anywhere else even with the private key in hand. Over a LAN the key is left unpinned rather than stranded on a DHCP address. A re-run of `blip-setup` replaces the key's line, so a changed address is one re-run away. No new setting: the pin follows the transport.

## Why

The key was already confined to `blip-dispatch` (no shell, no forwarding, no pty), but accepted from any address. The confinement protects the Mac, not the data: the bridge tools read every message and send as you.

**The threat this closes, precisely:** a copy of `~/.ssh/blip_ed25519` used from another machine — a home-directory backup, a sync, a dotfiles repo, a disk read outside the box. It does not address a compromised Linux box (the attacker is already at the pinned address) or a leaked everyday key (that is a shell on the Mac, and nothing in Blip can stand in for it). And the Blip key cannot undo the pin: it has no shell, none of the bridge tools touch `~/.ssh`, and `blip-setup` itself needs the everyday key to enrol anything.

Over Tailscale — where the README sends people — the address is a per-node identity that survives reboots and network changes, so pinning to it costs nothing and turns a leaked key file into a dead file. Elsewhere an address is not an identity, so nothing is pinned there; `docs/SECURITY.md` gets a short "hardening by hand" section with the one-line LAN pin and the Tailscale ACL that closes port 22 one layer down.

I first built this with a `key_from` setting (`auto | off | addresses`) and took it out again: it existed for LAN users on DHCP, who are exactly the users who never open `bridge.conf`, and half the code was validating input that no longer exists.

## How

- **`scripts/blip-setup`** — `blip_key_from()` takes the address the setup session arrived from (`SSH_CONNECTION` on the Mac, one round trip before enrolment): a `100.64.0.0/10` or `fd7a:115c:a1e0::/48` address is pinned, and widened to both of the node's addresses when it is among `tailscale ip`; anything else prints nothing. Step 4b replaces the key's line (`grep -vF` the key, append, `mv` under `umask 077`) and says in its ✓ line whether the key is pinned and to what.
- **`collector.test.ts`** — three tests run `blip_key_from()` for real with a `PATH` without `tailscale`: Tailscale IPv4 and IPv6 pin, `192.168.1.5` / `100.63.1.1` / `100.128.0.1` / `10.0.0.2` / `""` / `mac.local` do not, and the re-run replaces the line.
- **README / SECURITY.md / CHANGELOG** — the sentences that counted the bridge tools ("four", "five"; there are seven) say "the bridge tools" and describe the pin; SECURITY.md row 2 names it and a "Hardening by hand" section covers the LAN pin and the ACL.

## How it was verified

- [x] `bun test` is green (CI will check) — 393 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] The exact remote enrolment command, run locally against a file holding another user's key plus a stale line for the Blip key, leaves the other key alone and ends with one pinned line for the Blip key. `bash -n` passes.
- [x] My own Mac has carried the Tailscale pin by hand since 2026-09-03; the bridge has run on it every day since.
- [ ] Touches an invariant in `CLAUDE.md` → no

Note: adds a line at the top of the CHANGELOG like the other open PR; whichever lands later gets a one-line rebase from me.
