### PR TITLE
A reaction on a note to yourself survives the self-echo fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
   start of the text steps back. Leaving the list for the search or new-message
   field ends the preview, and the sidebar holds still while the pane fills or
   empties. The bar panel is unchanged.
+- **A reaction on a note to yourself shows.** The self-thread stores each
+  message twice, and Messages attaches a tapback to whichever row the reacting
+  device considers the message; folding the two rows into one dropped the
+  other row's tapbacks. The kept row now carries both.
 
 ## 2.4.0 — 2026-09-08 — read it from the keyboard, send without the wait
 

--- a/collector.test.ts
+++ b/collector.test.ts
@@ -17,6 +17,7 @@ import {
   fetchGroups,
   groupName,
   dedupeSelfEcho,
+  mergeTapbacks,
   isGroupChat,
   displayName,
   messagePreview,
@@ -204,6 +205,36 @@ describe("self-echo in the thread list", () => {
     const threads = buildThreads(msgs, "2026-08-30 10:00:00");
     expect(threads[0]!.unread).toBe(0);
     expect(threads[0]!.last_from_me).toBe(true);
+  });
+
+  test("a tapback on either twin of a self-thread message survives the dedupe", () => {
+    // Messages attaches the tapback to whichever row the reacting device
+    // considers the message; the dedupe used to keep one row and lose the
+    // other's tapbacks, so a reaction on your own note never showed.
+    const love = [{ emoji: "❤️", from_me: true, by: null }];
+    const base = { chat: "SELF", handle: "SELF", ts: "2026-09-05 17:00:00", text: "note" };
+    for (const order of [[true, false], [false, true]]) {
+      const msgs = dedupeSelfEcho([
+        msg({ ...base, from_me: order[0]!, tapbacks: order[0] ? love : null }),
+        msg({ ...base, from_me: order[1]!, tapbacks: order[1] ? love : null }),
+      ], ["SELF"]);
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]!.from_me).toBe(true);
+      expect(msgs[0]!.tapbacks).toEqual(love);
+    }
+    // the empty-outbound shape (an attachment) hands its tapback to the echo it promotes
+    const empty = dedupeSelfEcho([
+      msg({ chat: "SELF", handle: "SELF", ts: "2026-09-05 17:01:00", from_me: true, text: "", tapbacks: love }),
+      msg({ chat: "SELF", handle: "SELF", ts: "2026-09-05 17:01:00", from_me: false, text: "" }),
+    ], ["SELF"]);
+    expect(empty).toHaveLength(1);
+    expect(empty[0]!.tapbacks).toEqual(love);
+    // the same tapback on both twins is one tapback
+    const both = dedupeSelfEcho([
+      msg({ ...base, ts: "2026-09-05 17:02:00", from_me: true, tapbacks: love }),
+      msg({ ...base, ts: "2026-09-05 17:02:00", from_me: false, tapbacks: love }),
+    ], ["SELF"]);
+    expect(both[0]!.tapbacks).toEqual(love);
   });
 
   test("the same text in two different chats at one ts is two messages", () => {

--- a/collector.ts
+++ b/collector.ts
@@ -410,6 +410,19 @@ export function detectSelfChats(msgs: ImsgMessage[], minTwins = 1): string[] {
   return [...chats].filter(Boolean);
 }
 
+/** The union of two tapback lists (one entry per emoji + sender); undefined when both are empty. */
+export function mergeTapbacks(a?: Tapback[] | null, b?: Tapback[] | null): Tapback[] | undefined {
+  const all = [...(a ?? []), ...(b ?? [])];
+  if (all.length === 0) return undefined;
+  const seen = new Set<string>();
+  return all.filter((t) => {
+    const k = `${t.emoji}\u0000${t.from_me}\u0000${t.by ?? ""}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+}
+
 export function dedupeSelfEcho(msgs: ImsgMessage[], knownSelfChats: string[] = []): ImsgMessage[] {
   const contextKey = (m: ImsgMessage) => `${chatKey(m)}\u0000${m.handle || ""}\u0000${m.ts}`;
   const contentKey = (m: ImsgMessage) => `${contextKey(m)}\u0000${m.text}`;
@@ -418,6 +431,17 @@ export function dedupeSelfEcho(msgs: ImsgMessage[], knownSelfChats: string[] = [
   const emptySent = new Set(
     msgs.filter((m) => selfChats.has(chatKey(m)) && m.from_me && m.text === "").map(contextKey),
   );
+  // Messages attaches a tapback to ONE of the two rows of a self-thread
+  // message — whichever the reacting device considers the message. Whatever
+  // is dropped below hands its tapbacks to the row that stays, so a reaction
+  // on your own note is seen no matter which twin carried it.
+  const emptySentTapbacks = new Map<string, Tapback[] | undefined>();
+  for (const m of msgs) {
+    if (selfChats.has(chatKey(m)) && m.from_me && m.text === "") {
+      const k = contextKey(m);
+      emptySentTapbacks.set(k, mergeTapbacks(emptySentTapbacks.get(k), m.tapbacks));
+    }
+  }
   const retractedSent = new Set(
     msgs.filter((m) => selfChats.has(chatKey(m)) && m.from_me && m.retracted === true).map(contextKey),
   );
@@ -444,14 +468,15 @@ export function dedupeSelfEcho(msgs: ImsgMessage[], knownSelfChats: string[] = [
       const key = contentKey(m);
       const idx = selfText.get(key);
       if (idx !== undefined && out[idx]!.from_me !== m.from_me) {
-        if (m.from_me) out[idx] = { ...out[idx]!, from_me: true };
+        const kept = out[idx]!;
+        out[idx] = { ...kept, from_me: kept.from_me || m.from_me, tapbacks: mergeTapbacks(kept.tapbacks, m.tapbacks) };
         continue;
       }
       selfText.set(key, out.length);
     }
 
     if (emptySent.has(context) && !m.from_me) {
-      out.push({ ...m, from_me: true });
+      out.push({ ...m, from_me: true, tapbacks: mergeTapbacks(m.tapbacks, emptySentTapbacks.get(context)) });
       continue;
     }
     out.push(m);


### PR DESCRIPTION
## What

A reaction on a note to yourself shows in Blip. Before, it showed in Messages and never in Blip.

## Why

The self-thread stores each message twice, the send and its echo, and `dedupeSelfEcho()` folds the two rows into one. Messages attaches a tapback to whichever row the reacting device considers the message, and the fold kept only the survivor's tapbacks, so a reaction that landed on the other twin was dropped with it.

## How

- **`collector.ts`** — `mergeTapbacks(a, b)`: the union of two tapback lists, one entry per emoji and sender, `undefined` when both are empty. `dedupeSelfEcho()` uses it in both places a row is dropped: the text twins (the kept row takes the dropped row's tapbacks) and the empty-outbound shape, where the send's tapbacks are collected per context up front and handed to the echo it promotes. Nothing else in the fold changes.
- **`collector.test.ts`** — one test with three cases: the tapback on either twin survives (both orders), the empty-outbound shape hands its tapback to the promoted echo, and the same tapback on both twins is one tapback. CHANGELOG under Unreleased.

Rebased on today's main; the only overlap was the CHANGELOG.

## How it was verified

- [x] `bun test` is green (CI will check) — 434 pass
- [x] Any send/receive behavior was exercised against **my own number only** — reacted to a note in my own self-thread from the phone; Blip shows the pill on the next poll
- [ ] UI change → no QML in this change
- [ ] Touches an invariant in `CLAUDE.md` → no
