### PR TITLE
Remember resizable menubar panel dimensions within display limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ attempts trigger prompts on the Mac's screen.
 
 ```sh
 bun test
-cp *.qml *.ts manifest.json ~/.config/omarchy/plugins/nixfred.blip/
+cp *.qml *.ts *.mjs manifest.json ~/.config/omarchy/plugins/nixfred.blip/
 omarchy-restart-shell        # NOT a hot-reload: IPC would stay on the old instance
 qs -p /usr/share/omarchy/shell ipc call nixfred.blip status
 ```

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -2176,11 +2176,16 @@ FocusScope {
                     Rectangle {
                       id: pinnedAvatar
                       Layout.alignment: Qt.AlignHCenter
-                      // A layout sizes its children from Layout hints; a width:
-                      // binding here loses to the layout's first measurement.
-                      Layout.preferredWidth: Math.min(88, Math.max(56,
-                        (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3 * 0.62))
-                      Layout.preferredHeight: Layout.preferredWidth
+                      // Hidden layouts defer their first measurement. Derive
+                      // the size from the pane's known width and supply both
+                      // implicit size and layout hints before the first open.
+                      readonly property real avatarSize: Math.min(88, Math.max(56,
+                        ((root.splitView ? root.sidebarWidth - Style.space(36) : root.width)
+                          - pinnedGrid.columnSpacing * 2) / 3 * 0.62))
+                      implicitWidth: avatarSize
+                      implicitHeight: avatarSize
+                      Layout.preferredWidth: avatarSize
+                      Layout.preferredHeight: avatarSize
                       radius: width / 2
                       color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
                       readonly property string avatarHandle: root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")
@@ -3206,6 +3211,8 @@ FocusScope {
           Layout.fillWidth: true
           Layout.maximumWidth: parent.width
           visible: root.inThread
+          // Match the popup's bottom inset above the composer as well.
+          Layout.topMargin: root.splitView ? 0 : Math.max(0, Style.spacing.popupPadding - Style.space(8))
           spacing: Style.space(6)
 
           // Width must be assigned by the layout *before* wrap can happen.
@@ -3399,12 +3406,12 @@ FocusScope {
           }
         }
 
-        // Always one line tall, empty or not: a note that appears and vanishes
-        // must not shove the compose box and the bubbles around. Only failures
-        // are red; progress and confirmations are dim.
+        // No empty status row below the composer. The resize grip overlays
+        // the panel corner independently of this layout.
         Text {
+          visible: root.note !== ""
           Layout.fillWidth: true
-          text: root.note === "" ? " " : root.note
+          text: root.note
           textFormat: Text.PlainText
           readonly property bool calm: root.note === "copied" || root.note === "sending…"
             || root.note === "sent to LocalSend" || root.note.indexOf("attached") === 0

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -78,6 +78,7 @@ FocusScope {
     var small = Style.font.bodySmall
     return small > 0 ? uiFontSizePx / small : 1
   }
+  readonly property int fontTitle: Math.max(1, Math.round(Style.font.title * uiFontScale))
   readonly property int fontCaption: Math.max(1, Math.round(Style.font.caption * uiFontScale))
   readonly property int fontBodySmall: Math.max(1, Math.round(Style.font.bodySmall * uiFontScale))
   readonly property int fontBody: Math.max(1, Math.round(Style.font.body * uiFontScale))
@@ -1867,22 +1868,13 @@ FocusScope {
         anchors.topMargin: root.splitView ? Style.space(10) : 0
         anchors.bottomMargin: root.splitView ? Style.space(10) : 0
         spacing: Style.space(root.splitView ? 14 : 8)
-        PanelHero {
+        ColumnLayout {
           Layout.fillWidth: true
-          title: "Blip"
-          meta: (!root.online
-                ? "Mac unreachable — bridge offline"
-                : (root.unread > 0 ? root.unread + " unread" : "all caught up"))
-          detail: ""   // Fred: not needed — and it squeezed the title to "B…"
-          foreground: root.foreground
-          fontFamily: root.fontFamily
-          // The version, pinned to the trailing edge: the hero reserves the
-          // space itself, so unlike `detail` it never squeezes the title. One
-          // header for the popout and the app window, so one place, always the
-          // same number — and that number comes from manifest.json via the host.
-          trailingControl: Component {
+          spacing: Style.space(2)
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: Style.space(8)
             Text {
-              id: versionTag
               visible: root.version !== ""
               text: root.version
               textFormat: Text.PlainText
@@ -1890,6 +1882,48 @@ FocusScope {
               font.family: root.fontFamily
               font.pixelSize: root.fontCaption
             }
+            Text {
+              Layout.fillWidth: true
+              text: "Blip"
+              textFormat: Text.PlainText
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: root.fontTitle
+              font.bold: true
+              elide: Text.ElideRight
+            }
+            PanelActionButton {
+              visible: root.online && !root.newMode && !root.searchShowing
+              iconText: "＋"
+              tooltipText: "New message (n)"
+              bordered: true
+              foreground: root.foreground
+              hoverColor: root.accent
+              fontFamily: root.fontFamily
+              onClicked: root.startNew()
+            }
+            PanelActionButton {
+              visible: root.online && !root.splitView
+              iconText: "⇱"
+              tooltipText: "Open the app window"
+              bordered: true
+              foreground: root.foreground
+              hoverColor: root.accent
+              fontFamily: root.fontFamily
+              onClicked: root.openApp()
+            }
+          }
+          Text {
+            Layout.fillWidth: true
+            text: (!root.online ? "Mac unreachable — bridge offline"
+              : root.unread > 0 ? root.unread + " unread" : "all caught up").toUpperCase()
+            textFormat: Text.PlainText
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: root.fontCaption
+            font.bold: true
+            font.letterSpacing: 1.2
+            elide: Text.ElideRight
           }
         }
 
@@ -1970,36 +2004,12 @@ FocusScope {
             RowLayout {
               Layout.fillWidth: true
               visible: root.online && root.listShowing
+                && (root.newMode || root.unread > 0 && !root.searchShowing)
               PanelSectionHeader {
                 Layout.fillWidth: true
-                text: root.newMode ? "NEW MESSAGE" : root.searchShowing ? "SEARCH" : "MESSAGES"
+                text: root.newMode ? "NEW MESSAGE" : ""
                 foreground: root.foreground
                 fontFamily: root.fontFamily
-              }
-              // A real button (PanelActionButton = the stock panels' control).
-              // The hand-rolled Text+MouseArea version lost its clicks to the
-              // panel's dismiss layer — clicking it CLOSED the panel.
-              PanelActionButton {
-                visible: !root.newMode && !root.searchShowing && !root.splitView
-                iconText: "＋"
-                tooltipText: "New message (n)"
-                bordered: true
-                foreground: root.foreground
-                hoverColor: root.accent
-                fontFamily: root.fontFamily
-                onClicked: root.startNew()
-              }
-              // Open the full app window. Hidden in the app itself (it IS the
-              // window) and in the split/search/new views, like ＋.
-              PanelActionButton {
-                visible: !root.newMode && !root.searchShowing && !root.splitView
-                iconText: "⇱"
-                tooltipText: "Open the app window"
-                bordered: true
-                foreground: root.foreground
-                hoverColor: root.accent
-                fontFamily: root.fontFamily
-                onClicked: root.openApp()
               }
               // Local only: moves readMark/readMarks in state.json so the
               // badge and dots clear. Nothing is written back to the Mac —
@@ -2110,7 +2120,32 @@ FocusScope {
               id: searchField
               Layout.fillWidth: true
               visible: root.online && root.listShowing && !root.newMode
-              placeholderText: "name or message"
+              placeholderText: "Search"
+              Accessible.name: "Search"
+              leftPadding: horizontalPadding + searchGlyph.width + Style.space(7)
+              Canvas {
+                id: searchGlyph
+                anchors.left: parent.left
+                anchors.leftMargin: searchField.horizontalPadding
+                anchors.verticalCenter: parent.verticalCenter
+                width: Style.space(16)
+                height: width
+                readonly property color strokeColor: searchField.placeholderTextColor
+                onStrokeColorChanged: requestPaint()
+                onPaint: {
+                  var ctx = getContext("2d")
+                  ctx.reset()
+                  ctx.scale(width / 16, height / 16)
+                  ctx.strokeStyle = strokeColor
+                  ctx.lineWidth = 1.5
+                  ctx.lineCap = "round"
+                  ctx.beginPath()
+                  ctx.arc(6.5, 6.5, 5, 0, Math.PI * 2)
+                  ctx.moveTo(10.1, 10.1)
+                  ctx.lineTo(14.5, 14.5)
+                  ctx.stroke()
+                }
+              }
               foreground: root.foreground
               accent: root.accent
               font.family: root.fontFamily

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1875,6 +1875,14 @@ FocusScope {
             Layout.fillWidth: true
             spacing: Style.space(8)
             Text {
+              text: "Blip"
+              textFormat: Text.PlainText
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: root.fontTitle
+              font.bold: true
+            }
+            Text {
               visible: root.version !== ""
               text: root.version
               textFormat: Text.PlainText
@@ -1882,16 +1890,7 @@ FocusScope {
               font.family: root.fontFamily
               font.pixelSize: root.fontCaption
             }
-            Text {
-              Layout.fillWidth: true
-              text: "Blip"
-              textFormat: Text.PlainText
-              color: root.foreground
-              font.family: root.fontFamily
-              font.pixelSize: root.fontTitle
-              font.bold: true
-              elide: Text.ElideRight
-            }
+            Item { Layout.fillWidth: true }
             PanelActionButton {
               visible: root.online && !root.newMode && !root.searchShowing
               iconText: "＋"

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1868,49 +1868,16 @@ FocusScope {
         anchors.topMargin: root.splitView ? Style.space(10) : 0
         anchors.bottomMargin: root.splitView ? Style.space(10) : 0
         spacing: Style.space(root.splitView ? 14 : 8)
-        ColumnLayout {
+        RowLayout {
           Layout.fillWidth: true
-          spacing: Style.space(2)
-          RowLayout {
-            Layout.fillWidth: true
-            spacing: Style.space(8)
-            Text {
-              text: "Blip"
-              textFormat: Text.PlainText
-              color: root.foreground
-              font.family: root.fontFamily
-              font.pixelSize: root.fontTitle
-              font.bold: true
-            }
-            Text {
-              visible: root.version !== ""
-              text: root.version
-              textFormat: Text.PlainText
-              color: root.dim
-              font.family: root.fontFamily
-              font.pixelSize: root.fontCaption
-            }
-            Item { Layout.fillWidth: true }
-            PanelActionButton {
-              visible: root.online && !root.newMode && !root.searchShowing
-              iconText: "＋"
-              tooltipText: "New message (n)"
-              bordered: true
-              foreground: root.foreground
-              hoverColor: root.accent
-              fontFamily: root.fontFamily
-              onClicked: root.startNew()
-            }
-            PanelActionButton {
-              visible: root.online && !root.splitView
-              iconText: "⇱"
-              tooltipText: "Open the app window"
-              bordered: true
-              foreground: root.foreground
-              hoverColor: root.accent
-              fontFamily: root.fontFamily
-              onClicked: root.openApp()
-            }
+          spacing: Style.space(8)
+          Text {
+            text: "Blip"
+            textFormat: Text.PlainText
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: root.fontTitle
+            font.bold: true
           }
           Text {
             Layout.fillWidth: true
@@ -1923,6 +1890,34 @@ FocusScope {
             font.bold: true
             font.letterSpacing: 1.2
             elide: Text.ElideRight
+          }
+          Text {
+            visible: root.version !== ""
+            text: root.version
+            textFormat: Text.PlainText
+            color: root.dim
+            font.family: root.fontFamily
+            font.pixelSize: root.fontCaption
+          }
+          PanelActionButton {
+            visible: root.online && !root.newMode && !root.searchShowing
+            iconText: "＋"
+            tooltipText: "New message (n)"
+            bordered: true
+            foreground: root.foreground
+            hoverColor: root.accent
+            fontFamily: root.fontFamily
+            onClicked: root.startNew()
+          }
+          PanelActionButton {
+            visible: root.online && !root.splitView
+            iconText: "⇱"
+            tooltipText: "Open the app window"
+            bordered: true
+            foreground: root.foreground
+            hoverColor: root.accent
+            fontFamily: root.fontFamily
+            onClicked: root.openApp()
           }
         }
 

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -2358,138 +2358,167 @@ FocusScope {
               wrapMode: Text.WordWrap
             }
 
-            Repeater {
-              model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.unpinnedThreads : []
-              delegate: Rectangle {
-                id: threadRow
-                required property var modelData
-                required property int index
-                readonly property bool hasCursor: root.cursorChat === String(modelData.chat)
-                onHasCursorChanged: if (hasCursor) root.cursorRow = threadRow
+            ColumnLayout {
+              id: chronologicalRows
+              property int hoveredRow: -1
+              Layout.fillWidth: true
+              visible: root.online && root.listShowing && !root.searchShowing && !root.newMode
+              spacing: 0
+              Repeater {
+                id: chronologicalRepeater
+                model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.unpinnedThreads : []
+                delegate: Rectangle {
+                  id: threadRow
+                  required property var modelData
+                  required property int index
+                  readonly property bool highlighted: rowHover.hovered || (hasCursor && root.cursorShown)
+                  readonly property bool hasCursor: root.cursorChat === String(modelData.chat)
+                  onHasCursorChanged: if (hasCursor) root.cursorRow = threadRow
 
-                Layout.fillWidth: true
-                implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 20 : 12)
-                radius: Style.cornerRadius
-                color: rowHover.hovered || (hasCursor && root.cursorShown)
-                  ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
-                  : "transparent"
+                  Layout.fillWidth: true
+                  implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 30 : 18)
+                  radius: Style.cornerRadius
+                  color: highlighted
+                    ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+                    : "transparent"
 
-                HoverHandler { id: rowHover }
-                TapHandler { onTapped: root.openThread(modelData) }
-                  TapHandler {
-                    acceptedButtons: Qt.RightButton
-                    onTapped: { root.contactContext = modelData; contactMenu.popup() }
+                  HoverHandler {
+                    id: rowHover
+                    onHoveredChanged: {
+                      if (hovered) chronologicalRows.hoveredRow = index
+                      else if (chronologicalRows.hoveredRow === index) chronologicalRows.hoveredRow = -1
+                    }
                   }
+                  TapHandler { onTapped: root.openThread(modelData) }
+                    TapHandler {
+                      acceptedButtons: Qt.RightButton
+                      onTapped: { root.contactContext = modelData; contactMenu.popup() }
+                    }
 
-                RowLayout {
-                  id: rowRow
-                  anchors.fill: parent
-                  anchors.margins: Style.space(6)
-                  spacing: Style.space(8)
+                  RowLayout {
+                    id: rowRow
+                    anchors.fill: parent
+                    anchors.margins: Style.space(6)
+                    spacing: Style.space(8)
 
-                  // the iMessage blue dot — present only while the thread has
-                  // unread inbound; the slot stays so names line up.
-                  Rectangle {
-                    width: Style.space(9); height: width; radius: width / 2
-                    color: root.mineFill
-                    opacity: modelData.unread > 0 ? 1 : 0
-                  }
+                    // the iMessage blue dot — present only while the thread has
+                    // unread inbound; the slot stays so names line up.
+                    Rectangle {
+                      width: Style.space(9); height: width; radius: width / 2
+                      color: root.mineFill
+                      opacity: modelData.unread > 0 ? 1 : 0
+                    }
 
-                  // avatar circle — the contact's photo when Contacts has one,
-                  // initials otherwise (the iMessage sidebar look)
-                  Rectangle {
-                    id: avatarCircle
-                    // Messages' sidebar avatar is large relative to the row;
-                    // 30 looked like a contact list, not a conversation list.
-                    width: Style.space(34); height: width; radius: width / 2
-                    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
-                    // A group binds to ITS OWN chat id (its Messages group photo); a DM to
-                    // the person. Binding a group to `handle` showed whoever spoke last —
-                    // their cached contact photo one minute, initials the next.
-                    readonly property string avatarHandle: root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")
-                    Component.onCompleted: root.requestAvatar(avatarHandle)
-                    Image {
-                      id: avatarImg
-                      anchors.fill: parent
-                      visible: false
-                      source: root.avatarFiles[avatarCircle.avatarHandle] || ""
-                      asynchronous: true
-                      fillMode: Image.PreserveAspectCrop
-                      autoTransform: true
-                      sourceSize.width: 96
-                      sourceSize.height: 96
-                      // a stale/corrupt cache file → initials, and no retry this session
-                      onStatusChanged: if (status === Image.Error && avatarCircle.avatarHandle !== "") {
-                        var m = Object.assign({}, root.avatarFiles); m[avatarCircle.avatarHandle] = ""; root.avatarFiles = m
+                    // avatar circle — the contact's photo when Contacts has one,
+                    // initials otherwise (the iMessage sidebar look)
+                    Rectangle {
+                      id: avatarCircle
+                      // Messages' sidebar avatar is large relative to the row;
+                      // Keep ordinary avatars legible beside two preview lines.
+                      width: Style.space(40); height: width; radius: width / 2
+                      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+                      // A group binds to ITS OWN chat id (its Messages group photo); a DM to
+                      // the person. Binding a group to `handle` showed whoever spoke last —
+                      // their cached contact photo one minute, initials the next.
+                      readonly property string avatarHandle: root.isGroupId(String(modelData.chat || "")) ? String(modelData.chat) : String(modelData.handle || modelData.chat || "")
+                      Component.onCompleted: root.requestAvatar(avatarHandle)
+                      Image {
+                        id: avatarImg
+                        anchors.fill: parent
+                        visible: false
+                        source: root.avatarFiles[avatarCircle.avatarHandle] || ""
+                        asynchronous: true
+                        fillMode: Image.PreserveAspectCrop
+                        autoTransform: true
+                        sourceSize.width: 96
+                        sourceSize.height: 96
+                        // a stale/corrupt cache file → initials, and no retry this session
+                        onStatusChanged: if (status === Image.Error && avatarCircle.avatarHandle !== "") {
+                          var m = Object.assign({}, root.avatarFiles); m[avatarCircle.avatarHandle] = ""; root.avatarFiles = m
+                        }
                       }
-                    }
-                    Item {
-                      id: avatarMask
-                      anchors.fill: parent
-                      visible: false
-                      layer.enabled: true
-                      Rectangle { anchors.fill: parent; radius: width / 2 }
-                    }
-                    MultiEffect {
-                      anchors.fill: parent
-                      source: avatarImg
-                      visible: avatarImg.status === Image.Ready
-                      maskEnabled: true
-                      maskSource: avatarMask
-                    }
-                    Text {
-                      anchors.centerIn: parent
-                      visible: avatarImg.status !== Image.Ready
-                      text: root.avatarInitials(modelData)
-                      color: root.foreground
-                      font.family: root.fontFamily
-                      font.pixelSize: root.fontCaption
-                      font.bold: true
-                    }
-                  }
-
-                  ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: Style.space(1)
-                    RowLayout {
-                      Layout.fillWidth: true
-                      spacing: Style.space(6)
+                      Item {
+                        id: avatarMask
+                        anchors.fill: parent
+                        visible: false
+                        layer.enabled: true
+                        Rectangle { anchors.fill: parent; radius: width / 2 }
+                      }
+                      MultiEffect {
+                        anchors.fill: parent
+                        source: avatarImg
+                        visible: avatarImg.status === Image.Ready
+                        maskEnabled: true
+                        maskSource: avatarMask
+                      }
                       Text {
-                        Layout.fillWidth: true
-                        text: String(modelData.name || modelData.chat)
-                        textFormat: Text.PlainText
-                        elide: Text.ElideRight
+                        anchors.centerIn: parent
+                        visible: avatarImg.status !== Image.Ready
+                        text: root.avatarInitials(modelData)
                         color: root.foreground
                         font.family: root.fontFamily
-                        font.pixelSize: root.fontBodySmall
-                        // Messages keeps the name semibold ALWAYS; unread is
-                        // carried by the dot and the blue timestamp, not by
-                        // the name suddenly changing weight.
-                        font.weight: modelData.unread > 0 ? Font.Bold : Font.DemiBold
+                        font.pixelSize: root.fontCaption
+                        font.bold: true
                       }
+                    }
+
+                    ColumnLayout {
+                      Layout.fillWidth: true
+                      spacing: Style.space(1)
+                      RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Style.space(6)
+                        Text {
+                          Layout.fillWidth: true
+                          text: String(modelData.name || modelData.chat)
+                          textFormat: Text.PlainText
+                          elide: Text.ElideRight
+                          color: root.foreground
+                          font.family: root.fontFamily
+                          font.pixelSize: root.fontBodySmall
+                          // Messages keeps the name semibold ALWAYS; unread is
+                          // carried by the dot and the blue timestamp, not by
+                          // the name suddenly changing weight.
+                          font.weight: modelData.unread > 0 ? Font.Bold : Font.DemiBold
+                        }
+                        Text {
+                          text: root.fmtTime(modelData.last_ts)
+                          textFormat: Text.PlainText
+                          color: modelData.unread > 0 ? root.mineFill : root.dim
+                          font.family: root.fontFamily
+                          font.pixelSize: root.fontCaption
+                        }
+                      }
+                      // TWO lines, wrapped — the single most recognisable thing
+                      // about the Messages sidebar. One elided line reads like a
+                      // mail client; two lines of preview reads like Messages.
                       Text {
-                        text: root.fmtTime(modelData.last_ts)
+                        Layout.fillWidth: true
+                        text: (modelData.last_from_me ? "You: " : "") + String(modelData.last_text || "")
                         textFormat: Text.PlainText
-                        color: modelData.unread > 0 ? root.mineFill : root.dim
+                        wrapMode: Text.Wrap
+                        elide: Text.ElideRight
+                        maximumLineCount: 2
+                        color: root.dim
                         font.family: root.fontFamily
                         font.pixelSize: root.fontCaption
+                        lineHeight: 1.15
                       }
                     }
-                    // TWO lines, wrapped — the single most recognisable thing
-                    // about the Messages sidebar. One elided line reads like a
-                    // mail client; two lines of preview reads like Messages.
-                    Text {
-                      Layout.fillWidth: true
-                      text: (modelData.last_from_me ? "You: " : "") + String(modelData.last_text || "")
-                      textFormat: Text.PlainText
-                      wrapMode: Text.Wrap
-                      elide: Text.ElideRight
-                      maximumLineCount: 2
-                      color: root.dim
-                      font.family: root.fontFamily
-                      font.pixelSize: root.fontCaption
-                      lineHeight: 1.15
-                    }
+
+                  }
+                  Rectangle {
+                    anchors.bottom: parent.bottom
+                    anchors.right: parent.right
+                    // Align the hairline with the text, beyond the dot and avatar.
+                    anchors.left: parent.left
+                    anchors.leftMargin: rowRow.x + avatarCircle.x + avatarCircle.width + rowRow.spacing
+                    height: 1
+                    color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.12)
+                    visible: !threadRow.highlighted
+                      && chronologicalRows.hoveredRow !== index + 1
+                      && !(root.cursorShown && root.unpinnedThreads[index + 1]
+                        && root.cursorChat === String(root.unpinnedThreads[index + 1].chat))
                   }
 
                 }

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -2182,7 +2182,7 @@ FocusScope {
                   onHasCursorChanged: if (hasCursor) root.cursorRow = pinnedTile
                   Layout.fillWidth: true
                   Layout.preferredWidth: Math.max(1, (pinnedGrid.width - pinnedGrid.columnSpacing * 2) / 3)
-                  implicitHeight: pinnedColumn.implicitHeight + Style.space(4)
+                  implicitHeight: pinnedColumn.implicitHeight + Style.space(12)
                   radius: Style.cornerRadius
                   color: pinnedHover.hovered || (hasCursor && root.cursorShown)
                     ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
@@ -2199,7 +2199,9 @@ FocusScope {
                     id: pinnedColumn
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    anchors.top: parent.top
+                    anchors.leftMargin: Style.space(4)
+                    anchors.rightMargin: Style.space(4)
+                    anchors.verticalCenter: parent.verticalCenter
                     spacing: Style.space(4)
 
                     Rectangle {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,7 @@ what it is handed. Keep it that way.
 bun test                                   # 90+ tests, ~40 ms
 bun collector.ts --deep | jq .unread       # live against the Mac
 bun thread.ts <chat-id> 40 | jq .bubbles   # one conversation
-cp *.qml *.ts manifest.json ~/.config/omarchy/plugins/nixfred.blip/
+cp *.qml *.ts *.mjs manifest.json ~/.config/omarchy/plugins/nixfred.blip/
 omarchy-restart-shell                      # ALWAYS restart (hot-reload leaves IPC on a zombie)
 # MANDATORY after every deploy — a QML syntax error kills BOTH surfaces silently (2.1.4 shipped one):
 qs log /run/user/1000/quickshell/by-id/$(basename $(readlink /run/user/1000/quickshell/by-pid/$(pgrep -x quickshell)))/log.qslog -t 400 | grep -iE 'nixfred.blip.*(error|warn|unavailable|token)'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ break and expensive to rediscover.
 bun test                                   # unit tests, ~70 ms
 bun collector.ts --deep | jq .unread       # live poll through your bridge
 bun thread.ts <chat-id> 40 | jq .bubbles   # one conversation
-cp *.qml *.ts manifest.json ~/.config/omarchy/plugins/nixfred.blip/
+cp *.qml *.ts *.mjs manifest.json ~/.config/omarchy/plugins/nixfred.blip/
 omarchy-restart-shell                      # QML changes need a restart, not a hot-reload (see CLAUDE.md)
 ```
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -1,3 +1,4 @@
+import "PanelSize.mjs" as PanelSize
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -24,6 +25,34 @@ Panel {
   property var anchorItem: null
   property var hostWidget: null
   readonly property var barIdentity: hostWidget || root
+
+  property real preferredWidth: 0
+  property real preferredHeight: 0
+  property bool resized: false
+  readonly property string sizeHelper: decodeURIComponent(Qt.resolvedUrl("panel-size-store.ts").toString().replace(/^file:\/\//, ""))
+  Process {
+    command: ["bun", root.sizeHelper]
+    running: true
+    stdout: StdioCollector {
+      onStreamFinished: {
+        if (root.resized || text.length > 256) return
+        try {
+          var size = PanelSize.parseSize(JSON.parse(text))
+          if (size) { root.preferredWidth = size.width; root.preferredHeight = size.height }
+        } catch (e) { }
+      }
+    }
+  }
+  Process { id: saveSize }
+  Timer {
+    id: saveDebounce
+    interval: 250
+    onTriggered: {
+      if (saveSize.running) { restart(); return }
+      saveSize.command = ["bun", root.sizeHelper, String(Math.round(root.preferredWidth)), String(Math.round(root.preferredHeight))]
+      saveSize.running = true
+    }
+  }
 
   // ---- proxies: BarWidget and the IPC hooks talk to the panel, the view does the work
   readonly property bool inThread: view.inThread
@@ -62,16 +91,15 @@ Panel {
     bar: root.bar
     open: root.opened
     focusTarget: view.inThread ? view.composeEditor : keyCatcher
-    // 20% narrower than it was (Fred, 2.3.1). Messages' own sidebar is a
-    // narrow column; 440 read like a file browser.
-    contentWidth: panel.fittedContentWidth(Style.space(352))
-    // The floor keeps the panel usable if a mode flip's relayout ever lags
-    // again — search/new modes always have at least a field to show.
-    contentHeight: panel.fittedContentHeight(
-      view.contactsOpen || view.inThread ? Style.space(640)
-        : Math.max(view.contentHeightHint,
-                   (view.newMode || view.searching) ? Style.space(280) : 0),
-      Style.space(640))
+    readonly property var fittedSize: PanelSize.fitSize(
+      root.preferredWidth || Style.space(352),
+      root.preferredHeight || panel.fittedContentHeight(
+        view.contactsOpen || view.inThread ? Style.space(640) : Math.max(view.contentHeightHint,
+          (view.newMode || view.searching) ? Style.space(280) : 0), Style.space(640)),
+      panel.screenW, panel.screenH, panel.availableCardWidth, panel.availableCardHeight)
+    contentWidth: fittedSize.width
+    contentHeight: fittedSize.height
+
 
     PanelKeyCatcher {
       id: keyCatcher
@@ -99,5 +127,56 @@ Panel {
         onNavigationFocusRequested: keyCatcher.forceActiveFocus()
       }
     }
+    MouseArea {
+      id: resizeGrip
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      // The parent is inset by popup padding; extend into that padding so
+      // the grip sits against the card's inner border, not the content edge.
+      anchors.rightMargin: -panel.padding
+      anchors.bottomMargin: -panel.padding
+      width: Style.space(20); height: Style.space(20)
+      Accessible.name: "Resize Blip"
+      z: 100
+      cursorShape: Qt.SizeFDiagCursor
+      preventStealing: true
+      property point startPoint
+      property real startWidth
+      property real startHeight
+      property real widthMultiplier: 1
+      onPressed: function(mouse) {
+        startPoint = mapToItem(null, mouse.x, mouse.y)
+        startWidth = panel.contentWidth
+        startHeight = panel.contentHeight
+        widthMultiplier = panel.cardOrigin.x <= panel.margin + 1 ? 1 : 2
+      }
+      onPositionChanged: function(mouse) {
+        if (!pressed) return
+        var point = mapToItem(null, mouse.x, mouse.y)
+        var size = PanelSize.fitSize(startWidth + (point.x-startPoint.x)*widthMultiplier,
+          startHeight + point.y-startPoint.y, panel.screenW, panel.screenH,
+          panel.availableCardWidth, panel.availableCardHeight)
+        root.resized = true
+        root.preferredWidth = size.width
+        root.preferredHeight = size.height
+      }
+      onReleased: if (root.resized) saveDebounce.restart()
+      onCanceled: if (root.resized) saveDebounce.restart()
+      Repeater {
+        model: 3
+        Rectangle {
+          required property int index
+          width: Style.space(3 + index * 4)
+          height: Math.max(1, Style.space(1))
+          x: resizeGrip.width - width - Style.space(3)
+          y: resizeGrip.height - Style.space(4 + index * 4)
+          rotation: -45
+          color: view.foreground
+          opacity: resizeGrip.containsMouse || resizeGrip.pressed ? 0.8 : 0.35
+        }
+      }
+      hoverEnabled: true
+    }
+
   }
 }

--- a/PanelSize.mjs
+++ b/PanelSize.mjs
@@ -1,0 +1,19 @@
+// panel-size.ts
+function parseSize(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return null;
+  const { width, height } = value;
+  return Number.isInteger(width) && Number.isInteger(height) && width >= 1 && height >= 1 && width <= 16384 && height <= 16384 ? { width, height } : null;
+}
+function fitSize(width, height, screenWidth, screenHeight, availableWidth, availableHeight) {
+  const maxWidth = Math.max(1, Math.floor(Math.min(screenWidth || width, availableWidth || width)));
+  const maxHeight = Math.max(1, Math.floor(Math.min((screenHeight || height) * 0.8, availableHeight || height)));
+  return {
+    width: Math.round(Math.min(maxWidth, Math.max(Math.min(280, maxWidth), width))),
+    height: Math.round(Math.min(maxHeight, Math.max(Math.min(240, maxHeight), height)))
+  };
+}
+export {
+  parseSize,
+  fitSize
+};

--- a/PanelSize.mjs
+++ b/PanelSize.mjs
@@ -6,7 +6,7 @@ function parseSize(value) {
   return Number.isInteger(width) && Number.isInteger(height) && width >= 1 && height >= 1 && width <= 16384 && height <= 16384 ? { width, height } : null;
 }
 function fitSize(width, height, screenWidth, screenHeight, availableWidth, availableHeight) {
-  const maxWidth = Math.max(1, Math.floor(Math.min(screenWidth || width, availableWidth || width)));
+  const maxWidth = Math.max(1, Math.floor(Math.min(500, screenWidth || width, availableWidth || width)));
   const maxHeight = Math.max(1, Math.floor(Math.min((screenHeight || height) * 0.8, availableHeight || height)));
   return {
     width: Math.round(Math.min(maxWidth, Math.max(Math.min(280, maxWidth), width))),

--- a/README.md
+++ b/README.md
@@ -548,6 +548,14 @@ helper; the optional availability check needs Automation → Contacts on the Mac
 | thread | `Esc` | back to list (or clear a text selection first) |
 | anywhere | `Esc` | close |
 
+Drag the diagonal lines in the menubar panel’s bottom-right corner to resize it.
+Its width and height are remembered across shell restarts in
+`$HOME/.local/state/blip/panel.json`. The panel stays within the current display
+and never exceeds 80% of that display’s logical height, including its border
+and padding. Moving to a smaller display clamps the visible size without
+replacing your saved preference. The separate app window keeps its own size.
+
+
 IPC, for scripts and other plugins:
 
 ```sh

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -91,3 +91,7 @@ timestamp when `chat.db` changes; the client then fetches privately.
 
 Send tapbacks, edit or unsend, see typing indicators.
 Those need Apple private APIs that Blip deliberately does not use.
+
+The menubar panel saves only its preferred width and height in
+`$HOME/.local/state/blip/panel.json` (0600). No draft or conversation content
+is included. The dimensions are clamped to the current display on use.

--- a/panel-size-store.ts
+++ b/panel-size-store.ts
@@ -1,0 +1,37 @@
+// Only window dimensions are persisted. No message content is accepted.
+import { constants as C, openSync, closeSync, fstatSync, readSync, mkdirSync, writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parseSize } from './panel-size';
+export function sizeStore(directory:string, args:string[]) {
+  mkdirSync(directory,{recursive:true,mode:0o700});
+  const dir = openSync(directory,C.O_RDONLY|C.O_DIRECTORY|C.O_NOFOLLOW);
+  try {
+    const base = `/proc/self/fd/${dir}`;
+    if (fstatSync(dir).uid !== process.getuid!()) return null;
+    if (args.length) {
+      if (args.length !== 2) return null;
+      const size = parseSize({width:Number(args[0]),height:Number(args[1])});
+      if (!size) return null;
+      const temporary = `${base}/.panel-${crypto.randomUUID()}.tmp`;
+      try {
+        writeFileSync(temporary,JSON.stringify(size),{flag:'wx',mode:0o600});
+        renameSync(temporary,`${base}/panel.json`);
+      } finally { try { unlinkSync(temporary); } catch {} }
+      return size;
+    }
+    const fd = openSync(`${base}/panel.json`,C.O_RDONLY|C.O_NOFOLLOW|C.O_NONBLOCK);
+    try {
+      const stat=fstatSync(fd);
+      if (!stat.isFile() || stat.size>256 || stat.uid!==process.getuid!()) return null;
+      const bytes=Buffer.alloc(257);
+      const count=readSync(fd,bytes,0,257,0);
+      if (count>256) return null;
+      return parseSize(JSON.parse(bytes.subarray(0,count).toString('utf8')));
+    } finally { closeSync(fd); }
+  } finally { closeSync(dir); }
+}
+if (import.meta.main) {
+  try { console.log(JSON.stringify(sizeStore(join(homedir(),'.local/state/blip'),process.argv.slice(2)))); }
+  catch { console.log('null'); }
+}

--- a/panel-size.test.ts
+++ b/panel-size.test.ts
@@ -4,9 +4,9 @@ import {sizeStore} from './panel-size-store';
 import {mkdtempSync,rmSync,writeFileSync,symlinkSync,statSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-test('panel sizes track the current display and never exceed 80% height',()=>{
- expect(fitSize(700,1500,1920,1080,1880,1000)).toEqual({width:700,height:864});
- expect(fitSize(700,1500,3072,1728,3032,1650)).toEqual({width:700,height:1382});
+test('panel sizes cap width at 500px and height at 80% of the current display',()=>{
+ expect(fitSize(700,1500,1920,1080,1880,1000)).toEqual({width:500,height:864});
+ expect(fitSize(700,1500,3072,1728,3032,1650)).toEqual({width:500,height:1382});
  expect(fitSize(700,1500,320,200,300,180)).toEqual({width:300,height:160});
  expect(fitSize(500,600,1920,1080,1880,1000)).toEqual({width:500,height:600});
  for (const value of [null,[],{}, {width:'500',height:600},{width:NaN,height:3},{width:20000,height:600}]) expect(parseSize(value)).toBeNull();

--- a/panel-size.test.ts
+++ b/panel-size.test.ts
@@ -1,0 +1,27 @@
+import {test,expect} from 'bun:test';
+import {fitSize,parseSize} from './panel-size';
+import {sizeStore} from './panel-size-store';
+import {mkdtempSync,rmSync,writeFileSync,symlinkSync,statSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+test('panel sizes track the current display and never exceed 80% height',()=>{
+ expect(fitSize(700,1500,1920,1080,1880,1000)).toEqual({width:700,height:864});
+ expect(fitSize(700,1500,3072,1728,3032,1650)).toEqual({width:700,height:1382});
+ expect(fitSize(700,1500,320,200,300,180)).toEqual({width:300,height:160});
+ expect(fitSize(500,600,1920,1080,1880,1000)).toEqual({width:500,height:600});
+ for (const value of [null,[],{}, {width:'500',height:600},{width:NaN,height:3},{width:20000,height:600}]) expect(parseSize(value)).toBeNull();
+});
+test('size storage round-trips dimensions and rejects oversized files and symlinks',()=>{
+ const dir=mkdtempSync(join(tmpdir(),'blip-size-'));
+ try {
+  expect(sizeStore(dir,['500','600'])).toEqual({width:500,height:600});
+  expect(sizeStore(dir,[])).toEqual({width:500,height:600});
+  expect(statSync(join(dir,'panel.json')).mode & 0o777).toBe(0o600);
+  writeFileSync(join(dir,'panel.json'),' '.repeat(257));
+  expect(sizeStore(dir,[])).toBeNull();
+  rmSync(join(dir,'panel.json'));
+  symlinkSync('missing',join(dir,'panel.json'));
+  expect(()=>sizeStore(dir,[])).toThrow();
+  expect(sizeStore(dir,['bad','600'])).toBeNull();
+ } finally {rmSync(dir,{recursive:true,force:true});}
+});

--- a/panel-size.ts
+++ b/panel-size.ts
@@ -7,7 +7,7 @@ export function parseSize(value: unknown): PanelSize | null {
     && width <= 16384 && height <= 16384 ? {width,height} : null;
 }
 export function fitSize(width:number,height:number,screenWidth:number,screenHeight:number,availableWidth:number,availableHeight:number): PanelSize {
-  const maxWidth = Math.max(1, Math.floor(Math.min(screenWidth || width, availableWidth || width)));
+  const maxWidth = Math.max(1, Math.floor(Math.min(500, screenWidth || width, availableWidth || width)));
   const maxHeight = Math.max(1, Math.floor(Math.min((screenHeight || height) * .8, availableHeight || height)));
   return {
     width: Math.round(Math.min(maxWidth, Math.max(Math.min(280,maxWidth),width))),

--- a/panel-size.ts
+++ b/panel-size.ts
@@ -1,0 +1,16 @@
+// Rebuild: bun build panel-size.ts --target browser --format esm --outfile PanelSize.mjs
+export interface PanelSize { width: number; height: number }
+export function parseSize(value: unknown): PanelSize | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const {width,height} = value as PanelSize;
+  return Number.isInteger(width) && Number.isInteger(height) && width >= 1 && height >= 1
+    && width <= 16384 && height <= 16384 ? {width,height} : null;
+}
+export function fitSize(width:number,height:number,screenWidth:number,screenHeight:number,availableWidth:number,availableHeight:number): PanelSize {
+  const maxWidth = Math.max(1, Math.floor(Math.min(screenWidth || width, availableWidth || width)));
+  const maxHeight = Math.max(1, Math.floor(Math.min((screenHeight || height) * .8, availableHeight || height)));
+  return {
+    width: Math.round(Math.min(maxWidth, Math.max(Math.min(280,maxWidth),width))),
+    height: Math.round(Math.min(maxHeight, Math.max(Math.min(240,maxHeight),height))),
+  };
+}

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -518,7 +518,6 @@ test("outgoing bubbles are always iMessage blue with white text", () => {
 test("the header shows the version from manifest.json", () => {
   expect(widget).toContain('Qt.resolvedUrl("manifest.json")');
   expect(widget).toContain("root.version = String(JSON.parse(text()).version");
-  expect(panel).toContain("trailingControl: Component");
   expect(panel).toContain("text: root.version");
 });
 

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -403,9 +403,8 @@ describe("QML safety invariants", () => {
     expect(panel).toContain('var keepInline = root.fetchJobAction === "copy" && !!root.attFiles[id]');
     expect(panel).not.toContain("fetchJobOpen");
     expect(qmlFunction("quoteBubble")).toContain("leaveBubbles()");
-    // the status line never collapses (no layout shift) and only failures are red
-    expect(panel).toContain('text: root.note === "" ? " " : root.note');
-    expect(panel).not.toContain('visible: root.note !== ""');
+    // Empty status does not reserve a row; only failures are red.
+    expect(panel).toContain('visible: root.note !== ""');
     expect(panel).toContain("color: calm ? root.dim : root.urgent");
   });
 
@@ -608,9 +607,13 @@ test("search queries never ride argv", () => {
 test("pinned avatars size through Layout hints, not width bindings", () => {
   const start = panel.indexOf("id: pinnedAvatar");
   expect(start).toBeGreaterThan(-1);
-  const avatar = panel.slice(start, start + 600);
-  expect(avatar).toContain("Layout.preferredWidth: Math.min(88, Math.max(56,");
-  expect(avatar).toContain("Layout.preferredHeight: Layout.preferredWidth");
+  const avatar = panel.slice(start, panel.indexOf("radius: width / 2", start));
+  expect(avatar).toContain("readonly property real avatarSize: Math.min(88, Math.max(56,");
+  expect(avatar).toContain("implicitWidth: avatarSize");
+  expect(avatar).toContain("implicitHeight: avatarSize");
+  expect(avatar).toContain("Layout.preferredWidth: avatarSize");
+  expect(avatar).not.toContain("pinnedGrid.width");
+  expect(avatar).toContain("Layout.preferredHeight: avatarSize");
   expect(avatar).not.toContain(" width: Math.min(88");
 });
 


### PR DESCRIPTION
Add a bottom-right line grip and remember preferred panel dimensions across restarts. Clamp the full panel height to 80% of its current display and width to 500 logical pixels or the available space, whichever is smaller, preserving the saved preference when a smaller display limits it. Stabilize pinned avatar sizes before first open and match composer spacing without reserving an empty status row.

Restore contiguous conversation rows with text-aligned separators. Hover and keyboard highlights fill the row and hide both adjacent separators. Ordinary avatars increase from 34px to 40px; pinned avatars retain the 88px cap. Normal and highlighted states were verified with synthetic QML screenshots.

Only bounded width/height metadata is persisted, using private atomic writes. Contact-review sizing from main is preserved.

Validation: `bun test` (436 passing). Shared Mac-side CI test suites and shell syntax checks pass. No real conversations were opened or messages sent for testing. Shellcheck is unavailable locally; CI covers it.

Based directly on current main (`174b58e`), as a focused series; independent of the other split PRs and contact-write PR #25.