### PR TITLE
Use participant names and composite avatars for unnamed groups

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -2223,7 +2223,6 @@ FocusScope {
                         active: pinnedAvatarImg.status !== Image.Ready
                           && root.isGroupId(String(modelData.chat || ""))
                           && (modelData.participants || []).length > 0
-                          && root.avatarFiles[pinnedAvatar.avatarHandle] !== undefined
                         sourceComponent: GroupAvatar {
                           participants: modelData.participants || []
                           avatarFiles: root.avatarFiles
@@ -2456,7 +2455,6 @@ FocusScope {
                       active: avatarImg.status !== Image.Ready
                         && root.isGroupId(String(modelData.chat || ""))
                         && (modelData.participants || []).length > 0
-                        && root.avatarFiles[avatarCircle.avatarHandle] !== undefined
                       sourceComponent: GroupAvatar {
                         participants: modelData.participants || []
                         avatarFiles: root.avatarFiles

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -767,6 +767,7 @@ FocusScope {
 
   property var avatarFiles: ({})     // handle → file:// url, "" = no photo
   property var avatarQueue: []
+  property bool avatarBusy: false // hold the request identity until stdout is consumed
   function requestAvatar(handle) {
     handle = String(handle || "")
     if (handle === "") return          // groups are welcome: avatar.ts asks for the group's own photo
@@ -788,7 +789,8 @@ FocusScope {
   }
   onSurfaceOpenChanged: if (surfaceOpen) root.retryBareAvatars()
   function pumpAvatar() {
-    if (avatarProc.running || avatarQueue.length === 0) return
+    if (avatarBusy || avatarProc.running || avatarQueue.length === 0) return
+    avatarBusy = true
     avatarProc.handle = avatarQueue.shift()
     // --retry skips the 24h "no photo" marker so a picture set after the
     // first ask (a new group photo, a Contacts card) shows up this session.
@@ -805,7 +807,8 @@ FocusScope {
         var m = Object.assign({}, root.avatarFiles)
         m[avatarProc.handle] = url
         root.avatarFiles = m
-        root.pumpAvatar()
+        root.avatarBusy = false
+        Qt.callLater(root.pumpAvatar)
       }
     }
     onExited: Qt.callLater(root.pumpAvatar)

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -2214,9 +2214,24 @@ FocusScope {
                         maskEnabled: true
                         maskSource: pinnedAvatarMask
                       }
+                      Loader {
+                        id: pinnedAvatarComposite
+                        anchors.fill: parent
+                        active: pinnedAvatarImg.status !== Image.Ready
+                          && root.isGroupId(String(modelData.chat || ""))
+                          && (modelData.participants || []).length > 0
+                          && root.avatarFiles[pinnedAvatar.avatarHandle] !== undefined
+                        sourceComponent: GroupAvatar {
+                          participants: modelData.participants || []
+                          avatarFiles: root.avatarFiles
+                          foreground: root.foreground
+                          fontFamily: root.fontFamily
+                          onRequestAvatar: handle => root.requestAvatar(handle)
+                        }
+                      }
                       Text {
                         anchors.centerIn: parent
-                        visible: pinnedAvatarImg.status !== Image.Ready
+                        visible: pinnedAvatarImg.status !== Image.Ready && !pinnedAvatarComposite.active
                         text: root.avatarInitials(modelData)
                         color: root.foreground
                         font.family: root.fontFamily
@@ -2432,9 +2447,24 @@ FocusScope {
                       maskEnabled: true
                       maskSource: avatarMask
                     }
+                    Loader {
+                      id: avatarCircleComposite
+                      anchors.fill: parent
+                      active: avatarImg.status !== Image.Ready
+                        && root.isGroupId(String(modelData.chat || ""))
+                        && (modelData.participants || []).length > 0
+                        && root.avatarFiles[avatarCircle.avatarHandle] !== undefined
+                      sourceComponent: GroupAvatar {
+                        participants: modelData.participants || []
+                        avatarFiles: root.avatarFiles
+                        foreground: root.foreground
+                        fontFamily: root.fontFamily
+                        onRequestAvatar: handle => root.requestAvatar(handle)
+                      }
+                    }
                     Text {
                       anchors.centerIn: parent
-                      visible: avatarImg.status !== Image.Ready
+                      visible: avatarImg.status !== Image.Ready && !avatarCircleComposite.active
                       text: root.avatarInitials(modelData)
                       color: root.foreground
                       font.family: root.fontFamily

--- a/GroupAvatar.mjs
+++ b/GroupAvatar.mjs
@@ -1,0 +1,37 @@
+// group-avatar.ts
+function initials(value) {
+  const name = typeof value === "string" ? value.slice(0, 160).trim() : "";
+  if (!name || /^[+0-9]/.test(name) || name.includes("@"))
+    return "#";
+  const words = name.split(/\s+/);
+  return (Array.from(words[0])[0] + (words.length > 1 ? Array.from(words[words.length - 1])[0] : "")).toUpperCase();
+}
+function members(value) {
+  if (!Array.isArray(value))
+    return [];
+  const seen = new Set;
+  const people = [];
+  for (const person of value.slice(0, 64)) {
+    if (!person || typeof person.handle !== "string" || person.handle.length > 320 || !/^(?:\+?\d+|[^\s@]+@[^\s@]+)$/.test(person.handle) || seen.has(person.handle))
+      continue;
+    seen.add(person.handle);
+    people.push({ handle: person.handle, initials: initials(person.name) });
+    if (people.length === 4)
+      break;
+  }
+  const layouts = [
+    [],
+    [[0.18, 0.18, 0.64]],
+    [[0.1, 0.1, 0.55], [0.56, 0.56, 0.34]],
+    [[0.27, 0.06, 0.46], [0.09, 0.45, 0.46], [0.45, 0.45, 0.46]],
+    [[0.16, 0.16, 0.34], [0.51, 0.16, 0.34], [0.16, 0.51, 0.34], [0.51, 0.51, 0.34]]
+  ];
+  return people.map((person, i) => {
+    const [x, y, size] = layouts[people.length][i];
+    return { handle: person.handle, initials: person.initials, x, y, size };
+  });
+}
+export {
+  members,
+  initials
+};

--- a/GroupAvatar.mjs
+++ b/GroupAvatar.mjs
@@ -28,7 +28,14 @@ function members(value) {
   ];
   return people.map((person, i) => {
     const [x, y, size] = layouts[people.length][i];
-    return { handle: person.handle, initials: person.initials, x, y, size };
+    const inset = 0.08, scale = 1 - inset * 2;
+    return {
+      handle: person.handle,
+      initials: person.initials,
+      x: inset + x * scale,
+      y: inset + y * scale,
+      size: size * scale
+    };
   });
 }
 export {

--- a/GroupAvatar.qml
+++ b/GroupAvatar.qml
@@ -1,0 +1,62 @@
+import QtQuick
+import QtQuick.Effects
+import "GroupAvatar.mjs" as AvatarModel
+
+// Custom group photos are rendered by the caller. This is the fallback only.
+Item {
+  id: root
+  property var participants: []
+  property var avatarFiles: ({})
+  property color foreground: "white"
+  property string fontFamily: "sans-serif"
+  readonly property var members: AvatarModel.members(Array.from(participants))
+  signal requestAvatar(string handle)
+
+  Repeater {
+    model: root.members
+    delegate: Rectangle {
+      required property var modelData
+      x: modelData.x * root.width
+      y: modelData.y * root.height
+      width: modelData.size * root.width
+      height: width
+      radius: width / 2
+      color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.18)
+      Component.onCompleted: root.requestAvatar(modelData.handle)
+      Image {
+        id: photo
+        anchors.fill: parent
+        visible: false
+        source: root.avatarFiles[modelData.handle] || ""
+        asynchronous: true
+        autoTransform: true
+        fillMode: Image.PreserveAspectCrop
+        sourceSize: Qt.size(128,128)
+      }
+      Item {
+        id: mask
+        anchors.fill: parent
+        visible: false
+        layer.enabled: true
+        Rectangle { anchors.fill: parent; radius: width / 2 }
+      }
+      MultiEffect {
+        anchors.fill: parent
+        source: photo
+        visible: photo.status === Image.Ready
+        maskEnabled: true
+        maskSource: mask
+      }
+      Text {
+        anchors.centerIn: parent
+        visible: photo.status !== Image.Ready
+        text: modelData.initials
+        textFormat: Text.PlainText
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: parent.width * .36
+        font.bold: true
+      }
+    }
+  }
+}

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -302,6 +302,9 @@ def _dm_name(handle: str | None, chat_identifier: str | None) -> str | None:
     return name_for(chat_identifier) if _is_dm_id(chat_identifier) else None
 
 
+_SHORT_NAMES: dict[str, set[str]] = {}
+
+
 def name_for(handle: str | None) -> str | None:
     """Resolve a Messages handle (phone or email) to a Contacts display name.
     Lazily builds an in-memory index from all AddressBook source DBs on first
@@ -326,13 +329,17 @@ def name_for(handle: str | None) -> str | None:
             try:
                 con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
                 con.row_factory = sqlite3.Row
-                names = {
-                    r["pk"]: _card_name(r["first"], r["last"], r["org"], r["nick"])
-                    for r in con.execute(
-                        "SELECT Z_PK AS pk, ZFIRSTNAME AS first, ZLASTNAME AS last, "
-                        "ZORGANIZATION AS org, ZNICKNAME AS nick FROM ZABCDRECORD"
-                    )
-                }
+                cards = con.execute(
+                    "SELECT Z_PK AS pk, ZFIRSTNAME AS first, ZLASTNAME AS last, "
+                    "ZORGANIZATION AS org, ZNICKNAME AS nick FROM ZABCDRECORD"
+                ).fetchall()
+                names = {}
+                for card in cards:
+                    full = _card_name(card["first"], card["last"], card["org"], card["nick"])
+                    names[card["pk"]] = full
+                    short = card["first"] or card["nick"] or full
+                    if full and short:
+                        _SHORT_NAMES.setdefault(full, set()).add(short)
                 local: dict[str | Phone, str | None] = {}   # None = ambiguous within this source
                 for r in con.execute(
                     "SELECT ZOWNER AS pk, ZFULLNUMBER AS num FROM ZABCDPHONENUMBER"
@@ -380,6 +387,13 @@ def name_for(handle: str | None) -> str | None:
     parsed = _parse_phone(handle)
     near = {n for card, n in _PHONE_INDEX.items() if parsed and _same_number(parsed, card)}
     return near.pop() if len(near) == 1 else None
+
+
+def short_name_for(handle: str) -> str | None:
+    """Prefer the structured given name; never split a full name on spaces."""
+    full = name_for(handle)
+    choices = _SHORT_NAMES.get(full, set())
+    return next(iter(choices)) if len(choices) == 1 else full
 
 
 def unified_names(handles: list[str]) -> dict[str, dict[str, str]]:
@@ -1389,6 +1403,11 @@ def cmd_groups(con, args):
                                 or name_for(handle)
                                 or handle
                             )
+                            for handle in participant_lists[index]
+                        } if not args.no_names else {},
+                        "participant_short_names": {
+                            handle: contact_names.get(handle, {}).get("short")
+                                or short_name_for(handle) or handle
                             for handle in participant_lists[index]
                         } if not args.no_names else {},
                         "last": fmt_ts(r["last_date"]) if r["last_date"] else None,

--- a/bridge/mac/imsg_test.py
+++ b/bridge/mac/imsg_test.py
@@ -24,6 +24,23 @@ def load_imsg():
 imsg = load_imsg()
 
 
+class ShortNameTests(unittest.TestCase):
+    def test_structured_short_names_preserve_multiword_names_and_safe_fallbacks(self):
+        original = imsg.name_for
+        saved = imsg._SHORT_NAMES
+        try:
+            imsg.name_for = lambda _: "Mary Jane Example"
+            imsg._SHORT_NAMES = {"Mary Jane Example": {"Mary Jane"}}
+            self.assertEqual(imsg.short_name_for("+15551234567"), "Mary Jane")
+            imsg._SHORT_NAMES = {"Mary Jane Example": {"Mary Jane", "Mary"}}
+            self.assertEqual(imsg.short_name_for("+15551234567"), "Mary Jane Example")
+            imsg._SHORT_NAMES = {}
+            self.assertEqual(imsg.short_name_for("+15551234567"), "Mary Jane Example")
+        finally:
+            imsg.name_for = original
+            imsg._SHORT_NAMES = saved
+
+
 class ChatProjectionTests(unittest.TestCase):
     def test_chat_json_deduplicates_parallel_service_rows(self):
         con = sqlite3.connect(":memory:")

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -943,6 +943,25 @@ describe("complete conversation list (mergeChats)", () => {
       pinned: false, pin_order: null, aliases: ["+15559990000"], pin_name: null },
   ];
 
+  test("unnamed groups use resolved participants in both list merge paths", () => {
+    const chat = {...chats[1]!, name:null};
+    const info = {name:"", guid:"any;+;"+chat.id,
+      participants:["+15551234567", "+15550001111"],
+      participantNames:{"+15551234567":"Pat", "+15550001111":"Sam"}};
+    const groups = {[chat.id]:info};
+    const quiet = mergeChats([], [chat], groups, {})[0]!;
+    expect(quiet.name).toBe("Pat, Sam");
+    const existing = {...quiet, name:chat.id};
+    expect(mergeChats([existing], [chat], groups, {})[0]!.name).toBe("Pat, Sam");
+    expect(mergeChats([], [{...chat,name:"Custom title"}], groups, {})[0]!.name).toBe("Custom title");
+    expect(mergeChats([], [chat], {[chat.id]:{...info,name:"Group title"}}, {})[0]!.name).toBe("Group title");
+    const aliasChat = {...chat,id:"chat123456",aliases:["chat123456",chat.id]};
+    const aliased = mergeChats([], [aliasChat], groups, {})[0]!;
+    expect(aliased.name).toBe("Pat, Sam");
+    expect(aliased.guid).toBe(info.guid);
+    expect(mergeChats([], [chat], {}, {})[0]!.name).toBe(chat.id);
+  });
+
   test("quiet conversations outside the window appear, newest first", () => {
     const out = mergeChats([windowThread], chats, { ce5a593a78af408282d61461ade89135: { name: "Lunch Crew", guid: "any;+;ce5a", participants: [] } }, { ce5a593a78af408282d61461ade89135: 2 });
     expect(out.map((t) => t.chat)).toEqual(["+15551234567", "ce5a593a78af408282d61461ade89135", "+15559990000"]);

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -1648,3 +1648,15 @@ describe("blip-setup: the key's from= pin", () => {
     expect(src).not.toContain("key_from=");   // no config knob: the pin follows the transport
   });
 });
+
+test("group labels prefer short names while participant details retain full names", () => {
+ const {groupName,groupParticipants,normalizeGroups,fetchGroups} = require('./collector');
+ const info={name:"",guid:"any;+;chat123",participants:["+15551234567"],participantNames:{"+15551234567":"Mary Jane Example"},participantShortNames:{"+15551234567":"Mary Jane"}};
+ expect(groupName('chat123',info,new Map())).toBe('Mary Jane');
+ expect(groupParticipants(info)[0].name).toBe('Mary Jane Example');
+ expect(groupName('chat123',{...info,name:'Custom group'},new Map())).toBe('Custom group');
+ expect(normalizeGroups({chat123:info}).chat123).toEqual(info);
+ const fetched=fetchGroups(()=>({status:0,stdout:JSON.stringify([{chat:'chat123',name:'',guid:info.guid,participants:info.participants,participant_names:info.participantNames,participant_short_names:info.participantShortNames}])}));
+ expect(fetched.chat123).toEqual(info);
+ expect(normalizeGroups({chat123:{...info,participantShortNames:[]}}).chat123.participantShortNames).toBeUndefined();
+});

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -264,7 +264,7 @@ describe("self-echo in the thread list", () => {
       "", {},
       { [guid]: { name: "", guid: "any;+;" + guid, participants: ["+15550100004", "+15550100005"] } },
     );
-    expect(threads[0]!.name).toBe("Jordan Blake, +15550100005");
+    expect(threads[0]!.name).toBe("Jordan Blake & +15550100005");
   });
 
   test("group threads expose named participants for explicit contact actions", () => {
@@ -950,14 +950,14 @@ describe("complete conversation list (mergeChats)", () => {
       participantNames:{"+15551234567":"Pat", "+15550001111":"Sam"}};
     const groups = {[chat.id]:info};
     const quiet = mergeChats([], [chat], groups, {})[0]!;
-    expect(quiet.name).toBe("Pat, Sam");
+    expect(quiet.name).toBe("Pat & Sam");
     const existing = {...quiet, name:chat.id};
-    expect(mergeChats([existing], [chat], groups, {})[0]!.name).toBe("Pat, Sam");
+    expect(mergeChats([existing], [chat], groups, {})[0]!.name).toBe("Pat & Sam");
     expect(mergeChats([], [{...chat,name:"Custom title"}], groups, {})[0]!.name).toBe("Custom title");
     expect(mergeChats([], [chat], {[chat.id]:{...info,name:"Group title"}}, {})[0]!.name).toBe("Group title");
     const aliasChat = {...chat,id:"chat123456",aliases:["chat123456",chat.id]};
     const aliased = mergeChats([], [aliasChat], groups, {})[0]!;
-    expect(aliased.name).toBe("Pat, Sam");
+    expect(aliased.name).toBe("Pat & Sam");
     expect(aliased.guid).toBe(info.guid);
     expect(mergeChats([], [chat], {}, {})[0]!.name).toBe(chat.id);
   });
@@ -1659,4 +1659,13 @@ test("group labels prefer short names while participant details retain full name
  const fetched=fetchGroups(()=>({status:0,stdout:JSON.stringify([{chat:'chat123',name:'',guid:info.guid,participants:info.participants,participant_names:info.participantNames,participant_short_names:info.participantShortNames}])}));
  expect(fetched.chat123).toEqual(info);
  expect(normalizeGroups({chat123:{...info,participantShortNames:[]}}).chat123.participantShortNames).toBeUndefined();
+});
+
+test("generated group labels join the last short name with an ampersand", () => {
+ const {groupName} = require('./collector');
+ const info={name:"",guid:"",participants:["a","b","c"],participantShortNames:{a:"Pat",b:"Sam",c:"Alex"}};
+ expect(groupName('chat123',info,new Map())).toBe('Pat, Sam & Alex');
+ expect(groupName('chat123',{...info,participants:['a','b']},new Map())).toBe('Pat & Sam');
+ expect(groupName('chat123',{...info,participants:['a']},new Map())).toBe('Pat');
+ expect(groupName('chat123',{...info,name:'Custom, title'},new Map())).toBe('Custom, title');
 });

--- a/collector.ts
+++ b/collector.ts
@@ -140,6 +140,7 @@ export interface GroupInfo {
   guid: string;
   participants: string[];
   participantNames?: Record<string, string>;
+  participantShortNames?: Record<string, string>;
 }
 
 export interface BlipState {
@@ -208,6 +209,12 @@ export function validPins(raw: unknown): Record<string, number | null> {
   );
 }
 
+export function nameMap(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  return Object.fromEntries(Object.entries(raw).slice(0, 64).filter(([handle, name]) =>
+    handle.length <= 320 && typeof name === "string" && name.length <= 160 && name.trim() !== ""));
+}
+
 export function normalizeGroups(raw: unknown): Record<string, GroupInfo> {
   const out: Record<string, GroupInfo> = {};
   if (!raw || typeof raw !== "object") return out;
@@ -218,6 +225,8 @@ export function normalizeGroups(raw: unknown): Record<string, GroupInfo> {
       name: typeof r.name === "string" ? r.name : "",
       guid: typeof r.guid === "string" ? r.guid : "",
       participants: Array.isArray(r.participants) ? r.participants.filter((h): h is string => typeof h === "string") : [],
+      ...(Object.keys(nameMap(r.participantNames)).length ? {participantNames:nameMap(r.participantNames)} : {}),
+      ...(Object.keys(nameMap(r.participantShortNames)).length ? {participantShortNames:nameMap(r.participantShortNames)} : {}),
     };
   }
   return out;
@@ -496,7 +505,8 @@ export function hasIdentity(m: ImsgMessage): boolean {
  */
 export function groupName(chat: string, info: GroupInfo | undefined, byHandle: Map<string, string>): string {
   if (info?.name) return info.name;
-  const members = groupParticipants(info, byHandle).map((member) => member.name);
+  const members = groupParticipants(info, byHandle).map((member) =>
+    info?.participantShortNames?.[member.handle] || member.name);
   // A "(filtered)" stranger is not a phone/email shape, so it lands here (the
   // never-a-DM-target rule stands: nothing sends to it); its label is the number.
   return members.length ? members.join(", ") : prettyHandle(chat);
@@ -1501,6 +1511,8 @@ export function fetchGroups(runner = spawnSync): Record<string, GroupInfo> | nul
           ? r.participants.filter((h: unknown) => typeof h === "string")
           : typeof r.participants === "string" ? r.participants.split(",").filter(Boolean) : [],
         ...(Object.keys(participantNames).length ? { participantNames } : {}),
+        ...(Object.keys(nameMap(r.participant_short_names)).length
+          ? {participantShortNames:nameMap(r.participant_short_names)} : {}),
       };
     }
     return out;

--- a/collector.ts
+++ b/collector.ts
@@ -509,7 +509,9 @@ export function groupName(chat: string, info: GroupInfo | undefined, byHandle: M
     info?.participantShortNames?.[member.handle] || member.name);
   // A "(filtered)" stranger is not a phone/email shape, so it lands here (the
   // never-a-DM-target rule stands: nothing sends to it); its label is the number.
-  return members.length ? members.join(", ") : prettyHandle(chat);
+  if (members.length === 0) return prettyHandle(chat);
+  if (members.length === 1) return members[0]!;
+  return members.slice(0, -1).join(", ") + " & " + members[members.length - 1];
 }
 
 export type SendService = "iMessage" | "SMS" | "RCS";

--- a/collector.ts
+++ b/collector.ts
@@ -1430,7 +1430,8 @@ export function mergeChats(
       aliases,
       guid: group ? groupInfo?.guid ?? thread.guid : "",
       name: group
-        ? (groupInfo?.name || info.name || thread.name || thread.chat)
+        ? (groupInfo?.name || info.name || (groupInfo?.participants.length
+          ? groupName(thread.chat, groupInfo, knownParticipantNames) : thread.name || thread.chat))
         : (info.last_name || info.name || thread.name || thread.chat),
       service: info.service || thread.service,
       last_text: info.last === thread.last_ts ? info.last_text : messagePreview(thread.last_text),
@@ -1454,7 +1455,7 @@ export function mergeChats(
     const groupInfo = groups[c.id]
       ?? aliases.map((alias) => groups[alias]).find((value) => value !== undefined);
     const name = group
-      ? (groupInfo?.name || c.name || c.id)
+      ? (groupInfo?.name || c.name || groupName(c.id, groupInfo, new Map()))
       : (c.last_name || c.name || c.id);
     out.push({
       chat: c.id,

--- a/group-avatar.test.ts
+++ b/group-avatar.test.ts
@@ -1,0 +1,25 @@
+import {test, expect} from 'bun:test';
+import {initials, members} from './group-avatar';
+test('initials use full names and keep unknown handles neutral', () => {
+  expect(initials('Sam Smith')).toBe('SS');
+  expect(initials('Bill Nelson')).toBe('BN');
+  expect(initials('Pat')).toBe('P');
+  expect(initials('+15551234567')).toBe('#');
+  expect(initials('you@example.com')).toBe('#');
+  expect(initials(null)).toBe('#');
+});
+test('composites select at most four distinct valid participants', () => {
+  const people = Array.from({length: 8}, (_,i) => ({handle: `person${i}@example.com`,name: 'Sam Smith'}));
+  const result = members([null, {}, {handle:'chat123'},people[0],...people]);
+  expect(result).toHaveLength(4);
+  expect(result.map(p => p.handle)).toEqual(people.slice(0,4).map(p => p.handle));
+  expect(result.every(p => p.initials === 'SS')).toBe(true);
+  expect(members({})).toEqual([]);
+});
+test('all one-to-four-member layouts stay inside the circular avatar', () => {
+  for(let count=1; count<=4; count++) {
+    for(const p of members(Array.from({length:count},(_,i)=>({handle:`p${i}@example.com`,name:'Pat'})))) {
+      expect(Math.hypot(p.x!+p.size!/2-.5,p.y!+p.size!/2-.5)+p.size!/2).toBeLessThanOrEqual(.5);
+    }
+  }
+});

--- a/group-avatar.test.ts
+++ b/group-avatar.test.ts
@@ -16,10 +16,10 @@ test('composites select at most four distinct valid participants', () => {
   expect(result.every(p => p.initials === 'SS')).toBe(true);
   expect(members({})).toEqual([]);
 });
-test('all one-to-four-member layouts stay inside the circular avatar', () => {
+test('all one-to-four-member layouts leave breathing room inside the circular avatar', () => {
   for(let count=1; count<=4; count++) {
     for(const p of members(Array.from({length:count},(_,i)=>({handle:`p${i}@example.com`,name:'Pat'})))) {
-      expect(Math.hypot(p.x!+p.size!/2-.5,p.y!+p.size!/2-.5)+p.size!/2).toBeLessThanOrEqual(.5);
+      expect(Math.hypot(p.x!+p.size!/2-.5,p.y!+p.size!/2-.5)+p.size!/2).toBeLessThanOrEqual(.42);
     }
   }
 });

--- a/group-avatar.ts
+++ b/group-avatar.ts
@@ -1,0 +1,28 @@
+// Rebuild: bun build group-avatar.ts --target browser --format esm --outfile GroupAvatar.mjs
+export function initials(value: unknown): string {
+  const name = typeof value === 'string' ? value.slice(0, 160).trim() : '';
+  if (!name || /^[+0-9]/.test(name) || name.includes('@')) return '#';
+  const words = name.split(/\s+/);
+  return (Array.from(words[0]!)[0]! + (words.length > 1 ? Array.from(words[words.length - 1]!)[0]! : '')).toUpperCase();
+}
+
+/** Bounded render model; positions are fractions of the enclosing circle. */
+export function members(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const people: { handle: string; initials: string }[] = [];
+  for (const person of value.slice(0, 64)) {
+    if (!person || typeof person.handle !== 'string' || person.handle.length > 320
+      || !/^(?:\+?\d+|[^\s@]+@[^\s@]+)$/.test(person.handle) || seen.has(person.handle)) continue;
+    seen.add(person.handle);
+    people.push({ handle: person.handle, initials: initials(person.name) });
+    if (people.length === 4) break;
+  }
+  const layouts = [[], [[.18,.18,.64]], [[.1,.1,.55],[.56,.56,.34]],
+    [[.27,.06,.46],[.09,.45,.46],[.45,.45,.46]],
+    [[.16,.16,.34],[.51,.16,.34],[.16,.51,.34],[.51,.51,.34]]];
+  return people.map((person, i) => {
+    const [x,y,size] = layouts[people.length]![i]!;
+    return {handle: person.handle, initials: person.initials, x,y,size};
+  });
+}

--- a/group-avatar.ts
+++ b/group-avatar.ts
@@ -23,6 +23,9 @@ export function members(value: unknown) {
     [[.16,.16,.34],[.51,.16,.34],[.16,.51,.34],[.51,.51,.34]]];
   return people.map((person, i) => {
     const [x,y,size] = layouts[people.length]![i]!;
-    return {handle: person.handle, initials: person.initials, x,y,size};
+    // Leave an 8% radial inset so participant circles do not hug the rim.
+    const inset = .08, scale = 1 - inset * 2;
+    return {handle: person.handle, initials: person.initials,
+      x: inset + x! * scale, y: inset + y! * scale, size: size! * scale};
   });
 }


### PR DESCRIPTION
Unnamed groups outside the recent-message window display opaque chat IDs even when the bridge supplies resolved participant names. Use participant names in both list-merge paths, preferring structured short names and joining generated labels with a final ampersand ("Pat, Sam & Alex").

The bridge supplies full and short names separately. Participant details retain full names. Without the optional native Contacts helper, short names come from the contact’s given-name or nickname field, never by splitting a full name. Missing or ambiguous short names fall back to the full name. This does not promise exact parity with every Apple Short Name preference.

Groups without custom photos now show a composite of up to four participant photos or full-name initials in pinned tiles and conversation rows. Custom group photos take precedence. Participant selection and geometry live in a tested TypeScript model; QML renders it using the existing avatar cache.

Preserve custom titles, alias lookup, routing GUIDs, and read marks. Cache both name forms so shallow refreshes retain them. No message content is added to disk or argv. Based directly on main, independent of PRs #50–54.

Validation:
- `bun test`: 440 passing standalone; 454 with the other feature PRs integrated.
- Mac metadata tests: 4 passing; phone matching tests: 27 passing.
- Regression coverage includes both merge paths, custom titles, aliases, missing metadata, structured short names, cached name maps, bounded participant selection, initials, and circular layout bounds.
- Synthetic QML screenshots reviewed for two-, three-, and four-person composites, with initials and mixed photos/initials.
- Metadata-only live check found zero raw group IDs. No real conversations opened or messages sent during testing.
