### PR TITLE
A tapback on a picture-only message gets its pill on the picture

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -694,6 +694,36 @@ FocusScope {
     for (var i = 0; i < (list || []).length; i++) s += list[i].emoji
     return s
   }
+  // The tapback pill, overlapping the top corner opposite the tail. One
+  // definition for the text bubble and for the attachments: a picture-only
+  // message hides its text bubble, so the pill sits on the picture (or the
+  // file chip) itself, or the reaction is never seen.
+  component TapbackPill: Rectangle {
+    id: pill
+    property bool mine: false
+    property var tapbacks: []
+    visible: (tapbacks || []).length > 0
+    width: Math.ceil(pillText.implicitWidth) + Style.space(12)
+    height: Math.ceil(pillText.implicitHeight) + Style.space(8)
+    radius: height / 2
+    color: mine ? Qt.darker(root.mineFill, 2.2) : root.mineFill
+    border.color: Qt.rgba(0, 0, 0, 0.5)
+    border.width: 2
+    z: 2
+    anchors.top: parent.top
+    anchors.topMargin: -Style.space(12)
+    anchors.right: mine ? undefined : parent.right
+    anchors.rightMargin: mine ? 0 : -Style.space(6)
+    anchors.left: mine ? parent.left : undefined
+    anchors.leftMargin: mine ? -Style.space(6) : 0
+    Text {
+      id: pillText
+      anchors.centerIn: parent
+      text: root.tapbackRow(pill.tapbacks)
+      textFormat: Text.PlainText
+      font.pixelSize: root.fontCaption
+    }
+  }
 
   // ---------------------------------------------------- attachment fetching
 
@@ -2781,6 +2811,9 @@ FocusScope {
                         flick.contentY = Math.max(0, flick.contentY + d)
                     }
                     readonly property string attId: String(modelData.id || "")
+                    // the pill lands here when the message has no text bubble to carry it
+                    readonly property bool pillHere: index === 0 && String(bubbleRow.modelData.text || "") === ""
+                                                     && (bubbleRow.modelData.tapbacks || []).length > 0
                     // undefined = not fetched, "" = failed, else file:// url
                     readonly property var fileUrl: root.attFiles[chipRow.attId]
                     readonly property bool failed: chipRow.fileUrl === ""
@@ -2789,13 +2822,15 @@ FocusScope {
                       root.isImageMime(chipRow.modelData.mime) &&
                       chipRow.fileUrl !== undefined && chipRow.fileUrl !== ""
                     Layout.fillWidth: true
-                    Layout.topMargin: index === 0 && bubbleRow.modelData.groupStart ? Style.space(6) : 0
+                    Layout.topMargin: (index === 0 && bubbleRow.modelData.groupStart ? Style.space(6) : 0)
+                                      + (pillHere ? Style.space(12) : 0)
                     spacing: 0
                     Item { Layout.fillWidth: true; visible: bubbleRow.mine }
 
                     // fetched image renders inline, like Messages; click = full view
                     Image {
                       id: attImage
+                      TapbackPill { visible: chipRow.pillHere; mine: bubbleRow.mine; tapbacks: bubbleRow.modelData.tapbacks }
                       visible: chipRow.showImage
                       readonly property real maxW: Math.round(content.width * 0.6)
                       // Retina PNGs carry their density in the header (read by
@@ -2841,6 +2876,7 @@ FocusScope {
                     }
 
                     Rectangle {
+                      TapbackPill { visible: chipRow.pillHere; mine: bubbleRow.mine; tapbacks: bubbleRow.modelData.tapbacks }
                       visible: !chipRow.showImage
                       Layout.preferredWidth: Math.ceil(chipText.implicitWidth) + Style.space(18)
                       Layout.preferredHeight: Math.ceil(chipText.implicitHeight) + Style.space(12)
@@ -3078,29 +3114,7 @@ FocusScope {
                       }
                     }
 
-                    // tapback pill overlapping the corner opposite the tail
-                    Rectangle {
-                      visible: (modelData.tapbacks || []).length > 0
-                      width: Math.ceil(tapbackText.implicitWidth) + Style.space(12)
-                      height: Math.ceil(tapbackText.implicitHeight) + Style.space(8)
-                      radius: height / 2
-                      color: bubbleRow.mine ? Qt.darker(root.mineFill, 2.2) : root.mineFill
-                      border.color: Qt.rgba(0, 0, 0, 0.5)
-                      border.width: 2
-                      anchors.top: parent.top
-                      anchors.topMargin: -Style.space(12)
-                      anchors.right: bubbleRow.mine ? undefined : parent.right
-                      anchors.rightMargin: bubbleRow.mine ? 0 : -Style.space(6)
-                      anchors.left: bubbleRow.mine ? parent.left : undefined
-                      anchors.leftMargin: bubbleRow.mine ? -Style.space(6) : 0
-                      Text {
-                        id: tapbackText
-                        anchors.centerIn: parent
-                        text: root.tapbackRow(modelData.tapbacks)
-                        textFormat: Text.PlainText
-                        font.pixelSize: root.fontCaption
-                      }
-                    }
+                    TapbackPill { mine: bubbleRow.mine; tapbacks: modelData.tapbacks }
                   }
 
                   Item { Layout.fillWidth: true; visible: !bubbleRow.mine }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
   start of the text steps back. Leaving the list for the search or new-message
   field ends the preview, and the sidebar holds still while the pane fills or
   empties. The bar panel is unchanged.
+- **Reactions on pictures show.** A message that is only a picture (or a file)
+  has no text bubble, and that is where the tapback pill lived, so a reaction
+  on a picture was never seen. The pill now sits on the picture or chip itself.
 
 ## 2.4.0 — 2026-09-08 — read it from the keyboard, send without the wait
 

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -670,3 +670,12 @@ test("the share sheet steps through a message's links", () => {
   expect(sheet).toContain('visible: root.shareQr !== "" || qrProc.running');
   expect(qmlFunction("showShareUrl")).not.toContain('shareQr = ""');
 });
+
+// A picture-only message has no text bubble, so its tapback pill must live on
+// the picture (or file chip) itself, through the one shared TapbackPill.
+test("tapbacks on picture-only messages get a pill on the picture", () => {
+  expect(panel).toContain("component TapbackPill: Rectangle {");
+  expect(panel.split("TapbackPill {").length - 1).toBe(3);   // text bubble, picture, file chip
+  expect(panel).toContain('readonly property bool pillHere: index === 0 && String(bubbleRow.modelData.text || "") === ""');
+  expect(panel).toContain("+ (pillHere ? Style.space(12) : 0)");
+});


### PR DESCRIPTION
## What

A tapback on a picture-only message (or a file) now shows: the pill sits on the picture or the file chip itself. Text messages look exactly as before.

## Why

The pill lived inside the text bubble, and a message that is only a picture has no text bubble, so a reaction on a picture was never seen in Blip while Messages showed it. Pictures are where a lot of reactions land.

## How

- **`BlipView.qml`** — one inline `component TapbackPill` replaces the pill Rectangle that was written out inside the text bubble; the text bubble, the picture and the file chip each place one. On the attachment row, `pillHere` is true for the first attachment of a text-less message that has tapbacks, and the row leaves the same room above it (`Style.space(12)`) the text bubble's row does, so the pill does not overlap the row above. Net: +50/-24, most of it the move.
- **`ui.test.ts`** — one invariant: the component exists, is placed three times (text bubble, picture, file chip), and the attachment row makes room for it. CHANGELOG under Unreleased.

Rebased on today's main; the only overlap was the CHANGELOG.

## How it was verified

- [x] `bun test` is green (CI will check) — 434 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → verified live on Omarchy with a reaction on a received picture: the pill shows on the picture, on the sender's side; a text message with a reaction is unchanged, and `qmlformat` parses the file
- [ ] Touches an invariant in `CLAUDE.md` → no
