### PR TITLE
Scan more than 200 contacts using bounded batches

### DIFF
--- a/ContactReview.qml
+++ b/ContactReview.qml
@@ -21,6 +21,7 @@ FocusScope {
   property string error: ""
   property string notice: ""
   property bool busy: false
+  property var scanConversations: []
   visible: opened
   readonly property string helper: decodeURIComponent(Qt.resolvedUrl("contact-review.ts").toString().replace(/^file:\/\//, ""))
   signal closed()
@@ -42,11 +43,19 @@ FocusScope {
     request("review", { conversation: data })
     forceActiveFocus()
   }
-  function scan() {
+  function scan(page) {
     if (busy) return
     if (threads.length > 1000) { error = "Too many conversations to scan at once"; return }
     overview = null
-    request("audit", { conversations: threads.map(function(thread) { return { chat: textField(thread.chat, 320) } }) })
+    if (page === undefined) {
+      page = 0
+      scanConversations = threads.map(function(thread) {
+        return {chat: textField(thread.chat, 320), participants: (thread.participants || []).slice(0, 64).map(function(p) {
+          return {handle: textField(typeof p === "string" ? p : p.handle, 320)}
+        })}
+      })
+    }
+    request("audit", {conversations: scanConversations, page: page})
   }
   function back() {
     if (busy) return
@@ -57,7 +66,7 @@ FocusScope {
     if (busy) return
     var encoded = JSON.stringify(payload)
     error = ""; notice = ""
-    if (encoded.length > 49152) { error = "Too many contacts in this request"; return }
+    if (encoded.length > (operation === "audit" ? 4194304 : 49152)) { error = "Too many contacts in this request"; return }
     worker.received = false
     worker.command = ["bun", helper, operation]
     busy = true
@@ -83,6 +92,8 @@ FocusScope {
       if (["people", "cards", "scan", "opened"].indexOf(result.view) < 0
           || !validText(result.title, 160) || !validText(result.detail, 480)
           || !Array.isArray(result.rows) || result.rows.length > 200) throw "schema"
+      if (result.view === "scan" && (!Number.isInteger(result.page) || !Number.isInteger(result.pageCount)
+          || result.page < 0 || result.pageCount < 1 || result.pageCount > 250 || result.page >= result.pageCount)) throw "page"
       for (var i = 0; i < result.rows.length; i++) {
         var row = result.rows[i]
         if (!row || !validText(row.name, 320) || !validText(row.detail, 480)
@@ -195,6 +206,25 @@ FocusScope {
             }
           }
         }
+      }
+    }
+    RowLayout {
+      Layout.fillWidth: true
+      visible: root.model !== null && root.model.view === "scan" && root.model.pageCount > 1
+      ContactButton {
+        text: "Previous"; enabled: !root.busy && root.model && root.model.page > 0
+        foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+        onClicked: root.scan(root.model.page - 1)
+      }
+      Text {
+        Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter
+        text: root.model ? (root.model.page + 1) + " / " + root.model.pageCount : ""
+        color: root.foreground; font.family: root.fontFamily; font.pixelSize: root.fontSize; textFormat: Text.PlainText
+      }
+      ContactButton {
+        text: "Next"; enabled: !root.busy && root.model && root.model.page + 1 < root.model.pageCount
+        foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+        onClicked: root.scan(root.model.page + 1)
       }
     }
     ContactButton {

--- a/contact-review.test.ts
+++ b/contact-review.test.ts
@@ -306,3 +306,68 @@ describe("cache and streaming boundary", () => {
     } finally { child.kill(); try { child.stdin.end(); } catch { /* closed */ } }
   });
 });
+
+describe('batched contact scans', () => {
+  const handles = Array.from({length: 451}, (_,i) => `+15551${String(i).padStart(6,'0')}`);
+  const fingerprint = 'sha256:' + 'f'.repeat(64);
+  const result = (body: unknown) => ({status:0,stdout:JSON.stringify(body),stderr:''});
+  test('scans beyond 200 and reuses the complete cache on one fingerprint check', () => {
+    const batches: number[] = [];
+    const runner = ((_cmd: string, args: string[], options: any) => {
+      expect(args).toEqual(['--json','resolve']);
+      expect(Buffer.byteLength(options.input)).toBeLessThanOrEqual(MAX_IDENTITY_REQUEST_BYTES);
+      const request = JSON.parse(options.input);
+      if (request.operation === 'fingerprint') return result({ok:true,fingerprint});
+      batches.push(request.handles.length);
+      return result({ok:true,fingerprint,handleCount:request.handles.length,noMatchCount:request.handles.length,singleCards:[],duplicates:[],conflicts:[]});
+    }) as any;
+    expect(scanHandles(handles.map(chat => ({chat})))).toEqual(handles);
+    expect(auditContactsOnMac(handles,runner,cachePath).audit.handleCount).toBe(451);
+    expect(batches).toEqual([200,200,51]);
+    expect(auditContactsOnMac(handles,runner,cachePath).cached).toBe(true);
+    expect(batches).toHaveLength(3);
+  });
+  test('splits an oversized response instead of failing the whole scan', () => {
+    const runner = ((_cmd: string,_args: string[],options:any) => {
+      const hs = JSON.parse(options.input).handles;
+      if (hs.length > 25) return {status:1,stdout:'',error:{code:'ENOBUFS'}};
+      return result({ok:true,handleCount:hs.length,noMatchCount:hs.length,singleCards:[],duplicates:[],conflicts:[]});
+    }) as any;
+    expect(auditContactsOnMac(handles,runner,cachePath).audit.handleCount).toBe(451);
+  });
+  test('does not cache partial results or combine different Contacts snapshots', () => {
+    let calls=0;
+    const runner = ((_cmd: string,_args: string[],options:any) => {
+      const hs=JSON.parse(options.input).handles;
+      return result({ok:true,fingerprint:'sha256:'+(++calls===1?'a':'b').repeat(64),handleCount:hs.length,noMatchCount:hs.length,singleCards:[],duplicates:[],conflicts:[]});
+    }) as any;
+    expect(()=>auditContactsOnMac(handles,runner,cachePath)).toThrow('changed during');
+    expect(readAuditCache(cachePath)).toBeNull();
+  });
+  test('pages every finding without silently dropping later contacts', () => {
+    const duplicate = {token,name:'Example Person',recordCount:2,sourceCount:1,hasPhoto:false,cards:[]};
+    const audit = {handleCount:451,noMatchCount:0,singleCards:[],conflicts:[],duplicates:handles.map(handle=>({handle,candidates:[duplicate]}))};
+    const found = [];
+    for(let page=0;page<12;page++) {
+      const view=auditView(audit,page);
+      expect(view.rows.length).toBeLessThanOrEqual(40);
+      expect(Buffer.byteLength(JSON.stringify(view))).toBeLessThan(MAX_BRIDGE_OUTPUT_BYTES);
+      expect(view.pageCount).toBe(12);
+      found.push(...view.rows.map(r=>r.handle));
+    }
+    expect(found).toEqual(handles);
+    expect(()=>auditView(audit,-1)).toThrow();
+    expect(runReview('audit',{conversations:[]})).toMatchObject({page:0,pageCount:1});
+  });
+});
+
+test('splits the Mac size-contract error and long handle payloads',()=>{
+  const handles=Array.from({length:201},(_,i)=>'p'+i+'x'.repeat(220)+'@example.com');
+  const runner=((_cmd:string,_args:string[],options:any)=>{
+    expect(Buffer.byteLength(options.input)).toBeLessThanOrEqual(MAX_IDENTITY_REQUEST_BYTES);
+    const hs=JSON.parse(options.input).handles;
+    if(hs.length>10) return {status:1,stdout:JSON.stringify({ok:false,error:'identity response exceeded its size contract'})};
+    return {status:0,stdout:JSON.stringify({ok:true,handleCount:hs.length,noMatchCount:hs.length,singleCards:[],duplicates:[],conflicts:[]})};
+  }) as any;
+  expect(auditContactsOnMac(handles,runner,cachePath).audit.handleCount).toBe(201);
+});

--- a/contact-review.ts
+++ b/contact-review.ts
@@ -14,7 +14,10 @@ export const MAX_BRIDGE_OUTPUT_BYTES = 48 * 1024;
 export const MAX_IDENTITY_CANDIDATES = 8;
 export const MAX_IDENTITY_CARDS = 64;
 export const MAX_REPAIR_FIELDS = 8;
-export const MAX_CONTACT_AUDIT_HANDLES = 200;
+export const MAX_CONTACT_AUDIT_HANDLES = 200; // per Mac request
+export const MAX_CONTACT_SCAN_HANDLES = 10000;
+export const MAX_SCAN_REQUEST_BYTES = 4 * 1024 * 1024;
+export const SCAN_PAGE_SIZE = 40;
 export const MAX_HANDLE_CHARS = 320;
 export const MAX_NAME_CHARS = 160;
 export interface IdentityCandidate {
@@ -189,24 +192,24 @@ export function normalizeBridgeCandidates(value: unknown, requestedHandle: strin
   });
 }
 
-export function normalizeContactAudit(value: unknown, expectedHandleCount: number): ContactAudit {
+export function normalizeContactAudit(value: unknown, expectedHandleCount: number, maximum = MAX_CONTACT_AUDIT_HANDLES): ContactAudit {
   if (value === null || typeof value !== "object" || Array.isArray(value))
     throw new Error("Contacts returned an invalid audit");
   if (!Number.isInteger(expectedHandleCount) || expectedHandleCount < 1
-      || expectedHandleCount > MAX_CONTACT_AUDIT_HANDLES)
+      || expectedHandleCount > maximum)
     throw new Error("contact audit handle count is invalid");
   const audit = value as Record<string, unknown>;
   const handleCount = finiteInteger(
-    audit.handleCount, "audit handle count", 1, MAX_CONTACT_AUDIT_HANDLES,
+    audit.handleCount, "audit handle count", 1, maximum,
   );
   if (handleCount !== expectedHandleCount)
     throw new Error("Contacts returned an incomplete audit");
   const noMatchCount = finiteInteger(
-    audit.noMatchCount, "audit no-match count", 0, MAX_CONTACT_AUDIT_HANDLES,
+    audit.noMatchCount, "audit no-match count", 0, maximum,
   );
   const seen = new Set<string>();
   function entries(raw: unknown, kind: "single" | "duplicate" | "conflict"): ContactAuditEntry[] {
-    if (!Array.isArray(raw) || raw.length > MAX_CONTACT_AUDIT_HANDLES)
+    if (!Array.isArray(raw) || raw.length > maximum)
       throw new Error("Contacts returned an invalid audit category");
     return raw.map((item) => {
       if (item === null || typeof item !== "object" || Array.isArray(item))
@@ -236,7 +239,7 @@ export function normalizeContactAudit(value: unknown, expectedHandleCount: numbe
   return { handleCount, noMatchCount, singleCards, duplicates, conflicts };
 }
 
-export const MAX_AUDIT_CACHE_BYTES = 512 * 1024;
+export const MAX_AUDIT_CACHE_BYTES = 16 * 1024 * 1024;
 const FINGERPRINT_PATTERN = /^sha256:[0-9a-f]{64}$/;
 
 export function auditCachePath(): string {
@@ -311,7 +314,7 @@ export function readAuditCache(path = auditCachePath()): AuditCacheEntry | null 
     const handleCount = Number(rawAudit?.handleCount);
     if (!Number.isInteger(handleCount)) return null;
     let audit: ContactAudit;
-    try { audit = normalizeContactAudit(entry.audit, handleCount); }
+    try { audit = normalizeContactAudit(entry.audit, handleCount, MAX_CONTACT_SCAN_HANDLES); }
     catch { return null; }
     return { storeFingerprint: entry.storeFingerprint, handleFingerprint: entry.handleFingerprint, audit };
   } finally {
@@ -357,7 +360,8 @@ export function writeAuditCache(entry: AuditCacheEntry, path = auditCachePath())
 export function auditContactsOnMac(
   value: unknown, runner: Runner = spawnSync, cachePath = auditCachePath(),
 ): { audit: ContactAudit; cached: boolean } {
-  if (!Array.isArray(value) || value.length < 1 || value.length > MAX_CONTACT_AUDIT_HANDLES)
+  const deadline = Date.now() + 180000;
+  if (!Array.isArray(value) || value.length < 1 || value.length > MAX_CONTACT_SCAN_HANDLES)
     throw new Error("contact audit handle list is invalid");
   const seen = new Set<string>();
   const handles = value.map((raw) => {
@@ -374,7 +378,7 @@ export function auditContactsOnMac(
   const handleFingerprint = handleSetFingerprint(handles);
   let cache: AuditCacheEntry | null = null;
   try { cache = readAuditCache(cachePath); } catch { cache = null; }
-  if (cache && cache.handleFingerprint === handleFingerprint) {
+  if (cache && cache.audit.handleCount === handles.length && cache.handleFingerprint === handleFingerprint) {
     try {
       if (storeFingerprintOnMac(runner) === cache.storeFingerprint) {
         const requested = new Set(handles.map(identityKey));
@@ -385,39 +389,62 @@ export function auditContactsOnMac(
     } catch { /* fingerprint unavailable — fall through to a full scan */ }
   }
   const home = process.env.HOME ?? homedir();
-  const result: SpawnSyncReturns<string> = runner(
-    join(home, "bin", "contacts"),
-    ["--json", "resolve"],
-    {
-      encoding: "utf8",
-      input: JSON.stringify({ operation: "audit", handles }),
-      timeout: 35000,
-      maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
-    },
-  );
-  if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
-  const stdout = String(result.stdout || "");
-  if (Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES)
-    throw new Error("Contacts returned too much data");
-  let response: unknown;
-  try { response = JSON.parse(stdout); }
-  catch { throw new Error("Contacts returned invalid JSON"); }
-  if (response === null || typeof response !== "object" || Array.isArray(response))
-    throw new Error("Contacts returned an invalid audit response");
-  const body = response as Record<string, unknown>;
-  if (result.status !== 0 || body.ok !== true)
-    throw new Error(safeError(body.error || "Contacts audit failed"));
-  const audit = normalizeContactAudit(body, handles.length);
-  const requestedKeys = new Set(handles.map(identityKey));
-  for (const entry of [...audit.singleCards, ...audit.duplicates, ...audit.conflicts]) {
-    if (!requestedKeys.has(identityKey(entry.handle)))
-      throw new Error("Contacts returned an unrequested audited handle");
+  const audit: ContactAudit = {handleCount: 0, noMatchCount: 0, singleCards: [], duplicates: [], conflicts: []};
+  let fingerprint: string | undefined;
+  let cacheable = true;
+  let retainedBytes = 0;
+  function batch(batchHandles: string[]): void {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error("Contact scan timed out; no partial result was saved");
+    const input = JSON.stringify({operation: "audit", handles: batchHandles});
+    if (Buffer.byteLength(input) > MAX_IDENTITY_REQUEST_BYTES) {
+      split(batchHandles); return;
+    }
+    const result: SpawnSyncReturns<string> = runner(join(home, "bin", "contacts"), ["--json", "resolve"], {
+      encoding: "utf8", input, timeout: Math.min(35000, remaining), maxBuffer: MAX_BRIDGE_OUTPUT_BYTES,
+    });
+    const stdout = String(result.stdout || "");
+    if ((result.error as any)?.code === "ENOBUFS" || Buffer.byteLength(stdout) > MAX_BRIDGE_OUTPUT_BYTES) {
+      split(batchHandles); return;
+    }
+    let body: any;
+    try { body = JSON.parse(stdout); } catch { /* report malformed replies below */ }
+    if (body?.ok === false && /too (?:much data|large)|exceeded its size contract/i.test(String(body.error))) {
+      split(batchHandles); return;
+    }
+    if (result.error) throw new Error(result.error.message || "Contacts bridge failed");
+    if (!body || typeof body !== "object" || Array.isArray(body)) throw new Error("Contacts returned invalid JSON");
+    if (result.status !== 0 || body.ok !== true) throw new Error(safeError(body.error || "Contacts audit failed"));
+    const part = normalizeContactAudit(body, batchHandles.length);
+    const requested = new Set(batchHandles.map(identityKey));
+    for (const entry of [...part.singleCards, ...part.duplicates, ...part.conflicts]) {
+      if (!requested.has(identityKey(entry.handle))) throw new Error("Contacts returned an unrequested audited handle");
+    }
+    if (typeof body.fingerprint === "string" && FINGERPRINT_PATTERN.test(body.fingerprint)) {
+      if (fingerprint && fingerprint !== body.fingerprint)
+        throw new Error("Contacts changed during the scan; please scan again");
+      fingerprint = body.fingerprint;
+    } else cacheable = false;
+    retainedBytes += Buffer.byteLength(JSON.stringify(part));
+    if (retainedBytes > MAX_AUDIT_CACHE_BYTES) throw new Error("Contact scan results exceed the storage limit");
+    audit.handleCount += part.handleCount;
+    audit.noMatchCount += part.noMatchCount;
+    audit.singleCards.push(...part.singleCards);
+    audit.duplicates.push(...part.duplicates);
+    audit.conflicts.push(...part.conflicts);
   }
-  if (typeof body.fingerprint === "string" && FINGERPRINT_PATTERN.test(body.fingerprint)) {
-    try { writeAuditCache({ storeFingerprint: body.fingerprint, handleFingerprint, audit }, cachePath); }
+  function split(part: string[]): void {
+    if (part.length < 2) throw new Error("One contact returned too much data; review it individually");
+    const middle = Math.ceil(part.length / 2);
+    batch(part.slice(0, middle)); batch(part.slice(middle));
+  }
+  for (let offset = 0; offset < handles.length; offset += MAX_CONTACT_AUDIT_HANDLES)
+    batch(handles.slice(offset, offset + MAX_CONTACT_AUDIT_HANDLES));
+  if (cacheable && fingerprint) {
+    try { writeAuditCache({storeFingerprint: fingerprint, handleFingerprint, audit}, cachePath); }
     catch { /* caching is best-effort */ }
   }
-  return { audit, cached: false };
+  return {audit, cached: false};
 }
 
 export function resolveOnMac(
@@ -526,6 +553,8 @@ export interface ReviewRow extends ReviewPerson {
 export interface ReviewView {
   ok: true;
   view: "people" | "cards" | "scan" | "opened";
+  page?: number;
+  pageCount?: number;
   title: string;
   detail: string;
   rows: ReviewRow[];
@@ -573,8 +602,8 @@ export function scanHandles(value: unknown): string[] {
     for (const item of conversationPeople(raw)) {
       const key = identityKey(item.handle);
       if (!found.has(key)) found.set(key, item.handle);
-      if (found.size > MAX_CONTACT_AUDIT_HANDLES)
-        throw new Error("Scan supports up to 200 distinct contacts; review a conversation individually");
+      if (found.size > MAX_CONTACT_SCAN_HANDLES)
+        throw new Error("Contact scan exceeds 10,000 distinct handles");
     }
   }
   return [...found.values()];
@@ -590,17 +619,20 @@ export function cardView(handle: string, candidates: IdentityCandidate[]): Revie
   };
 }
 
-export function auditView(audit: ContactAudit): ReviewView {
+export function auditView(audit: ContactAudit, requestedPage = 0): ReviewView {
   const rows = (entries: ContactAuditEntry[], label: string): ReviewRow[] => entries.map((entry) => ({
     handle: entry.handle,
     name: entry.candidates.map((candidate) => candidate.name).join(" / ").slice(0, 160),
     detail: `${label} · ${entry.candidates.reduce((n, candidate) => n + candidate.recordCount, 0)} cards`,
     action: "candidates", token: "",
   }));
+  const allRows = [...rows(audit.conflicts, "Different names share this handle"), ...rows(audit.duplicates, "Possible duplicate")];
+  const pageCount = Math.max(1, Math.ceil(allRows.length / SCAN_PAGE_SIZE));
+  const page = Math.min(finiteInteger(requestedPage, "scan page", 0, MAX_CONTACT_SCAN_HANDLES), pageCount - 1);
   return {
-    ok: true, view: "scan", title: "Contact scan",
+    ok: true, view: "scan", title: "Contact scan", page, pageCount,
     detail: `${audit.handleCount} checked · ${audit.duplicates.length} possible duplicates · ${audit.conflicts.length} name conflicts · ${audit.singleCards.length} single cards · ${audit.noMatchCount} unmatched`,
-    rows: [...rows(audit.conflicts, "Different names share this handle"), ...rows(audit.duplicates, "Possible duplicate")],
+    rows: allRows.slice(page * SCAN_PAGE_SIZE, (page + 1) * SCAN_PAGE_SIZE),
   };
 }
 
@@ -623,8 +655,8 @@ export function runReview(
   }
   if (operation === "audit") {
     const handles = scanHandles(request.conversations);
-    if (!handles.length) return { ok: true, view: "scan", title: "Contact scan", detail: "No contact handles to scan", rows: [] };
-    return auditView(auditContactsOnMac(handles, runner, cachePath).audit);
+    if (!handles.length) return { ok: true, view: "scan", title: "Contact scan", detail: "No contact handles to scan", rows: [], page: 0, pageCount: 1 };
+    return auditView(auditContactsOnMac(handles, runner, cachePath).audit, Number(request.page ?? 0));
   }
   if (operation === "open") {
     const result = resolveOnMac("open", request.handle, request.token, runner);
@@ -639,7 +671,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }, 5000);
   try {
-    const request = parseRequest(await readStdinBounded());
+    const request = parseRequest(await readStdinBounded(process.stdin as any, process.argv[2] === "audit" ? MAX_SCAN_REQUEST_BYTES : MAX_IDENTITY_REQUEST_BYTES));
     clearTimeout(deadline);
     emit(runReview(process.argv[2] || "", request));
   } catch (error) {

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -91,3 +91,12 @@ timestamp when `chat.db` changes; the client then fetches privately.
 
 Send tapbacks, edit or unsend, see typing indicators.
 Those need Apple private APIs that Blip deliberately does not use.
+
+Contact scans include conversation handles and group participants, with up to
+10,000 distinct handles from the bounded conversation list. Mac requests stay
+under 200 handles and 48 KiB; oversized responses are split into smaller
+requests. A scan has a three-minute deadline and rejects changing Contacts
+fingerprints instead of caching a partial result. The owner-only scan cache
+holds at most 16 MiB of contact summaries; QML receives 40 findings per page,
+under its existing 48 KiB response limit. Scan input is metadata only, bounded
+to 4 MiB on stdin. No message bodies enter the scan.


### PR DESCRIPTION
Contact scanning currently rejects the whole scan when more than 200 distinct handles are present. Keep 200 as a Mac request limit, split oversized payloads/responses further, and combine the results. Group participants now participate in the UI's scan request as well.

Show all duplicate/conflict findings in pages of 40. Reuse the complete fingerprint-validated metadata cache when moving between pages; changing fingerprints or a failed batch never publish a partial scan. Overall bounds are 10,000 distinct handles, 4 MiB of metadata input, a three-minute scan budget, and a 16 MiB private cache. Per-bridge and QML response limits remain 48 KiB.

Validation: 439 Bun tests pass, including 451-handle scans, request/reply splitting, cache reuse, changing fingerprints, and complete pagination. The paginated QML view was inspected at 360px with synthetic data. No messages were read or sent.

Based directly on main and independent of #25. This fixes the read-only scanning path already merged in #24.
