### PR TITLE
Add Ctrl+1–9 pinned shortcuts and a conversation back arrow

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -20,6 +20,17 @@ import qs.Ui
 FocusScope {
   id: root
 
+  PinnedShortcuts {
+    pins: root.pinnedThreads
+    active: root.surfaceOpen && !root.contactsOpen && root.shareUrl === ""
+    onChosen: function(thread) {
+      if (root.newMode) root.exitNew()
+      if (root.searching) root.exitSearch()
+      if (root.inThread && String(root.active.chat) === String(thread.chat)) root.focusDefault()
+      else root.openThread(thread)
+    }
+  }
+
   // ---- host contract (docs/app-design-review.md) ----------------------
   property var hostWidget: null
   /** Qt format strings, owned by the host widget (see BarWidget). Empty when no host is
@@ -2521,6 +2532,19 @@ FocusScope {
         RowLayout {
           Layout.fillWidth: true
           spacing: Style.space(8)
+          PanelActionButton {
+            visible: root.inThread && !root.splitView
+            Layout.alignment: Qt.AlignTop
+            Layout.topMargin: Style.space(6)
+            iconText: "←"
+            tooltipText: "Back to messages (Esc)"
+            Accessible.name: "Back to messages"
+            focusable: true
+            foreground: root.foreground
+            hoverColor: root.accent
+            fontFamily: root.fontFamily
+            onClicked: root.back()
+          }
           PanelHero {
             Layout.fillWidth: true
             title: root.inThread ? String(root.active.name || root.active.chat) : "Select a conversation"
@@ -2529,9 +2553,7 @@ FocusScope {
                   ? (root.isSendable(root.active) ? "group" : "group · read-only (id unknown)")
                   : String(root.active.handle))
               : ""
-            detail: root.inThread
-              ? (root.loading ? "loading…" : (root.splitView ? "" : "Esc = back"))
-              : ""
+            detail: root.inThread && root.loading ? "loading…" : ""
             foreground: root.foreground
             fontFamily: root.fontFamily
           }

--- a/PinnedShortcuts.qml
+++ b/PinnedShortcuts.qml
@@ -1,0 +1,24 @@
+import QtQuick
+
+// Window-scoped shortcuts also work while a draft editor owns keyboard focus.
+Item {
+  id: root
+  property var pins: []
+  property bool active: false
+  signal chosen(var thread)
+  Repeater {
+    model: 9
+    delegate: Item {
+      required property int index
+      Shortcut {
+        sequence: "Ctrl+" + (index + 1)
+        context: Qt.WindowShortcut
+        enabled: root.active
+        onActivated: {
+          var thread = root.pins[index]
+          if (thread) root.chosen(thread)
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ helper; the optional availability check needs Automation → Contacts on the Mac
 | list | `a` · *mark all read* link | clear every badge and dot — and tell the Mac, so your iPhone catches up too |
 | list | `/` | search conversations by name as you type, then messages; Enter opens the highlight, Esc backs out |
 | list | `n` · *＋ new* link | start a conversation with anyone — search contacts by name, or type a number/email directly |
+| panel or window | `Ctrl+1` … `Ctrl+9` | open the corresponding pinned conversation, left to right then top to bottom; works while typing; unused numbers do nothing |
 | thread | `Enter` | send (text, or the queued file with the text as caption) |
 | thread | `Ctrl+V` | paste — an image on the clipboard becomes a queued file, text pastes normally |
 | thread | `/attach <path>` + `Enter` | queue any file on this machine; drag-and-drop works too |

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -670,3 +670,13 @@ test("the share sheet steps through a message's links", () => {
   expect(sheet).toContain('visible: root.shareQr !== "" || qrProc.running');
   expect(qmlFunction("showShareUrl")).not.toContain('shareQr = ""');
 });
+ test("Ctrl+number shortcuts use pin order and remain available in editors", () => {
+   const source = readFileSync(new URL("./PinnedShortcuts.qml", import.meta.url), "utf8");
+   expect(source).toContain('sequence: "Ctrl+" + (index + 1)');
+   expect(source).toContain('context: Qt.WindowShortcut');
+   expect(source).toContain('model: 9');
+   expect(source).toContain('if (thread) root.chosen(thread)');
+   expect(panel).toContain('pins: root.pinnedThreads');
+   expect(panel).toContain('active: root.surfaceOpen && !root.contactsOpen && root.shareUrl === ""');
+   expect(panel).toContain('String(root.active.chat) === String(thread.chat)) root.focusDefault()');
+ });


### PR DESCRIPTION
Open pinned conversations in displayed grid order with Ctrl+1–9, including while the composer has focus. Missing pin slots do nothing; shortcuts stand down during contact review. Add a visible, accessible back arrow to the single-pane conversation header and move the Escape hint into its tooltip. Existing draft and read-mark behavior is retained.

Validation: `bun test` (435 passing). Shared Mac-side CI test suites and shell syntax checks pass. No real conversations were opened or messages sent for testing. Shellcheck is unavailable locally; CI covers it.

Based directly on current main (`174b58e`), as one focused commit; independent of the other split PRs and contact-write PR #25.