### PR TITLE
Do not open the share menu after sending a link

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -188,7 +188,7 @@ FocusScope {
   property int shareCursor: 0      // highlighted action (mouse and keys agree)
   property real shareKeysFrom: 0   // Enter and digits act from this time on
   /** Open the sheet on one URL or a list (a message's links, first showing).
-   *  `auto`: it opened by itself — a link you sent, a link that arrived, IPC.
+   *  `auto`: it opened by itself — a link that arrived, IPC.
    *  The sheet is the warning either way (host, full URL, a button that says
    *  what Enter does), but for 700 ms after an auto sheet appears Enter and
    *  digits still belong to the draft, so a link landing as Enter is pressed
@@ -1485,10 +1485,6 @@ FocusScope {
       root.sendText = ""
       root.sendStamp = ""
       if (code === 0) {
-        // A URL you just SHARED opens the sheet too (Fred, 2.3.0): send it,
-        // then offer the QR / LocalSend / copy for the same link.
-        var sentUrls = root.allUrls(completedText)
-        if (belongsHere && sentUrls.length > 0) Qt.callLater(function() { root.openShare(sentUrls, true) })
         // The bubble is already up; reload to swap it for the real row.
         root.reloadChat = completedChat
         reloadTimer.restart()

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Linux side. If the Mac is asleep, the widget dims and says so.
 </p>
 
 <p align="center">
-  <sub>Right-click any link — or just send or receive one — and the share sheet comes up on it.</sub>
+  <sub>Right-click any link to open its share sheet. Incoming links can also open it automatically; sending a link does not.</sub>
 </p>
 
 ## Privacy

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -112,9 +112,8 @@ describe("QML safety invariants", () => {
     expect(widget).toContain("root.windowVisible");                   // or the app window
   });
 
-  test("a link you SEND opens the sheet too, and the app button asks the host", () => {
-    expect(panel).toContain("var sentUrls = root.allUrls(completedText)");   // every link of the message
-    expect(panel).toContain("root.openShare(sentUrls, true)");
+  test("sending a link does not open the share sheet, and the app button asks the host", () => {
+    expect(panel).not.toContain("root.openShare(sentUrls, true)");
     expect(panel).toContain("function openApp()");
     expect(panel).toContain('hostWidget.showApp()');
     // the popout gets out of the way, and closes BEFORE the window is shown —
@@ -645,7 +644,7 @@ test("a selected link opens the share sheet, and the sheet has keys", () => {
   // send must not be opened by that Enter.
   expect(qmlFunction("shareKey")).toContain("if (Date.now() < shareKeysFrom) return false");
   expect(qmlFunction("openShare")).toContain("shareKeysFrom = Date.now() + (auto === true ? 700 : 0)");
-  expect(panel).toContain("root.openShare(sentUrls, true)");
+  expect(panel).not.toContain("root.openShare(sentUrls, true)");
   expect(qmlFunction("shareLink")).toContain("openShare(u, true)");
   const compose = panel.slice(panel.indexOf("id: composeField"));
   expect(compose.indexOf("if (root.shareKey(event.key)) { event.accepted = true; return }")).toBeLessThan(compose.indexOf("root.send()"));


### PR DESCRIPTION
Sending a URL currently opens the QR/copy/LocalSend sheet after success, interrupting the conversation. Remove that post-send action. Explicit link actions and incoming-link behavior remain available; optimistic sending and failure handling are unchanged.

Validation: `bun test` (434 passing). Shared Mac-side CI test suites and shell syntax checks pass. No real conversations were opened or messages sent for testing. Shellcheck is unavailable locally; CI covers it.

Based directly on current main (`174b58e`), as one focused commit; independent of the other split PRs and contact-write PR #25.