### PR TITLE
fix: restore the app on its last workspace without taking focus

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -176,7 +176,7 @@ BarWidget {
     }
     // A fresh BlipWindow honours window.json (which may say hidden) — this
     // call means SHOW, so make it so once its restore pass has run.
-    Qt.callLater(function() { if (windowLoader.item && !windowLoader.item.visible) windowLoader.item.visible = true })
+    Qt.callLater(function() { if (windowLoader.item) windowLoader.item.requestShow() })
   }
   /** Toggle the app window. Returns what it just DID, not what windowVisible
    *  says: ensureWindow() defers the actual `visible = true` to a callLater

--- a/BlipWindow.qml
+++ b/BlipWindow.qml
@@ -21,7 +21,8 @@ FloatingWindow {
   id: win
   property var hostWidget: null
   // "Blip (3)" while unread exists — selectors match the "Blip" PREFIX.
-  title: "Blip" + (hostWidget && hostWidget.unread > 0 ? " (" + hostWidget.unread + ")" : "")
+  property string restorationTitle: ""
+  title: restorationTitle || "Blip" + (hostWidget && hostWidget.unread > 0 ? " (" + hostWidget.unread + ")" : "")
   // Same fill as Omarchy's other FloatingWindow (dev gallery). A 0.70
   // alpha assumed Hyprland blur, which Omarchy 4.x ships off.
   color: Color.background
@@ -60,9 +61,52 @@ FloatingWindow {
 
   // ---- persistence: the window lives inside the shell process, so every
   // omarchy-restart-shell (every plugin deploy/update) would kill it. Remember
-  // "was open" + size in ~/.local/state/blip/window.json and restore on start.
+  // "was open", size and workspace in window.json; restore quietly on start.
   readonly property string stateDir: Quickshell.env("HOME") + "/.local/state/blip"
   property bool restoring: true
+  property bool restoreReady: false
+  property bool explicitShow: false
+  property string savedWorkspace: ""
+  // Match this shell process and this exact window, never another app's title.
+  readonly property var ownToplevel: Hyprland.toplevels.values.find(function(t) {
+    return Number(t.lastIpcObject.pid) === Quickshell.processId && t.title === win.title
+  }) || null
+  readonly property string currentWorkspace: ownToplevel && ownToplevel.workspace
+    ? String(ownToplevel.workspace.name) : ""
+  Connections {
+    target: Hyprland
+    function onRawEvent(event) {
+      // New toplevels initially have no IPC metadata (including their PID).
+      if (event.name === "openwindow" || event.name === "movewindowv2") Hyprland.refreshToplevels()
+    }
+  }
+  onCurrentWorkspaceChanged: {
+    if (currentWorkspace !== "") { savedWorkspace = currentWorkspace; saveWinState() }
+  }
+  onOwnToplevelChanged: {
+    if (ownToplevel && restorationTitle !== "") Qt.callLater(function() { restorationTitle = "" })
+  }
+  function requestShow() {
+    explicitShow = true
+    if (restoreReady) visible = true
+  }
+  Process {
+    id: prepareRestore
+    command: ["bun", Qt.resolvedUrl("window-restore.ts").toString().replace(/^file:\/\//, ""), win.savedWorkspace]
+    stdout: StdioCollector {
+      onStreamFinished: {
+        try { win.restorationTitle = JSON.parse(text).title || "" } catch (e) { }
+      }
+    }
+    onExited: (code, status) => {
+      win.restoreReady = true
+      win.restoring = false
+      // Failure leaves the window closed rather than stealing the workspace.
+      // An explicit launch can still open it normally.
+      if (code === 0 || win.explicitShow) win.visible = true
+      if (win.hostWidget && win.visible) win.hostWidget.refresh(true, false)
+    }
+  }
   FileView {
     id: winState
     path: win.stateDir + "/window.json"
@@ -71,7 +115,7 @@ FloatingWindow {
   }
   function saveWinState() {
     if (restoring) return
-    var j = JSON.stringify({ visible: visible, width: Math.round(width), height: Math.round(height) })
+    var j = JSON.stringify({ visible: visible, width: Math.round(width), height: Math.round(height), workspace: savedWorkspace })
     // detached: a Process object drops writes while a previous one is alive,
     // and hideWindow() destroying this window mid-write lost the "hidden" state
     Quickshell.execDetached(["sh", "-c",
@@ -82,9 +126,10 @@ FloatingWindow {
     try {
       var d = JSON.parse(winState.text())
       if (d && d.width >= 720 && d.height >= 480) { implicitWidth = d.width; implicitHeight = d.height }
-      if (d && d.visible === true) Qt.callLater(function() { win.visible = true; if (win.hostWidget) win.hostWidget.refresh(true, false) })
+      if (d && typeof d.workspace === "string") savedWorkspace = d.workspace
+      if (d && d.visible === true) { prepareRestore.running = true; return }
     } catch (e) { /* first run */ }
-    Qt.callLater(function() { win.restoring = false })
+    Qt.callLater(function() { win.restoring = false; win.restoreReady = true; if (win.explicitShow) win.visible = true })
   }
   onVisibleChanged: { saveWinState(); if (visible) Qt.callLater(view.focusDefault) }
   onWidthChanged: if (visible) saveWinState()

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,17 @@
+# Development log
+
+## 2026-09-07 — Upstream composer update
+
+- Updated the installed plugin to upstream ba1d8f9 (manifest 2.3.3), including the fix that keeps the cursor visible after a draft exceeds the composer height.
+- Updated the Mac imsg tool to the matching upstream version and restarted the shell.
+- Earlier local merged-conversation changes are included upstream; preserved the installed diff in a Git stash before updating. No additional application patch was needed.
+- Verification: 391 TypeScript tests and 48 Mac-tool Python tests passed; synthetic drafts wrapped to 18 lines in the wide view and 26 in the narrow view, scrolled to the cursor, and shrank to one line when cleared. Inspected the synthetic narrow-view screenshot. Installed tests passed again; runtime reported online, healthy, and push enabled; Mac tool checksum matched.
+- No real messages were read or sent during testing. Visual confirmation in the user's normal session remains with the user.
+
+## 2026-09-07 — Restore the app on its last workspace
+
+- Remember the window's actual workspace, including moves while unfocused. Restore an open window there without initial focus; leave closed windows closed. Explicit launches remain available.
+- Prepare placement before mapping through a narrowly matched, unique restoration title and one replaceable runtime compositor rule. No permanent workspace rule or user configuration is required by the application. A missing old workspace field falls back to quiet placement on the current workspace. A failed preparation leaves automatic restoration closed.
+- Wait for compositor metadata before identifying the shell's own window; never match another process by title alone. Persist no conversation data.
+- Verification: 394 tests passed. An isolated window restored on workspace 4, followed a manual move to 5 on its next restart without changing the active workspace, and stayed closed after closing and restarting.
+- Removed the earlier fixed-workspace workaround. The existing window had already recorded workspace 2 during deployment. A live shell restart from workspace 3 restored Blip on workspace 2, unfocused, with healthy IPC; all 394 installed tests passed. This patch is local pending upstream submission.

--- a/window-restore.test.ts
+++ b/window-restore.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { luaString, restoreRule, workspaceSelector } from "./window-restore";
+
+test("restores numbered, named and special workspaces without relative selectors", () => {
+  expect(workspaceSelector("2")).toBe("2");
+  expect(workspaceSelector("work")).toBe("name:work");
+  expect(workspaceSelector("+1")).toBe("name:+1");
+  expect(workspaceSelector("special:scratchpad")).toBe("special:scratchpad");
+  expect(workspaceSelector(null)).toBeNull();
+  expect(workspaceSelector("bad\nvalue")).toBeNull();
+});
+test("quiet mapping applies only to the unique restoration window", () => {
+  const rule = restoreRule("7", "Blip-restore-abcd-1234");
+  expect(rule).toContain('title = "^Blip-restore-abcd-1234$"');
+  expect(rule).toContain("no_initial_focus = true");
+  expect(rule).toContain(`workspace = ${luaString("7 silent")}`);
+  expect(restoreRule(undefined, "Blip-restore-abcd")).not.toContain("workspace =");
+  expect(() => restoreRule("2", 'Blip"')).toThrow();
+});
+test("workspace names cannot inject Lua", () => {
+  expect(luaString('"\\\n')).toBe('"\\034\\092\\010"');
+  expect(restoreRule('x"}); os.execute("bad', "Blip-restore-abcd")).not.toContain('os.execute');
+});

--- a/window-restore.ts
+++ b/window-restore.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+/** Prepare a single restored window before it maps. No permanent user rules. */
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+// Lua quoted strings use decimal escapes, unlike JSON's Unicode escapes.
+export function luaString(value: string): string {
+  return '"' + Array.from(Buffer.from(value), b => `\\${String(b).padStart(3, "0")}`).join("") + '"';
+}
+
+export function workspaceSelector(value: unknown): string | null {
+  if (typeof value !== "string" || !value || /[\x00-\x1f\x7f]/.test(value)) return null;
+  if (/^[1-9][0-9]*$/.test(value) || value === "special" || value.startsWith("special:")) return value;
+  return "name:" + value;
+}
+
+export function restoreRule(workspace: unknown, title: string): string {
+  if (!/^Blip-restore-[a-f0-9-]+$/.test(title)) throw new Error("Invalid restore title");
+  const target = workspaceSelector(workspace);
+  return `hl.window_rule({ name = "blip-session-restore", match = { class = "^org\\\\.quickshell$", title = "^${title}$" }, no_initial_focus = true${target ? `, workspace = ${luaString(target + " silent")}` : ""} })`;
+}
+
+if (import.meta.main) {
+  const title = `Blip-restore-${randomUUID()}`;
+  const result = spawnSync("hyprctl", ["eval", restoreRule(process.argv[2], title)], { encoding: "utf8", timeout: 3000 });
+  if (result.status !== 0 || !/^ok\s*$/.test(result.stdout)) {
+    console.error("Blip could not prepare quiet window restoration");
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ title }));
+}


### PR DESCRIPTION
Blip's app window is recreated when the shell or plugin bar reloads. Previously it restored visibility and size but appeared on the active workspace, taking focus. This change remembers workspace moves and prepares quiet placement before mapping the replacement window. Closed windows remain closed, and explicit launches remain available.

The restoration rule exists only at runtime and matches a unique temporary window title. No fixed-workspace user configuration is needed. Window identity is scoped to the shell PID; only window metadata is persisted.

Validation: 394 tests pass. An isolated window restored on workspace 4, followed a manual move to workspace 5 on restart without changing the active workspace, and remained closed after closing and restarting. Live shell restart and plugin rescan from workspace 3 restored Blip on workspace 2 without focus or workspace changes.
