### PR TITLE
Retain failed optimistic sends with visible failure reasons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ attempts trigger prompts on the Mac's screen.
 
 ```sh
 bun test
-cp *.qml *.ts manifest.json ~/.config/omarchy/plugins/nixfred.blip/
+cp *.qml *.ts *.mjs manifest.json ~/.config/omarchy/plugins/nixfred.blip/
 omarchy-restart-shell        # NOT a hot-reload: IPC would stay on the old instance
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip status
 ```

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1,3 +1,4 @@
+import "SendState.mjs" as SendState
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -345,6 +346,10 @@ FocusScope {
   property string pendingThreadChat: "" // latest chat requested while it runs
   property string sendChat: ""          // immutable context for the current send
   property string sendText: ""
+  property string sendLocalId: ""
+  property int nextSendId: 0
+  property int pendingRevision: 0
+  property int threadPendingRevision: 0
   property string sendStamp: ""         // local "YYYY-MM-DD HH:mm:ss" the current send was typed at
   // Text sends queue instead of refusing while one is on the wire; each gets
   // its bubble the instant Enter is pressed (see pendingSends).
@@ -541,6 +546,7 @@ FocusScope {
     if (threadProc.running || pendingThreadChat === "") return
     threadRunningChat = pendingThreadChat
     pendingThreadChat = ""
+    root.threadPendingRevision = root.pendingRevision
     var pending = root.pendingSends.filter(function(p) { return p.chat === threadRunningChat })
     threadProc.command = ["bun", root.threadScript, threadRunningChat, "80",
                           "--time-format", root.timeFormat,
@@ -1301,12 +1307,14 @@ FocusScope {
     // green-bubble (SMS/RCS) threads send on their own service (war room #2)
     var svc = String(root.active.service || "")
     if (!root.activeIsGroup && /^(SMS|RCS)$/i.test(svc)) target = target.concat(["--service", svc.toUpperCase()])
-    root.pendingSends = root.pendingSends.concat([{ chat: chat, text: text, ts: stamp }])
-    root.bubbles = root.appendPendingBubble(root.bubbles, text, stamp)
+    var localId = String(++root.nextSendId)
+    root.pendingRevision++
+    root.pendingSends = root.pendingSends.concat([{ chat: chat, text: text, ts: stamp, localId: localId }])
+    root.bubbles = root.appendPendingBubble(root.bubbles, text, stamp, localId)
     root.pinToBottom = true
     composeField.text = ""
     note = ""
-    root.sendQueue = root.sendQueue.concat([{ chat: chat, text: text, stamp: stamp, target: target }])
+    root.sendQueue = root.sendQueue.concat([{ chat: chat, text: text, stamp: stamp, localId: localId, target: target }])
     pumpSend()
   }
 
@@ -1318,25 +1326,29 @@ FocusScope {
   /** The instant echo: thread.ts's pendingBubble() in miniature — enough to
    *  draw the bubble in the right run with the right clock. Every reload
    *  replaces it with the TypeScript version until the real row lands. */
-  function appendPendingBubble(list, text, stamp) {
+  function appendPendingBubble(list, text, stamp, localId) {
     var out = (list || []).slice()
     var prev = out.length ? out[out.length - 1] : null
     var newDay = !prev || String(prev.ts || "").slice(0, 10) !== stamp.slice(0, 10)
     var gapMin = prev ? (Date.parse(stamp.replace(" ", "T")) - Date.parse(String(prev.ts || "").replace(" ", "T"))) / 60000 : Infinity
     var start = !prev || newDay || prev.from_me !== true || !(gapMin <= 15)
     if (!start) { var p = Object.assign({}, prev); p.groupEnd = false; p.time = ""; out[out.length - 1] = p }
-    out.push({ ts: stamp, from_me: true, name: "", text: String(text).trim(), day: newDay ? "Today" : "",
+    out.push({ localId: localId, ts: stamp, from_me: true, name: "", text: String(text).trim(), day: newDay ? "Today" : "",
                groupStart: start, groupEnd: true, time: Qt.formatTime(new Date(), root.timeFormat),
                receipt: "", tapbacks: [], attachments: [], replyText: "", replyMine: false, edited: false,
                link: null, retracted: false, effect: "", audio: false, html: "", failed: false, pending: true })
     return out
   }
 
-  /** Drop one in-flight send (by chat + stamp) from the ledger and the view. */
-  function dropPending(chat, stamp) {
-    root.pendingSends = root.pendingSends.filter(function(p) { return !(p.chat === chat && p.ts === stamp) })
-    if (root.inThread && String(root.active.chat) === chat)
-      root.bubbles = root.bubbles.filter(function(b) { return !(b.pending === true && String(b.ts) === stamp) })
+  function failPending(chat, localId, reason, text, stamp) {
+    root.pendingRevision++
+    root.pendingSends = SendState.markSendFailed(root.pendingSends, localId, reason,
+      {chat: chat, localId: localId, text: text, ts: stamp})
+    if (root.inThread && String(root.active.chat) === chat) {
+      if (!root.bubbles.some(function(b) { return b.localId === localId }))
+        root.bubbles = root.appendPendingBubble(root.bubbles, text, stamp, localId)
+      root.bubbles = SendState.markSendFailed(root.bubbles, localId, reason)
+    }
   }
 
   /** Start the next queued text send when the wire is free. */
@@ -1347,6 +1359,8 @@ FocusScope {
     root.sendChat = job.chat
     root.sendText = job.text
     root.sendStamp = job.stamp
+    root.sendLocalId = job.localId
+    sendProc.lastErr = ""
     root.reloadTries = 0
     // Body on STDIN (--text-stdin), never argv: argv is readable by every
     // process on this machine and travels through ssh into the Mac's ps.
@@ -1400,6 +1414,12 @@ FocusScope {
         // render into a hidden view or mark the thread read unseen.
         var belongsHere = root.surfaceOpen && root.inThread && String(root.active.chat) === root.threadRunningChat
         if (!belongsHere) return
+        // A send or failure happened after this request took its snapshot.
+        // Keep the current bubbles and request a fresh snapshot on exit.
+        if (root.threadPendingRevision !== root.pendingRevision) {
+          root.requestThreadLoad(root.threadRunningChat)
+          return
+        }
         root.loading = false
         try {
           var d = JSON.parse(text.trim())
@@ -1419,7 +1439,7 @@ FocusScope {
             if (Array.isArray(d.pending)) {
               var chat = root.threadRunningChat
               root.pendingSends = root.pendingSends.filter(function(p) { return p.chat !== chat }).concat(d.pending)
-              if (d.pending.length > 0 && root.reloadTries < 8) {
+              if (d.pending.some(function(p) { return p.failed !== true }) && root.reloadTries < 8) {
                 root.reloadTries++
                 root.reloadChat = chat
                 reloadTimer.restart()
@@ -1480,10 +1500,12 @@ FocusScope {
       var completedChat = root.sendChat
       var completedText = root.sendText
       var completedStamp = root.sendStamp
+      var completedId = root.sendLocalId
       var belongsHere = root.inThread && String(root.active.chat) === completedChat
       root.sendChat = ""
       root.sendText = ""
       root.sendStamp = ""
+      root.sendLocalId = ""
       if (code === 0) {
         // A URL you just SHARED opens the sheet too (Fred, 2.3.0): send it,
         // then offer the QR / LocalSend / copy for the same link.
@@ -1493,9 +1515,11 @@ FocusScope {
         root.reloadChat = completedChat
         reloadTimer.restart()
       } else {
-        // The bubble comes down, the words go back in the field (unless a
+        // Keep the failed bubble; put the words back in the field (unless a
         // newer draft is there), and the reason is on the status line.
-        root.dropPending(completedChat, completedStamp)
+        var reason = code === 69 || code === 255 ? "Mac unreachable"
+          : sendProc.lastErr !== "" ? sendProc.lastErr : "Send failed (exit " + code + ")"
+        root.failPending(completedChat, completedId, reason, completedText, completedStamp)
         if (belongsHere) {
           if (composeField.text === "") composeField.text = completedText
           if (code === 69 || code === 255) root.note = "not sent — Mac unreachable"
@@ -3118,8 +3142,11 @@ FocusScope {
                   Text {
                     Layout.rightMargin: bubbleRow.mine ? Style.space(6) : 0
                     Layout.leftMargin: bubbleRow.mine ? 0 : Style.space(6)
+                    Layout.maximumWidth: Math.max(1, content.width * 0.78)
+                    wrapMode: Text.WrapAnywhere
                     text: [modelData.failed === true ? "⚠ Not Delivered" : "",
-                           modelData.pending === true ? "Sending…" : String(modelData.time || ""),
+                           modelData.failed === true ? String(modelData.failureReason || "")
+                             : modelData.pending === true ? "Sending…" : String(modelData.time || ""),
                            modelData.edited === true ? "Edited" : "",
                            String(modelData.effect || "") !== "" ? "sent with " + modelData.effect : ""]
                           .filter(function(s) { return s !== "" }).join(" · ")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,7 @@ what it is handed. Keep it that way.
   stdin (`--pending-stdin`) and `withPendingSends()` in thread.ts keeps each
   bubble until a real from-me row with the same text lands, resolving one
   send per row. The read watermark (`--seen`) skips pending bubbles: their ts
-  is THIS machine's clock. A failed send drops its bubble and restores the
-  text. Never go back to "wait 1.5 s, then reload".
+  is THIS machine's clock. A failed send retains its bubble with a failure reason in memory. Never go back to "wait 1.5 s, then reload".
 - **A peeked thread is not read.** In the window, the sidebar cursor resting on
   a row shows that thread (`peeking`); focus stays in the list and neither
   read path fires — `markRead()` in BlipView (the only caller of the host's
@@ -316,7 +315,7 @@ what it is handed. Keep it that way.
 bun test                                   # 90+ tests, ~40 ms
 bun collector.ts --deep | jq .unread       # live against the Mac
 bun thread.ts <chat-id> 40 | jq .bubbles   # one conversation
-cp *.qml *.ts manifest.json ~/.config/omarchy/plugins/nixfred.blip/
+cp *.qml *.ts *.mjs manifest.json ~/.config/omarchy/plugins/nixfred.blip/
 omarchy-restart-shell                      # ALWAYS restart (hot-reload leaves IPC on a zombie)
 # MANDATORY after every deploy — a QML syntax error kills BOTH surfaces silently (2.1.4 shipped one):
 qs log /run/user/1000/quickshell/by-id/$(basename $(readlink /run/user/1000/quickshell/by-pid/$(pgrep -x quickshell)))/log.qslog -t 400 | grep -iE 'nixfred.blip.*(error|warn|unavailable|token)'
@@ -394,3 +393,10 @@ to whatever has focus otherwise.
 - **Attachments out.** `send POSIX file` works on Sequoia IF the file is staged
   in `~/Pictures/` — from anywhere else Messages fails silently (`error=25`,
   "Not Delivered"). Verified delivered for PNG and PDF. See ROADMAP.md.
+
+Local text-send failures retain their optimistic bubble and a bounded reason
+in memory, including across thread reloads. `send-state.ts` builds the QML
+module `SendState.mjs`; regenerate it with the command in its header. Local
+send IDs distinguish same-second sends. A reload started before a local send
+or failure is discarded and retried, so it cannot erase the new state. Failed
+local bubbles remain provisional and never advance read marks.

--- a/SendState.mjs
+++ b/SendState.mjs
@@ -1,0 +1,9 @@
+// send-state.ts
+function markSendFailed(items, id, reason, fallback) {
+  const safeReason = reason.slice(0, 240).replace(/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/g, " ");
+  const current = fallback && !items.some((item) => item.localId === id) ? items.concat([fallback]) : items;
+  return current.map((item) => item.localId === id ? Object.assign({}, item, { failed: true, failureReason: safeReason }) : item);
+}
+export {
+  markSendFailed
+};

--- a/scripts/demo/blip-shots
+++ b/scripts/demo/blip-shots
@@ -74,7 +74,7 @@ CONF
 echo "· shell copy $SHELLDIR"
 cp -r /usr/share/omarchy/shell "$SHELLDIR"
 touch "$SHELLDIR/.blip-demo-scratch"
-cp "$REPO"/*.qml "$REPO"/*.ts "$REPO/manifest.json" "$SHELLDIR/"   # manifest: the header's version (Astra D#7)
+cp "$REPO"/*.qml "$REPO"/*.ts "$REPO"/*.mjs "$REPO/manifest.json" "$SHELLDIR/"   # manifest: the header's version (Astra D#7)
 cp "$REPO/scripts/demo/DemoShell.qml" "$SHELLDIR/shell.qml"
 
 echo "· launching"

--- a/send-state.test.ts
+++ b/send-state.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { markSendFailed } from "./send-state";
+import { pendingBubble, withPendingSends, DEFAULT_FORMATS } from "./thread";
+
+test("failure targets one of two sends in the same second and keeps the original immutable", () => {
+  const sends = ["1", "2"].map(localId => ({localId, chat: "+15551234567", text: "hello", ts: "2026-09-09 12:00:00"}));
+  const result = markSendFailed(sends, "1", "Mac unreachable");
+  expect(result[0]).toMatchObject({failed: true, failureReason: "Mac unreachable"});
+  expect(result[1]).toBe(sends[1]);
+  expect(sends[0]).not.toHaveProperty("failed");
+  const bubble = pendingBubble(undefined, result[0]!, "2026-09-09").bubble;
+  expect(bubble).toMatchObject({localId: "1", failed: true, pending: true, failureReason: "Mac unreachable"});
+  const reloaded = withPendingSends([], result, "2026-09-09", DEFAULT_FORMATS, Date.parse("2026-09-09T12:10:00"));
+  expect(reloaded.pending).toEqual([result[0]!]);
+  expect(reloaded.bubbles[0]?.failed).toBe(true);
+});
+
+test("an older identical sent message cannot hide a rejected attempt", () => {
+  const send = {localId: "1", chat: "+15551234567", text: "hello", ts: "2026-09-09 12:00:00", failed: true};
+  const real = {...pendingBubble(undefined, send, "2026-09-09").bubble, pending: false, failed: false};
+  const result = withPendingSends([real], [send], "2026-09-09", DEFAULT_FORMATS, Date.parse("2026-09-09T12:00:05"));
+  expect(result.bubbles).toHaveLength(2);
+  expect(result.pending).toEqual([send]);
+});
+
+test("failure reasons are bounded plain display text", () => {
+  const result = markSendFailed([{localId: "1"}], "1", "bad\n\u202e" + "x".repeat(1000));
+  expect(result[0]).toMatchObject({failureReason: "bad  " + "x".repeat(235)});
+});
+
+
+test("the deployed QML module agrees with the TypeScript state reducer", async () => {
+  const runtime = await import("./SendState.mjs");
+  const items = [{localId: "1"}, {localId: "2"}];
+  expect(runtime.markSendFailed(items, "2", "Mac unreachable"))
+    .toEqual(markSendFailed(items, "2", "Mac unreachable"));
+});
+
+
+test("a late transport failure is retained even if a fetched row already resolved the local placeholder", () => {
+  const send = {localId:"1", text:"hello", ts:"2026-09-09 12:00:00", chat:"+15551234567"};
+  const result = markSendFailed([], "1", "Mac unreachable", send);
+  expect(result).toEqual([{...send, failed:true, failureReason:"Mac unreachable"}]);
+  expect(markSendFailed(result, "1", "Mac unreachable", send)).toHaveLength(1);
+});

--- a/send-state.ts
+++ b/send-state.ts
@@ -1,0 +1,15 @@
+// Pure local-send state shared by the QML renderer and tests.
+// Rebuild the QML module: bun build send-state.ts --target browser --format esm --outfile SendState.mjs
+export interface LocalSend {
+  localId?: string;
+  failed?: boolean;
+  failureReason?: string;
+}
+
+/** Change exactly one optimistic send, even when several share a timestamp. */
+export function markSendFailed<T extends LocalSend>(items: T[], id: string, reason: string, fallback?: T): T[] {
+  const safeReason = reason.slice(0, 240).replace(/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/g, " ");
+  const current = fallback && !items.some((item) => item.localId === id) ? items.concat([fallback]) : items;
+  return current.map((item) => item.localId === id
+    ? Object.assign({}, item, { failed: true, failureReason: safeReason }) : item);
+}

--- a/thread.ts
+++ b/thread.ts
@@ -91,11 +91,13 @@ export interface Bubble {
   /** Drawn the moment Enter was pressed, before the Mac has written the row;
    *  "Sending…" replaces the time. Absent on every real bubble. */
   pending?: boolean;
+  localId?: string;
+  failureReason?: string;
 }
 
 /** A send in flight: what was typed, where, and when Enter was pressed
  *  (local "YYYY-MM-DD HH:MM:SS"). Lives in BarWidget memory only. */
-export interface PendingSend { chat: string; text: string; ts: string }
+export interface PendingSend { chat: string; text: string; ts: string; localId?: string; failed?: boolean; failureReason?: string }
 
 export interface ThreadOutput {
   ok: boolean;
@@ -369,8 +371,10 @@ export function pendingBubble(prev: Bubble | undefined, send: PendingSend, today
     effect: "",
     audio: false,
     html: linkify(send.text.trim()),
-    failed: false,
+    failed: send.failed === true,
     pending: true,
+    ...(send.localId ? { localId: send.localId } : {}),
+    ...(send.failureReason ? { failureReason: send.failureReason } : {}),
   };
   return { bubble, prev: prev && !groupStart ? { ...prev, groupEnd: false, time: "" } : prev };
 }
@@ -385,12 +389,14 @@ export function pendingBubble(prev: Bubble | undefined, send: PendingSend, today
  */
 export function withPendingSends(bubbles: Bubble[], pending: PendingSend[], today: string, formats = DEFAULT_FORMATS, now = Date.now()): { bubbles: Bubble[]; pending: PendingSend[] } {
   const live = pending
-    .filter((p) => Number.isFinite(stampMs(p.ts)) && now - stampMs(p.ts) <= PENDING_MAX_AGE_MS)
+    .filter((p) => Number.isFinite(stampMs(p.ts)) && (p.failed === true || now - stampMs(p.ts) <= PENDING_MAX_AGE_MS))
     .sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
   if (live.length === 0) return { bubbles, pending: [] };
   const taken = new Set<number>();
   const open: PendingSend[] = [];
   for (const p of live) {
+    // A rejected attempt is not resolved by an older identical message.
+    if (p.failed === true) { open.push(p); continue; }
     const want = p.text.trim();
     let hit = -1;
     for (let i = bubbles.length - 1; i >= 0; i--) {

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -79,11 +79,11 @@ describe("QML safety invariants", () => {
   });
 
   test("a send shows its bubble at once and reloads carry the in-flight ledger on stdin", () => {
-    expect(panel).toContain("root.bubbles = root.appendPendingBubble(root.bubbles, text, stamp)");
-    expect(panel).toContain("root.pendingSends = root.pendingSends.concat([{ chat: chat, text: text, ts: stamp }])");
+    expect(panel).toContain("root.bubbles = root.appendPendingBubble(root.bubbles, text, stamp, localId)");
+    expect(panel).toContain("root.pendingSends = root.pendingSends.concat([{ chat: chat, text: text, ts: stamp, localId: localId }])");
     expect(panel).toContain('"--pending-stdin"');
     expect(panel).toContain("threadProc.write(JSON.stringify(pending))");
-    expect(panel).toContain("root.dropPending(completedChat, completedStamp)");
+    expect(panel).toContain("root.failPending(completedChat, completedId, reason, completedText, completedStamp)");
     expect(panel).toContain('modelData.pending === true ? "Sending…"');
     // the read watermark never takes a pending bubble's local-clock stamp
     expect(panel).toContain("if (list[k].pending === true) continue");
@@ -669,4 +669,23 @@ test("the share sheet steps through a message's links", () => {
   // swaps the image instead of collapsing and re-growing the card.
   expect(sheet).toContain('visible: root.shareQr !== "" || qrProc.running');
   expect(qmlFunction("showShareUrl")).not.toContain('shareQr = ""');
+});
+
+
+test("a thread response taken before a local send or failure cannot replace bubbles", () => {
+  const start = panel.indexOf("onStreamFinished: {", panel.indexOf("id: threadProc"));
+  const brace = panel.indexOf("{", start);
+  let depth = 1, end = brace + 1;
+  for (; depth && end < panel.length; end++) {
+    if (panel[end] === "{") depth++;
+    if (panel[end] === "}") depth--;
+  }
+  const bubbles = [{text: "new local send"}];
+  const requested: string[] = [];
+  const root = {surfaceOpen:true, inThread:true, active:{chat:"+15551234567"},
+    threadRunningChat:"+15551234567", threadPendingRevision:1, pendingRevision:2,
+    bubbles, loading:true, requestThreadLoad:(chat:string) => requested.push(chat)};
+  new Function("root", panel.slice(brace + 1, end - 1))(root);
+  expect(root.bubbles).toBe(bubbles);
+  expect(requested).toEqual(["+15551234567"]);
 });


### PR DESCRIPTION
Failed sends currently lose their optimistic bubble. Retain the failed attempt with a bounded Not Delivered reason, distinguish sends by local ID, and reject thread snapshots that predate local send changes. Provisional bubbles remain in memory and never advance read marks.

Validation: `bun test` (440 passing). Shared Mac-side CI test suites and shell syntax checks pass. No real conversations were opened or messages sent for testing. Shellcheck is unavailable locally; CI covers it.

Based directly on current main (`174b58e`), as one focused commit; independent of the other split PRs and contact-write PR #25.