### PR TITLE
Lists page from the keyboard: PgUp/PgDn/Home/End in threads, search, new

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -595,7 +595,8 @@ FocusScope {
    *  PgDn mirrors it with the bottommost, and past the newest leaves. */
   function pageBubbles(dy) {
     if (bubbles.length === 0) return
-    var edge = edgeVisibleBubble(dy)
+    var items = repeaterItems(bubbleRepeater)
+    var edge = edgeVisible(flick, items, dy)
     if (edge === bubbleCursor && bubbleCursorItem) {
       if (dy > 0 && edge === bubbles.length - 1) { leaveBubbles(); return }
       // Page so the selected row lands at the OPPOSITE edge — a screen with
@@ -603,28 +604,11 @@ FocusScope {
       var it = bubbleCursorItem, margin = Style.space(6)
       scrollConversation(dy < 0 ? it.y + it.height + margin - flick.height - flick.contentY
                                 : it.y - margin - flick.contentY)
-      edge = edgeVisibleBubble(dy)
+      edge = edgeVisible(flick, items, dy)
     }
     if (edge < 0) return
     bubbleCursor = edge
     revealBubbleCursor()
-  }
-  /** Index of the topmost (dy < 0) or bottommost (dy > 0) bubble that is
-   *  WHOLLY inside the viewport — a sliver of the neighbour above the
-   *  selection must not count, or the next PgUp steps one row instead of
-   *  paging. Falls back to a partly visible row (a picture taller than the
-   *  view); -1 when nothing is laid out yet. */
-  function edgeVisibleBubble(dy) {
-    var top = flick.contentY, bottom = top + flick.height
-    var n = bubbleRepeater.count, partial = -1
-    for (var k = 0; k < n; k++) {
-      var i = dy < 0 ? k : n - 1 - k
-      var it = bubbleRepeater.itemAt(i)
-      if (!it || it.y >= bottom || it.y + it.height <= top) continue
-      if (partial < 0) partial = i
-      if (dy < 0 ? it.y >= top - 1 : it.y + it.height <= bottom + 1) return i
-    }
-    return partial
   }
   function revealBubbleCursor() {
     var it = bubbleCursorItem   // set synchronously by the row's hasCursor binding
@@ -1758,6 +1742,11 @@ FocusScope {
     // and Down in an empty field hands it back (Omarchy's SearchableDropdown).
     if (dy < 0 && cursor <= 0) { startSearch(); return }
     cursor = Math.max(0, Math.min(threads.length - 1, cursor + dy))
+    cursorMoved()
+  }
+  /** Every way the thread cursor moves ends here: keep the row in view and,
+   *  in split view, arm the preview — arrows, paging and Home/End alike. */
+  function cursorMoved() {
     scrollCursorIntoView()
     if (splitView) peekTimer.restart()
   }
@@ -1781,6 +1770,79 @@ FocusScope {
   }
   function activateCursor() {
     if (listShowing && cursor >= 0) openThread(threads[cursor])
+  }
+  // ---- paging: PgUp/PgDn select the row at the edge of the viewport, and
+  // page a screen (one row of overlap) when the cursor is already there;
+  // Home/End take the first/last row. Omarchy's menu, clipboard and emoji
+  // lists bind the same four keys. Whichever of the three lists is showing
+  // — new-message hits, search hits, threads — is the one that moves.
+  function repeaterItems(rep) {
+    var out = []
+    for (var i = 0; i < rep.count; i++) out.push(rep.itemAt(i))
+    return out
+  }
+  /** Index into `items` of the topmost (dy < 0) or bottommost (dy > 0) row
+   *  wholly inside `fl`'s viewport; a partly visible row is the fallback
+   *  (a row taller than the view); -1 when nothing is laid out. Wholly, not
+   *  partly: a sliver of the neighbour above the cursor must not count, or
+   *  the next PgUp steps one row instead of paging. */
+  function edgeVisible(fl, items, dy) {
+    var top = fl.contentY, bottom = top + fl.height, partial = -1
+    for (var k = 0; k < items.length; k++) {
+      var i = dy < 0 ? k : items.length - 1 - k
+      var it = items[i]
+      if (!it) continue
+      var y = it.mapToItem(fl.contentItem, 0, 0).y
+      if (y >= bottom || y + it.height <= top) continue
+      if (partial < 0) partial = i
+      if (dy < 0 ? y >= top - 1 : y + it.height <= bottom + 1) return i
+    }
+    return partial
+  }
+  /** The row PgUp/PgDn lands on: the edge row, or — when the cursor already
+   *  sits there — the edge row after paging so the cursor row lands at the
+   *  opposite edge. null when the list has nothing laid out. */
+  function pageTo(fl, items, currentItem, dy) {
+    var edge = edgeVisible(fl, items, dy)
+    if (edge >= 0 && items[edge] === currentItem) {
+      var y = currentItem.mapToItem(fl.contentItem, 0, 0).y, m = Style.space(6)
+      var max = Math.max(0, fl.contentHeight - fl.height)
+      fl.contentY = Math.max(0, Math.min(max, dy < 0 ? y + currentItem.height + m - fl.height : y - m))
+      edge = edgeVisible(fl, items, dy)
+    }
+    return edge >= 0 ? items[edge] : null
+  }
+  function indexOfChat(chat) {
+    for (var i = 0; i < threads.length; i++) if (String(threads[i].chat) === String(chat)) return i
+    return -1
+  }
+  // Which of the three lists the paging keys drive, answered once per press:
+  // its rows, its length, how a landed row maps back to a cursor index
+  // (search/new rows carry their model index; a thread row is found by chat,
+  // since the thread list is two Repeaters), and how its cursor is set.
+  function activeList() {
+    if (newMode) return { items: repeaterItems(newRepeater), count: newResults.length,
+      indexOf: function(it) { return it.index }, set: function(i) { newCursor = i; scrollCursorIntoView() } }
+    if (searchShowing) return { items: repeaterItems(searchRepeater), count: searchResults.length,
+      indexOf: function(it) { return it.index }, set: function(i) { searchCursor = i; scrollCursorIntoView() } }
+    return { items: repeaterItems(pinnedRepeater).concat(repeaterItems(unpinnedRepeater)), count: threads.length,
+      indexOf: function(it) { return indexOfChat(it.modelData.chat) }, set: function(i) { cursor = i; cursorMoved() } }
+  }
+  function pageActive(dy) {
+    var l = activeList(), it = pageTo(threadFlick, l.items, cursorRow, dy)
+    if (it) l.set(l.indexOf(it))
+  }
+  function jumpActive(toEnd) {
+    var l = activeList()
+    if (l.count > 0) l.set(toEnd ? l.count - 1 : 0)
+  }
+  /** PgUp/PgDn/Home/End for whichever list is showing; true if consumed. */
+  function catchPagingKey(key) {
+    if (key === Qt.Key_PageUp) { pageActive(-1); return true }
+    if (key === Qt.Key_PageDown) { pageActive(1); return true }
+    if (key === Qt.Key_Home) { jumpActive(false); return true }
+    if (key === Qt.Key_End) { jumpActive(true); return true }
+    return false
   }
   function handleTextKey(text) {
     if (text === "/") { startSearch(); return true }
@@ -1818,7 +1880,17 @@ FocusScope {
     // Right = into the right pane: focus the compose field of the thread on
     // screen (which commits a peek). Left in an EMPTY compose field comes back.
     if (key === Qt.Key_Right && inThread) { composeField.forceActiveFocus(); return true }
-    return false
+    return listShowing && catchPagingKey(key)
+  }
+  /** List-mode focus holder. The panel's PanelKeyCatcher takes the arrows,
+   *  Enter and letters BEFORE the focused item and lets the rest fall
+   *  through; parking focus here (rather than on the catcher itself) is what
+   *  lets PgUp/PgDn/Home/End reach the list. The window's navCatcher does
+   *  the same job with its own handler. */
+  readonly property alias navigationKeys: navKeys
+  Item {
+    id: navKeys
+    Keys.onPressed: function(event) { if (root.catchNavKey(event.key)) event.accepted = true }
   }
   function catchEscape() {
     if (newField.activeFocus || newMode) { exitNew(); return true }
@@ -2043,6 +2115,7 @@ FocusScope {
                   event.accepted = true
                 }
                 else if (event.key === Qt.Key_Up) { root.moveNewCursor(-1); event.accepted = true }
+                else if (root.catchPagingKey(event.key)) event.accepted = true
               }
               onVisibleChanged: if (visible) {
                 forceActiveFocus()
@@ -2061,6 +2134,7 @@ FocusScope {
             }
 
             Repeater {
+              id: newRepeater
               model: root.online && root.listShowing && root.newMode ? root.newResults : []
               delegate: Rectangle {
                 id: contactHit
@@ -2125,6 +2199,7 @@ FocusScope {
                   event.accepted = true
                 }
                 else if (event.key === Qt.Key_Up) { root.moveSearchCursor(-1); event.accepted = true }
+                else if (root.catchPagingKey(event.key)) event.accepted = true
               }
             }
 
@@ -2143,6 +2218,7 @@ FocusScope {
               Layout.bottomMargin: Style.space(8)
 
               Repeater {
+                id: pinnedRepeater
                 model: pinnedGrid.visible ? root.pinnedThreads : []
                 delegate: Rectangle {
                   id: pinnedTile
@@ -2279,6 +2355,7 @@ FocusScope {
             }
 
             Repeater {
+              id: searchRepeater
               model: root.online && root.listShowing && root.searchShowing ? root.searchResults : []
               delegate: Rectangle {
                 id: searchHit
@@ -2354,6 +2431,7 @@ FocusScope {
             }
 
             Repeater {
+              id: unpinnedRepeater
               model: root.online && root.listShowing && !root.searchShowing && !root.newMode ? root.unpinnedThreads : []
               delegate: Rectangle {
                 id: threadRow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@
   where an address can change, the key stays unpinned (`docs/SECURITY.md` shows
   the manual pin). A re-run replaces the key's line, so a changed address is one
   re-run away.
+
+- **The lists page from the keyboard.** `PgUp`/`PgDn` select the row at the
+  edge of the view and then move a screen per press, `Home`/`End` take the
+  first and last row — in the thread list, the search hits and the
+  new-message picker, in the panel and the window. Omarchy's own lists bind
+  the same four keys. In the panel, list-mode focus now sits inside the view
+  so the keys the PanelKeyCatcher does not claim reach it.
 - **The window's sidebar previews on the cursor.** Rest the arrow keys on a row
   for a beat and the right pane shows that thread, the way Messages' sidebar
   does. Focus stays in the list and the thread is *not* marked read; Enter, a

--- a/Panel.qml
+++ b/Panel.qml
@@ -61,7 +61,9 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    focusTarget: view.inThread ? view.composeEditor : keyCatcher
+    // List mode parks focus INSIDE the view: PanelKeyCatcher still takes its
+    // keys first (Keys.BeforeItem), and PgUp/PgDn/Home/End fall through to it.
+    focusTarget: view.inThread ? view.composeEditor : view.navigationKeys
     // 20% narrower than it was (Fred, 2.3.1). Messages' own sidebar is a
     // narrow column; 440 read like a file browser.
     contentWidth: panel.fittedContentWidth(Style.space(352))
@@ -96,7 +98,7 @@ Panel {
         foreground: root.bar ? root.bar.foreground : Color.foreground
         urgent: root.bar ? root.bar.urgent : Color.urgent
         themeFont: root.bar ? root.bar.fontFamily : Style.font.family
-        onNavigationFocusRequested: keyCatcher.forceActiveFocus()
+        onNavigationFocusRequested: view.navigationKeys.forceActiveFocus()
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ helper; the optional availability check needs Automation → Contacts on the Mac
 | list | `Enter` · `1`–`9` | open thread (the first nine rows show the digit; Super+M jumps from an empty compose) |
 | list (window) | rest on a row | the right pane shows that thread, like Messages' sidebar — without marking it read; `Enter`, a click or typing commits it |
 | window | `→` · `←` | into the compose field · back to the sidebar (from the start of the text, or an empty field) |
+| list | `PgUp` / `PgDn` · `Home` / `End` | select the row at the edge of the view, then a screen further each press · first / last row — in the thread list, the search hits and the new-message picker alike |
 | list | `r` | refresh |
 | list | `a` · *mark all read* link | clear every badge and dot — and tell the Mac, so your iPhone catches up too |
 | list | `/` | search conversations by name as you type, then messages; Enter opens the highlight, Esc backs out |

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -289,7 +289,8 @@ describe("QML safety invariants", () => {
       const fn = qmlFunction(name);
       expect(fn).toContain("Math.max(0, Math.min(");
       expect(fn).not.toContain("%");
-      expect(fn).toContain("scrollCursorIntoView()");
+      // the thread cursor goes through cursorMoved() (scroll + split-view preview)
+      expect(fn).toMatch(/scrollCursorIntoView\(\)|cursorMoved\(\)/);
     }
     const scroll = qmlFunction("scrollCursorIntoView");
     expect(scroll).toContain("row.mapToItem(threadFlick.contentItem, 0, 0)");
@@ -362,7 +363,8 @@ describe("QML safety invariants", () => {
     const page = qmlFunction("pageBubbles");
     expect(page.indexOf("if (edge === bubbleCursor && bubbleCursorItem)")).toBeLessThan(page.indexOf("scrollConversation(dy < 0 ?"));
     // only a WHOLLY visible row counts as the edge, else a sliver of the row above turns paging into single steps
-    expect(qmlFunction("edgeVisibleBubble")).toContain("it.y >= top - 1 : it.y + it.height <= bottom + 1");
+    expect(qmlFunction("edgeVisible")).toContain("y >= top - 1 : y + it.height <= bottom + 1");   // shared with the lists
+    expect(page).toContain("edgeVisible(flick, items, dy)");
     expect(page).toContain("leaveBubbles()");
   });
 
@@ -431,11 +433,29 @@ describe("QML safety invariants", () => {
     expect(qmlFunction("peekCursor")).toContain("!cursorShown");
     // The sidebar's spacing must not follow inThread in split view (8px shift).
     expect(panel).toContain("spacing: root.splitView ? Style.space(10) : (root.inThread ? Style.space(2) : Style.space(6))");
-    expect(qmlFunction("moveCursor")).toContain("if (splitView) peekTimer.restart()");
     // one place empties the pane; back() and resetToList() go through it
     expect(qmlFunction("clearThread")).toContain("peekTimer.stop()");
     expect(qmlFunction("clearThread")).toContain("peeking = false");
     for (const name of ["back", "resetToList"]) expect(qmlFunction(name)).toContain("clearThread()");
+    expect(qmlFunction("moveCursor")).toContain("cursorMoved()");
+  });
+
+  test("PgUp/PgDn/Home/End page whichever list is showing, in both hosts", () => {
+    // One edge finder and one pager for all three lists; the panel parks
+    // list-mode focus inside the view so the keys its catcher ignores arrive.
+    expect(qmlFunction("edgeVisible")).toContain("y >= top - 1 : y + it.height <= bottom + 1");
+    const list = qmlFunction("activeList");
+    for (const rep of ["newRepeater", "searchRepeater", "pinnedRepeater", "unpinnedRepeater"]) expect(list).toContain(rep);
+    expect(qmlFunction("catchNavKey")).toContain("return listShowing && catchPagingKey(key)");
+    // paging and Home/End arm the split-view preview exactly like the arrows do
+    expect(qmlFunction("cursorMoved")).toContain("if (splitView) peekTimer.restart()");
+    expect(list).toContain("set: function(i) { cursor = i; cursorMoved() }");
+    expect(list).toContain("indexOf: function(it) { return indexOfChat(it.modelData.chat) }");
+    expect(panel).not.toContain("function edgeVisibleBubble");   // one edge finder for bubbles and lists
+    expect(panel.split("else if (root.catchPagingKey(event.key)) event.accepted = true").length - 1).toBe(2);
+    const panelQml = readFileSync(new URL("./Panel.qml", import.meta.url), "utf8");
+    expect(panelQml).toContain("focusTarget: view.inThread ? view.composeEditor : view.navigationKeys");
+    expect(panelQml).toContain("onNavigationFocusRequested: view.navigationKeys.forceActiveFocus()");
   });
 
   test("an old toast can still reopen its conversation (omarchy-exec-argv)", () => {


### PR DESCRIPTION
## What

The thread list, the search hits and the new-message picker page from the keyboard: `PgUp`/`PgDn` select the row at the edge of the view and then move a screen per press, `Home`/`End` take the first and last row. In the panel and in the window. The four keys Omarchy's own lists (menu, clipboard, emoji) already bind.

## Why

After #37 and #39 a conversation reads from the keyboard, but the lists still had the arrows and nothing else: 300 conversations is 300 presses. The bubbles got a pager in #39; the lists should page the same way, and with the same keys the rest of the desktop uses. In the panel, the keys did not even have a place to land: `PanelKeyCatcher` takes its keys before the focused item and lets the rest fall through, but focus sat on the catcher itself, so nothing fell anywhere.

## How

- **`BlipView.qml`** — one edge finder and one pager serve all three lists. `edgeVisible(fl, items, dy)` returns the topmost or bottommost row *wholly* inside the viewport (a sliver of the neighbour above the cursor must not count, or the next `PgUp` steps one row). `pageTo()` selects the edge row, or, when the cursor already sits there, the edge row after paging, so the cursor row lands at the opposite edge. The bubbles' pager from #39 had its own copy of the edge finder; it now uses this one, so there is one. `activeList()` answers, once per press, which list is showing: its rows, its length, how a landed row maps back to a cursor (model index for search and new; chat lookup for threads, whose rows live in two Repeaters) and how its cursor is set. `catchPagingKey(key)` is called from `catchNavKey` (list focus) and from the search and new fields' own key handlers; the clipboard's precedent settles `Home`/`End` there: the list, not the caret. `catchNavKey` still returns early on `editorActive`, which covers the contact review from #24, so the keys never page the list behind it.
- **`Panel.qml`** — list-mode focus now parks on a small `Item` inside the view (`navigationKeys`) instead of on the catcher, so the keys the catcher does not claim reach the list. The catcher's own keys are unchanged.
- **`README.md`** one row, **`CHANGELOG.md`** under Unreleased, **`ui.test.ts`** one invariant: the four keys are handled in all three lists and the bubbles' pager goes through the shared edge finder.

Rebased on today's main after #45, #46, #48, #49 and #24; the only overlap was the CHANGELOG.

## How it was verified

- [x] `bun test` is green (CI will check) — 434 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → verified live on Omarchy: `PgUp`/`PgDn`/`Home`/`End` in the thread list, in the search hits and in the new-message picker, in the panel and in the window; the cursor row lands at the opposite edge on the second press, and `Home`/`End` in the search field move the list, not the caret
- [ ] Touches an invariant in `CLAUDE.md` → no
