### PR TITLE
Improve composer accessibility, spelling, and arrow navigation

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -3259,9 +3259,10 @@ FocusScope {
                 else if (contentY > max) contentY = max
               }
 
-              TextArea {
+              ComposerInput {
                 id: composeField
                 onActiveFocusChanged: if (activeFocus) root.commitPeek()
+                spellingColor: root.urgent
                 width: composeFlick.width
                 // At least the viewport, so a click in empty space still lands in
                 // the field; taller than it once the text outgrows five lines.
@@ -3320,22 +3321,13 @@ FocusScope {
                     root.startPaste()
                     return
                   }
-                  // Reading history without the mouse: the compose field is the
-                  // thread's focus holder, so the keys live here. An empty field
-                  // has no caret for Up/Down to move; they select bubbles instead.
-                  // The arrows are the bubbles' when there is no caret line to
-                  // move to: Up from the first line of a draft (or an empty
-                  // field), Down from the last line while a bubble is selected.
-                  // Omarchy's own lists get this for free from single-line
-                  // fields; the compose box is multi-line, hence the edge rule.
                   var empty = text.length === 0
-                  var caret = cursorRectangle
-                  var onFirstLine = empty || caret.y < topPadding + caret.height * 0.5
-                  var onLastLine = empty || caret.y + caret.height > topPadding + contentHeight - caret.height * 0.5
-                  if ((event.key === Qt.Key_Up && onFirstLine)
-                      || (event.key === Qt.Key_Down && onLastLine && root.bubbleCursor >= 0)) {
-                    event.accepted = true
-                    root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)
+                  // Ordinary editing keys belong to the draft, including at
+                  // its boundaries. History selection uses Page Up/Page Down.
+                  if (event.key === Qt.Key_Up || event.key === Qt.Key_Down
+                      || event.key === Qt.Key_Home || event.key === Qt.Key_End) {
+                    root.clearBubbleCursor()
+                    event.accepted = composeField.moveAtBoundary(event.key, event.modifiers)
                     return
                   }
                   // PgUp/PgDn work with a draft in the field (they move no caret):
@@ -3354,22 +3346,6 @@ FocusScope {
                     if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) { event.accepted = true; root.openBubble(b); return }
                     if (event.matches(StandardKey.Copy)) { event.accepted = true; root.copyBubble(b); return }
                     if (event.key === Qt.Key_R && (event.modifiers & Qt.ControlModifier)) { event.accepted = true; root.quoteBubble(b); return }
-                  }
-                  // Home/End select the oldest / newest bubble from an empty
-                  // field, or once the caret already sits at the start / end
-                  // of its line — the first press is the caret's, the second
-                  // the bubbles' (the arrows' edge rule). Neighbour glyphs on
-                  // another line mean a line edge, so wrapped lines count too.
-                  var atLineStart = empty || cursorPosition === 0
-                    || positionToRectangle(cursorPosition - 1).y < caret.y - 1
-                  var atLineEnd = empty || cursorPosition === length
-                    || positionToRectangle(cursorPosition + 1).y > caret.y + 1
-                  if (((event.key === Qt.Key_Home && atLineStart) || (event.key === Qt.Key_End && atLineEnd))
-                      && root.bubbles.length > 0) {
-                    event.accepted = true
-                    root.bubbleCursor = event.key === Qt.Key_Home ? 0 : root.bubbles.length - 1
-                    root.revealBubbleCursor()
-                    return
                   }
                   if ((event.key === Qt.Key_Return || event.key === Qt.Key_Enter)
                       && !(event.modifiers & Qt.ShiftModifier)) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,3 +394,8 @@ to whatever has focus otherwise.
 - **Attachments out.** `send POSIX file` works on Sequoia IF the file is staged
   in `~/Pictures/` — from anywhere else Messages fails silently (`error=25`,
   "Not Delivered"). Verified delivered for PNG and PDF. See ROADMAP.md.
+
+The composer keeps arrow/Home/End keys for native text editing; PageUp/PageDown
+select history bubbles. `ComposerInput.qml` exposes the editable accessibility
+field and draws spelling ranges supplied by `spellcheck.ts`. Draft text stays
+on bounded stdin, never argv or disk; the helper emits only UTF-16 ranges.

--- a/ComposerInput.qml
+++ b/ComposerInput.qml
@@ -1,0 +1,90 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell.Io
+
+TextArea {
+  id: input
+  objectName: "blipMessageInput"
+  Accessible.role: Accessible.EditableText
+  Accessible.name: "Message"
+  Accessible.description: "Message draft. Enter sends; Shift+Enter inserts a new line."
+  Accessible.editable: !readOnly
+  Accessible.multiLine: true
+  textFormat: TextEdit.PlainText
+  selectByMouse: true
+  property color spellingColor: "#e06c75"
+  property var misspelled: []
+  property int spellingRevision: 0
+  property int checkedRevision: -1
+  readonly property string spellingHelper: decodeURIComponent(Qt.resolvedUrl("spellcheck.ts").toString().replace(/^file:\/\//, ""))
+  // Compare rendered lines so soft wraps behave like explicit newlines.
+  function moveAtBoundary(key, modifiers) {
+    if (modifiers !== Qt.NoModifier) return false
+    if (key !== Qt.Key_Up && key !== Qt.Key_Down) return false
+    var target = key === Qt.Key_Up ? 0 : text.length
+    if (Math.abs(cursorRectangle.y - positionToRectangle(target).y) >= 1) return false
+    cursorPosition = target
+    return true
+  }
+  function checkSpelling() {
+    if (checker.running || text.length > 8192 || text.length === 0 || readOnly) return
+    checkedRevision = spellingRevision
+    checker.command = ["bun", spellingHelper]
+    checker.stdinEnabled = true
+    checker.running = true
+    checker.write(text)
+    checker.stdinEnabled = false
+  }
+  onTextChanged: {
+    spellingRevision++
+    misspelled = []
+    debounce.restart()
+    underlines.requestPaint()
+  }
+  onWidthChanged: underlines.requestPaint()
+  onContentHeightChanged: underlines.requestPaint()
+  Timer { id: debounce; interval: 350; onTriggered: input.checkSpelling() }
+  Process {
+    id: checker
+    stdout: StdioCollector {
+      onStreamFinished: {
+        if (input.checkedRevision !== input.spellingRevision || text.length > 16384) return
+        try {
+          var ranges = JSON.parse(text)
+          if (!Array.isArray(ranges) || ranges.length > 256) return
+          input.misspelled = ranges.filter(function(r) {
+            return Number.isInteger(r.start) && Number.isInteger(r.end)
+              && r.start >= 0 && r.end > r.start && r.end <= input.text.length && r.end-r.start <= 48
+          })
+          underlines.requestPaint()
+        } catch (e) { }
+      }
+    }
+    onExited: if (input.checkedRevision !== input.spellingRevision) debounce.restart()
+  }
+  Canvas {
+    id: underlines
+    anchors.fill: parent
+    Accessible.ignored: true
+    onPaint: {
+      var ctx = getContext("2d")
+      ctx.reset()
+      ctx.strokeStyle = input.spellingColor
+      ctx.lineWidth = 1
+      for (var i = 0; i < input.misspelled.length; i++) {
+        var range = input.misspelled[i]
+        for (var p = range.start; p < range.end; p++) {
+          var a = input.positionToRectangle(p)
+          var b = input.positionToRectangle(p+1)
+          var right = Math.abs(a.y-b.y) < 1 ? b.x : a.x + input.font.pixelSize * 0.5
+          ctx.beginPath()
+          for (var x = a.x; x < right; x += 2) {
+            var y = a.y + a.height - 1 + (Math.floor(x/2)%2)
+            if (x === a.x) ctx.moveTo(x,y); else ctx.lineTo(x,y)
+          }
+          ctx.stroke()
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -540,13 +540,26 @@ helper; the optional availability check needs Automation → Contacts on the Mac
 | thread | `Enter` | send (text, or the queued file with the text as caption) |
 | thread | `Ctrl+V` | paste — an image on the clipboard becomes a queued file, text pastes normally |
 | thread | `/attach <path>` + `Enter` | queue any file on this machine; drag-and-drop works too |
-| thread | `↑` / `↓` | select a bubble, newest first, and keep it in view — from an empty compose field, or from the first / last line of a draft; `↓` past the newest or `Esc` drops the selection and returns to the bottom |
+| thread | `↑` / `↓` | move through draft lines; on the first / last visual line, jump to the beginning / end of the draft |
 | thread | `Enter` · `Ctrl+C` · `Ctrl+R` (bubble selected) | open its attachment or link · copy its text, or the picture itself when the bubble is only a picture · quote it into the compose field (`> …`) |
 | thread | `PgUp` / `PgDn` (Fn+`↑`/`↓` on a Mac keyboard) | select the topmost / bottommost visible bubble, then a screen further each press — also with text in the compose field, since they move no caret |
 | thread | `Shift+PgUp` / `Shift+PgDn` | one bubble at a time from anywhere in a draft, without moving the caret first |
-| thread | `Home` / `End` | select the oldest / newest bubble — from an empty compose field, or once the caret already sits at the start / end of its line |
+| thread | `Home` / `End` · `Ctrl+Home` / `Ctrl+End` | start / end of the current line · start / end of the whole draft |
 | thread | `Esc` | back to list (or clear a text selection first) |
 | anywhere | `Esc` | close |
+
+The message composer exposes a named, editable multiline accessibility field for
+apps such as hyprcorrect. Quickshell must include upstream accessibility fix
+`916a0dd90c`; unpatched 0.3.1 hides its windows from accessibility clients.
+
+Misspellings receive red underlines using local Hunspell with an English (US)
+dictionary. Install `hunspell` and `hunspell-en_us` to enable this on Arch, or
+provide `en_US.aff` and `en_US.dic` under
+`$HOME/.local/share/blip/dictionaries/`. No packages are installed automatically.
+Spelling checks debounce for 350 ms, inspect at most 256 words in drafts up to
+8 KiB, and skip URLs and email addresses. Missing dictionaries or checker errors
+leave the draft usable without underlines. Draft text travels only over stdin;
+only character ranges return to the UI, and nothing is saved or sent remotely.
 
 IPC, for scripts and other plugins:
 

--- a/spellcheck.test.ts
+++ b/spellcheck.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { words, misspellings, check, MAX_BYTES } from './spellcheck';
+test('ranges use UTF-16 editor offsets and skip links and email',()=> {
+ const text = '😀 teh https://example.com/mispell foo@example.com wrng';
+ expect(misspellings(text,'teh\nwrng\nexample\n')).toEqual([{start:3,end:6},{start:51,end:55}]);
+});
+test('spelling is bounded, literal, and stdin-only',()=> {
+ expect(words('x'.repeat(MAX_BYTES+1))).toEqual([]);
+ expect(misspellings('teh','x'.repeat(MAX_BYTES+1))).toEqual([]);
+ let args:any, options:any;
+ const result=check('teh',((_:any,a:any,o:any)=>{args=a;options=o;return {status:0,stdout:'teh\n'}}) as any);
+ expect(args).not.toContain('teh'); expect(options.input).toBe('teh\n');
+ expect(result).toEqual([{start:0,end:3}]);
+ expect(check('teh',(()=>({status:1,stdout:''})) as any)).toEqual([]);
+});
+test('word and byte limits include Unicode and exact boundaries', () => {
+ expect(words(' '.repeat(MAX_BYTES-3)+'teh')).toEqual([{word:'teh',start:MAX_BYTES-3,end:MAX_BYTES}]);
+ expect(words(' '.repeat(MAX_BYTES-3)+'téhh')).toEqual([]);
+ expect(words('teh '.repeat(300))).toHaveLength(256);
+ expect(words('a'.repeat(49))).toEqual([]);
+ expect(misspellings('teh teh','teh\n')).toEqual([{start:0,end:3},{start:4,end:7}]);
+});
+test('oversized stdin exits without waiting for EOF', async () => {
+ const child = Bun.spawn(['bun', 'spellcheck.ts'], {stdin:'pipe',stdout:'pipe',stderr:'pipe'});
+ child.stdin.write('x'.repeat(MAX_BYTES+1));
+ child.stdin.flush();
+ const timer=setTimeout(()=>child.kill(),2000);
+ try {
+  expect(await child.exited).toBe(0);
+  expect(await new Response(child.stdout).text()).toBe('[]\n');
+ } finally { clearTimeout(timer); child.kill(); }
+});

--- a/spellcheck.ts
+++ b/spellcheck.ts
@@ -1,0 +1,39 @@
+// Local-only spelling: draft text uses bounded stdin and is never persisted.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+export const MAX_BYTES = 8192;
+export function words(text: string): {word:string; start:number; end:number}[] {
+  if (Buffer.byteLength(text) > MAX_BYTES) return [];
+  const ignored = [...text.matchAll(/https?:\/\/\S+|[\w.+-]+@[\w.-]+\.[a-z]+/gi)]
+    .map(m => [m.index!, m.index! + m[0].length]);
+  return [...text.matchAll(/\p{L}+(?:['’]\p{L}+)*/gu)]
+    .filter(m => m[0].length > 1 && m[0].length <= 48 && !ignored.some(([a,b]) => m.index! >= a! && m.index! < b!))
+    .slice(0,256).map(m => ({word:m[0],start:m.index!,end:m.index!+m[0].length}));
+}
+export function misspellings(text: string, output: string) {
+  if (Buffer.byteLength(output) > MAX_BYTES) return [];
+  const bad = new Set(output.split(/\r?\n/));
+  return words(text).filter(w => bad.has(w.word)).map(({start,end})=>({start,end}));
+}
+export function check(text:string, runner = spawnSync) {
+  const tokens = words(text);
+  if (!tokens.length) return [];
+  const local = join(homedir(), '.local/share/blip/dictionaries/en_US');
+  const dictionary = existsSync(local+'.aff') && existsSync(local+'.dic') ? local : 'en_US';
+  const result = runner('/usr/bin/hunspell',['-l','-d',dictionary], {
+    input: tokens.map(w=>w.word).join('\n')+'\n', encoding:'utf8', timeout:1500, maxBuffer:MAX_BYTES,
+  });
+  return result.status === 0 ? misspellings(text, result.stdout) : [];
+}
+if (import.meta.main) {
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  for await (const chunk of Bun.stdin.stream()) {
+    bytes += chunk.byteLength;
+    if (bytes > MAX_BYTES) { console.log('[]'); process.exit(0); }
+    chunks.push(chunk);
+  }
+  console.log(JSON.stringify(check(Buffer.concat(chunks).toString('utf8'))));
+}

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -45,7 +45,7 @@ describe("QML safety invariants", () => {
     const start = panel.indexOf("id: composeField");
     expect(start).toBeGreaterThan(-1);
     const compose = panel.slice(Math.max(0, start - 80), start + 2800);
-    expect(compose).toContain("TextArea {");
+    expect(compose).toContain("ComposerInput {");
     expect(compose).toContain("wrapMode: TextEdit.Wrap");
     expect(compose).toContain("width: composeFlick.width");
     expect(compose).not.toContain("implicitWidth:");
@@ -351,10 +351,7 @@ describe("QML safety invariants", () => {
     expect(qmlFunction("scrollConversation")).toContain("flick.stick = flick.contentY >= max - 4");
     expect(panel).toContain("root.scrollConversation(-d)");
     expect(panel.split("flick.stick = flick.contentY >= max - 4").length - 1).toBe(1);
-    // Home/End select the ends only from an empty field (caret otherwise)
-    expect(panel).toContain("(event.key === Qt.Key_Home && atLineStart) || (event.key === Qt.Key_End && atLineEnd)");
-    expect(panel).toContain("var atLineStart = empty || cursorPosition === 0");
-    expect(panel).toContain("root.bubbleCursor = event.key === Qt.Key_Home ? 0 : root.bubbles.length - 1");
+    expect(panel).not.toContain("var atLineStart");
     expect(panel).not.toContain("conversationStep");
     // PgUp/PgDn select the edge bubble regardless of text, and page when already there
     expect(panel).toContain("if (event.modifiers & Qt.ShiftModifier) root.moveBubbleCursor(dir)");
@@ -366,7 +363,7 @@ describe("QML safety invariants", () => {
     expect(page).toContain("leaveBubbles()");
   });
 
-  test("arrows in an empty compose field select bubbles, and the selection clears cleanly", () => {
+  test("draft navigation keeps normal caret movement and clears history selection", () => {
     // The selection is a target for actions; it must never outlive the rows
     // it indexes (a reload renumbers them) and Esc must drop it before leaving.
     expect(panel).toContain("onBubblesChanged: clearBubbleCursor()");
@@ -378,11 +375,9 @@ describe("QML safety invariants", () => {
     expect(move).toContain("bubbleCursor = n - 1");            // Up from nothing = newest
     expect(move).toContain("leaveBubbles()");                  // Down past newest = same exit as Esc
     expect(qmlFunction("leaveBubbles")).toContain("scrollConversation(flick.contentHeight)");
-    expect(panel).toContain("root.moveBubbleCursor(event.key === Qt.Key_Up ? -1 : 1)");
-    // the edge rule: Up leaves a draft only from its first line, Down only from
-    // its last and only while a bubble is selected (otherwise the caret keeps it)
-    expect(panel).toContain("var onFirstLine = empty || caret.y < topPadding + caret.height * 0.5");
-    expect(panel).toContain("(event.key === Qt.Key_Down && onLastLine && root.bubbleCursor >= 0)");
+    expect(panel).toContain("event.key === Qt.Key_Home || event.key === Qt.Key_End");
+    expect(panel).toContain("root.clearBubbleCursor()\n                    event.accepted = composeField.moveAtBoundary(event.key, event.modifiers)");
+    expect(panel).not.toContain("var onFirstLine");
   });
 
   test("bubble actions reuse the click handlers and never steal a real send", () => {
@@ -670,3 +665,16 @@ test("the share sheet steps through a message's links", () => {
   expect(sheet).toContain('visible: root.shareQr !== "" || qrProc.running');
   expect(qmlFunction("showShareUrl")).not.toContain('shareQr = ""');
 });
+ test("composer boundary arrows use visual lines and preserve modified keys", () => {
+   const source = readFileSync(new URL("./ComposerInput.qml", import.meta.url), "utf8");
+   const body = source.split("function moveAtBoundary(key, modifiers) {")[1]!.split("\n  }")[0]!;
+   const run = new Function("key", "modifiers", "Qt", "text", "cursorRectangle", "positionToRectangle", "cursorPosition", body + "; return false");
+   const qt = {NoModifier:0,Key_Up:1,Key_Down:2};
+   const rect = (p:number) => ({y:p === 0 ? 0 : 40});
+   expect(run(1,0,qt,"sample",{y:0},rect,3)).toBe(true);
+   expect(run(2,0,qt,"sample",{y:40},rect,3)).toBe(true);
+   expect(run(1,0,qt,"sample",{y:20},rect,3)).toBe(false);
+   expect(run(2,0,qt,"sample",{y:20},rect,3)).toBe(false);
+   expect(run(1,1,qt,"sample",{y:0},rect,3)).toBe(false);
+   expect(run(99,0,qt,"sample",{y:0},rect,3)).toBe(false);
+ });


### PR DESCRIPTION
Expose the composer as named editable multiline text for accessibility tools. Underline misspellings with optional local Hunspell checks, keeping draft text off disk and argv. Up/Down move through rendered lines and jump to the draft boundary from its first/last line; Home/End keep native editing behavior and paging keys select history. Preserve main’s peek commitment and sidebar navigation.

Spelling requires Hunspell and an English (US) dictionary. Hyprcorrect also requires Quickshell’s upstream accessibility initialization fix 916a0dd90c; QML metadata alone cannot repair an unpatched shell.

Validation: `bun test` (439 passing). Shared Mac-side CI test suites and shell syntax checks pass. No real conversations were opened or messages sent for testing. Shellcheck is unavailable locally; CI covers it.

Based directly on current main (`174b58e`), as one focused commit; independent of the other split PRs and contact-write PR #25.