### PR TITLE
Show full read-only contact source-card details

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -1357,17 +1357,36 @@ FocusScope {
     sendProc.stdinEnabled = false
   }
 
-  Process { id: copyProc }
+  property string copyFeedback: ""
+  Process {
+    id: copyProc
+    onExited: function(code, status) {
+      copyTimeout.stop()
+      root.copyFeedback = code === 0 && status === 0 ? "Copied to clipboard" : "Could not copy to clipboard"
+      copyFeedbackTimer.restart()
+    }
+  }
+  Timer {
+    id: copyTimeout
+    interval: 5000
+    onTriggered: {
+      copyProc.running = false
+      root.copyFeedback = "Could not copy to clipboard"
+      copyFeedbackTimer.restart()
+    }
+  }
+  Timer { id: copyFeedbackTimer; interval: 2200; onTriggered: root.copyFeedback = "" }
   function copyText(t) {
     if (t === "") return
     // stdin, not argv: message text can be long and can start with "-".
-    copyProc.command = ["sh", "-c", "wl-copy"]
+    copyFeedback = ""
+    copyFeedbackTimer.stop()
+    copyTimeout.restart()
+    copyProc.command = ["/usr/bin/wl-copy"]
     copyProc.stdinEnabled = true
     copyProc.running = true
     copyProc.write(t)
     copyProc.stdinEnabled = false
-    note = "copied"
-    noteTimer.restart()
   }
   Timer { id: noteTimer; interval: 1500; onTriggered: if (root.note === "copied" || root.note === "sent to LocalSend") root.note = "" }
 
@@ -3436,6 +3455,31 @@ FocusScope {
     fontSize: root.fontBodySmall
     onClosed: root.focusDefault()
     onCopyRequested: function(text) { root.copyText(text) }
+  }
+
+  // Copy feedback must remain visible above contact review and other subviews.
+  // Only fixed status text is shown; copied contents never enter a notification.
+  Rectangle {
+    objectName: "blipCopyFeedback"
+    visible: root.copyFeedback !== ""
+    z: 1000
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.bottom: parent.bottom
+    anchors.bottomMargin: Style.space(56)
+    width: Math.max(0, Math.min(parent.width - Style.space(16), copyFeedbackText.implicitWidth + Style.space(24)))
+    height: copyFeedbackText.implicitHeight + Style.space(16)
+    radius: Style.cornerRadius
+    color: Color.background
+    border.width: 1
+    border.color: root.copyFeedback === "Copied to clipboard" ? root.accent : root.urgent
+    Text {
+      id: copyFeedbackText
+      width: Math.max(0, parent.width - Style.space(24))
+      wrapMode: Text.WordWrap; horizontalAlignment: Text.AlignHCenter
+      anchors.centerIn: parent
+      text: root.copyFeedback; textFormat: Text.PlainText
+      color: root.foreground; font.family: root.fontFamily; font.pixelSize: root.fontCaption
+    }
   }
 
     // drag a file from a file manager onto the open conversation → draft chip

--- a/BlipView.qml
+++ b/BlipView.qml
@@ -3435,6 +3435,7 @@ FocusScope {
     fontFamily: root.fontFamily
     fontSize: root.fontBodySmall
     onClosed: root.focusDefault()
+    onCopyRequested: function(text) { root.copyText(text) }
   }
 
     // drag a file from a file manager onto the open conversation → draft chip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ what it is handed. Keep it that way.
   "Mom" cards outvote your own "Monica Gamble" for the same number.
 - **Contact review is read-only and separate from configuration.**
   `ContactReview.qml` opens from a conversation and renders models supplied by
-  `contact-review.ts`. Only candidates, audit, fingerprint, and exact-card open
+  `contact-review.ts`. Only candidates, audit, fingerprint, exact-card open, and exact-card details
   cross the Mac protocol. Handles and opaque tokens travel on bounded stdin;
   no display-name choices or appearance preferences are saved. A group offers
   its participants, never the last speaker as a stand-in for the group.

--- a/ContactDetails.qml
+++ b/ContactDetails.qml
@@ -17,6 +17,7 @@ FocusScope {
   property string error: ""
   signal closed()
   signal openOnMac()
+  signal copyRequested(string text)
   readonly property string helper: decodeURIComponent(Qt.resolvedUrl("contact-details.ts").toString().replace(/^file:\/\//, ""))
   Keys.onEscapePressed: closed()
   function validText(value, limit) {
@@ -97,6 +98,10 @@ FocusScope {
             required property var modelData
             Layout.fillWidth: true
             spacing: Style.space(2)
+            TapHandler {
+              acceptedButtons: Qt.RightButton
+              onTapped: root.copyRequested(modelData.value)
+            }
             Text {
               Layout.fillWidth: true; text: modelData.label; textFormat: Text.PlainText
               wrapMode: Text.WordWrap; color: Qt.darker(root.foreground,1.4)
@@ -106,6 +111,12 @@ FocusScope {
               Layout.fillWidth: true; text: modelData.value; textFormat: TextEdit.PlainText
               readOnly: true; selectByMouse: true; wrapMode: TextEdit.Wrap
               color: root.foreground; font.family: root.fontFamily; font.pixelSize: root.fontSize
+              Keys.onPressed: function(event) {
+                if (event.matches(StandardKey.Copy)) {
+                  if (selectedText !== "") root.copyRequested(selectedText)
+                  event.accepted = true
+                }
+              }
             }
           }
         }

--- a/ContactDetails.qml
+++ b/ContactDetails.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Ui
+
+FocusScope {
+  id: root
+  required property var card
+  property color foreground: Color.foreground
+  property color accent: "#0a84ff"
+  property string fontFamily: Style.font.family
+  property int fontSize: Style.font.bodySmall
+  property var details: null
+  property string error: ""
+  signal closed()
+  signal openOnMac()
+  readonly property string helper: decodeURIComponent(Qt.resolvedUrl("contact-details.ts").toString().replace(/^file:\/\//, ""))
+  Keys.onEscapePressed: closed()
+  function validText(value, limit) {
+    return typeof value === "string" && value.length <= limit
+      && !/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/.test(value)
+  }
+  Component.onCompleted: {
+    worker.stdinEnabled = true
+    worker.running = true
+    forceActiveFocus()
+  }
+  Process {
+    id: worker
+    command: ["bun", root.helper]
+    property bool received: false
+    onStarted: {
+      write(JSON.stringify({handle: root.card.handle, token: root.card.token}))
+      stdinEnabled = false
+    }
+    stdout: StdioCollector {
+      onStreamFinished: {
+        worker.received = true
+        try {
+          if (text.length > 49152) throw "large"
+          var value = JSON.parse(text)
+          if (!value || value.ok !== true) {
+            root.error = value && root.validText(value.error,180) ? value.error : "Could not read contact details"
+            return
+          }
+          if (!root.validText(value.name,160) || !root.validText(value.source,160)
+            || !Array.isArray(value.fields) || value.fields.length>160) throw "schema"
+          for (var i=0;i<value.fields.length;i++) {
+            if (!root.validText(value.fields[i].label,120) || !root.validText(value.fields[i].value,4096)) throw "field"
+          }
+          root.details=value
+        } catch (_) { root.error="Invalid contact details" }
+      }
+    }
+    onExited: Qt.callLater(function() { if (!worker.received) root.error="Could not start contact details" })
+  }
+  ColumnLayout {
+    anchors.fill: parent
+    spacing: Style.space(10)
+    RowLayout {
+      Layout.fillWidth: true
+      PanelActionButton {
+        iconText: "←"; tooltipText: "Back to contact review"
+        foreground: root.foreground; hoverColor: root.accent
+        onClicked: root.closed()
+      }
+      Text {
+        Layout.fillWidth: true
+        text: root.details ? root.details.name : root.card.name
+        textFormat: Text.PlainText; wrapMode: Text.WordWrap
+        color: root.foreground; font.family: root.fontFamily; font.pixelSize: root.fontSize+2; font.bold: true
+      }
+    }
+    Text {
+      Layout.fillWidth: true
+      text: root.error || (root.details ? root.details.source : "Reading contact details…")
+      textFormat: Text.PlainText; wrapMode: Text.WordWrap
+      color: root.error ? Color.urgent : root.foreground
+      font.family: root.fontFamily; font.pixelSize: root.fontSize
+    }
+    PanelSeparator { Layout.fillWidth: true; foreground: root.foreground }
+    Flickable {
+      Layout.fillWidth: true; Layout.fillHeight: true
+      contentWidth: width; contentHeight: fields.implicitHeight
+      clip: true; boundsBehavior: Flickable.StopAtBounds
+      QQC.ScrollBar.vertical: QQC.ScrollBar {}
+      ColumnLayout {
+        id: fields
+        width: parent.width
+        spacing: Style.space(12)
+        Repeater {
+          model: root.details ? root.details.fields : []
+          delegate: ColumnLayout {
+            required property var modelData
+            Layout.fillWidth: true
+            spacing: Style.space(2)
+            Text {
+              Layout.fillWidth: true; text: modelData.label; textFormat: Text.PlainText
+              wrapMode: Text.WordWrap; color: Qt.darker(root.foreground,1.4)
+              font.family: root.fontFamily; font.pixelSize: root.fontSize
+            }
+            TextEdit {
+              Layout.fillWidth: true; text: modelData.value; textFormat: TextEdit.PlainText
+              readOnly: true; selectByMouse: true; wrapMode: TextEdit.Wrap
+              color: root.foreground; font.family: root.fontFamily; font.pixelSize: root.fontSize
+            }
+          }
+        }
+      }
+    }
+    ContactButton {
+      Layout.fillWidth: true; text: "Open on Mac ↗"
+      foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+      onClicked: root.openOnMac()
+    }
+  }
+}

--- a/ContactReview.qml
+++ b/ContactReview.qml
@@ -21,11 +21,12 @@ FocusScope {
   property string error: ""
   property string notice: ""
   property bool busy: false
+  property var selectedCard: null
   visible: opened
   readonly property string helper: decodeURIComponent(Qt.resolvedUrl("contact-review.ts").toString().replace(/^file:\/\//, ""))
   signal closed()
 
-  function close() { opened = false; closed() }
+  function close() { selectedCard = null; opened = false; closed() }
   function textField(value, maximum) { return typeof value === "string" ? value.slice(0, maximum) : "" }
   function metadata(thread) {
     return { chat: textField(thread.chat, 320), name: textField(thread.name, 160) }
@@ -49,6 +50,7 @@ FocusScope {
     request("audit", { conversations: threads.map(function(thread) { return { chat: textField(thread.chat, 320) } }) })
   }
   function back() {
+    if (selectedCard) { selectedCard = null; return }
     if (busy) return
     if (overview) { model = overview; overview = null; error = ""; notice = "" }
     else close()
@@ -106,7 +108,22 @@ FocusScope {
     })
   }
 
+  Loader {
+    anchors.fill: parent
+    active: root.selectedCard !== null
+    sourceComponent: ContactDetails {
+      card: root.selectedCard
+      foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+      onClosed: root.selectedCard = null
+      onOpenOnMac: {
+        var card = root.selectedCard
+        root.selectedCard = null
+        root.request("open", {handle: card.handle, token: card.token})
+      }
+    }
+  }
   ColumnLayout {
+    visible: root.selectedCard === null
     anchors.fill: parent
     spacing: Style.space(10)
     RowLayout {
@@ -180,6 +197,14 @@ FocusScope {
                 Layout.fillWidth: true; text: modelData.detail; textFormat: Text.PlainText
                 wrapMode: Text.WordWrap; color: Qt.darker(root.foreground, 1.3)
                 font.family: root.fontFamily; font.pixelSize: root.fontSize
+              }
+              ContactButton {
+                Layout.fillWidth: true
+                visible: modelData.action === "open"
+                text: "View details"
+                enabled: !root.busy
+                foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+                onClicked: root.selectedCard = modelData
               }
               ContactButton {
                 Layout.fillWidth: true

--- a/ContactReview.qml
+++ b/ContactReview.qml
@@ -25,6 +25,7 @@ FocusScope {
   visible: opened
   readonly property string helper: decodeURIComponent(Qt.resolvedUrl("contact-review.ts").toString().replace(/^file:\/\//, ""))
   signal closed()
+  signal copyRequested(string text)
 
   function close() { selectedCard = null; opened = false; closed() }
   function textField(value, maximum) { return typeof value === "string" ? value.slice(0, maximum) : "" }
@@ -115,6 +116,7 @@ FocusScope {
       card: root.selectedCard
       foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
       onClosed: root.selectedCard = null
+      onCopyRequested: function(text) { root.copyRequested(text) }
       onOpenOnMac: {
         var card = root.selectedCard
         root.selectedCard = null

--- a/README.md
+++ b/README.md
@@ -515,6 +515,9 @@ Each card shows its name, account, source, matching-field count, and whether it
 has a photo. **Open in Contacts on Mac** opens that exact card; make edits in
 Contacts itself.
 
+In a card's details, right-click any field to copy its whole value. To copy
+part of a value, select the text and press Ctrl+C or Ctrl+Insert, or use Omapop.
+
 **Scan contacts** checks the conversation list for possible duplicate cards
 and handles shared by different names. Named conversations and short-code
 senders are included. A shared number or name is evidence to review, never an

--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Contacts itself.
 
 In a card's details, right-click any field to copy its whole value. To copy
 part of a value, select the text and press Ctrl+C or Ctrl+Insert, or use Omapop.
+A brief toast confirms a successful right-click copy or reports a clipboard error.
 
 **Scan contacts** checks the conversation list for possible duplicate cards
 and handles shared by different names. Named conversations and short-code

--- a/bridge/mac/contact-repair.js
+++ b/bridge/mac/contact-repair.js
@@ -1,10 +1,10 @@
 #!/usr/bin/osascript -l JavaScript
 /*
- * Read-only Contacts availability check for Blip.
+ * Read-only Contacts availability and exact-card details for Blip.
  *
  * The Python bridge sends one bounded JSON request on stdin. Raw Contacts
  * identifiers never appear in argv, and this helper emits a small JSON
- * result only. Its single operation answers which person ids the object
+ * result only. Its availability operation answers which person ids the object
  * layer can actually address — raw per-account databases can retain
  * inactive cache rows. It mutates nothing.
  */
@@ -36,7 +36,7 @@ function readRequest() {
 }
 
 function normalizeRequest(value) {
-  if (value.operation !== "available") throw new Error("repair operation is invalid");
+  if (["available", "details"].indexOf(value.operation) < 0) throw new Error("repair operation is invalid");
   if (!Array.isArray(value.personUids) || value.personUids.length < 1
       || value.personUids.length > MAX_PERSON_IDS)
     throw new Error("person id list is invalid");
@@ -47,7 +47,74 @@ function normalizeRequest(value) {
     seen[normalized] = true;
     return normalized;
   });
-  return { operation: "available", personUids: personUids };
+  if (value.operation === "details" && personUids.length !== 1) throw new Error("details requires one exact card");
+  return { operation: value.operation, personUids: personUids };
+}
+
+// Read-only subset of the source-card comparison from contact management.
+// The AddressBook object layer avoids driving Contacts.app or compiling Swift.
+function describePerson(person) {
+  const fields = [];
+  function text(value) {
+    const plain = ObjC.unwrap(value);
+    if (plain === undefined || plain === null) return "";
+    const result = String(plain);
+    if (result.length > 4096) throw new Error("Contact field is too long to display");
+    return result.replace(UNSAFE, " ").trim();
+  }
+  function add(key, value, label) {
+    if (value) fields.push({key: key, value: value, label: label || ""});
+    if (fields.length > 160) throw new Error("Too many contact fields");
+  }
+  function date(value) {
+    if (!ObjC.unwrap(value)) return "";
+    const formatter = $.NSDateFormatter.alloc.init;
+    formatter.dateFormat = "yyyy-MM-dd";
+    return text(formatter.stringFromDate(value));
+  }
+  const scalar = [
+    ["prefix", $.kABTitleProperty], ["firstName", $.kABFirstNameProperty],
+    ["middleName", $.kABMiddleNameProperty], ["lastName", $.kABLastNameProperty],
+    ["suffix", $.kABSuffixProperty], ["nickname", $.kABNicknameProperty],
+    ["maidenName", $.kABMaidenNameProperty],
+    ["phoneticFirstName", $.kABFirstNamePhoneticProperty],
+    ["phoneticMiddleName", $.kABMiddleNamePhoneticProperty],
+    ["phoneticLastName", $.kABLastNamePhoneticProperty],
+    ["organization", $.kABOrganizationProperty], ["department", $.kABDepartmentProperty],
+    ["jobTitle", $.kABJobTitleProperty], ["note", $.kABNoteProperty]
+  ];
+  scalar.forEach(function(pair) { add(pair[0], text(person.valueForProperty(pair[1]))); });
+  add("birthday", date(person.valueForProperty($.kABBirthdayProperty)));
+  const collections = [
+    ["phone", $.kABPhoneProperty], ["email", $.kABEmailProperty],
+    ["url", $.kABURLsProperty], ["address", $.kABAddressProperty],
+    ["relatedName", $.kABRelatedNamesProperty], ["date", $.kABOtherDatesProperty],
+    ["socialProfile", $.kABSocialProfileProperty], ["instantMessage", $.kABInstantMessageProperty]
+  ];
+  collections.forEach(function(pair) {
+    const values = person.valueForProperty(pair[1]);
+    if (!ObjC.unwrap(values)) return;
+    const count = Number(values.count);
+    if (!Number.isInteger(count) || count > 32) throw new Error("Too many values for one contact field");
+    for (let i = 0; i < count; i++) {
+      let value = values.valueAtIndex(i);
+      if (pair[0] === "date") value = date(value);
+      else if (["address", "socialProfile", "instantMessage"].indexOf(pair[0]) >= 0) {
+        const dict = ObjC.deepUnwrap(value);
+        if (!dict || typeof dict !== "object" || Array.isArray(dict)) throw new Error("Invalid contact field");
+        const keys = Object.keys(dict);
+        if (keys.length > 16) throw new Error("Too many contact field components");
+        value = keys.map(function(key) {
+          if (key.length > 80 || typeof dict[key] !== "string" || dict[key].length > 1024) throw new Error("Invalid contact field component");
+          return key + ": " + dict[key];
+        }).join("; ");
+      } else value = text(value);
+      const label = text($.ABLocalizedPropertyOrLabel(values.labelAtIndex(i)));
+      if (label.length > 80) throw new Error("Contact label is too long");
+      add(pair[0], String(value).replace(UNSAFE, " "), label);
+    }
+  });
+  return fields;
 }
 
 function perform(request) {
@@ -55,6 +122,11 @@ function perform(request) {
   // raw per-account databases can retain inactive cache rows.
   ObjC.import("AddressBook");
   const book = $.ABAddressBook.sharedAddressBook;
+  if (request.operation === "details") {
+    const person = book.recordForUniqueId($(request.personUids[0]));
+    if (!ObjC.unwrap(person)) throw new Error("This contact card is no longer available");
+    return {ok: true, fields: describePerson(person)};
+  }
   const available = request.personUids.filter(function(uid) {
     try {
       const person = book.recordForUniqueId($(uid));

--- a/bridge/mac/contacts
+++ b/bridge/mac/contacts
@@ -644,6 +644,23 @@ def _cmd_resolve(args):
         emit_resolve({"ok": True, "fingerprint": fingerprint,
                       **audit_contact_handles(request.get("handles"))})
         return
+    if operation == "details":
+        original, _, candidate, record, number, account = selected_card(
+            request.get("handle"), request.get("token"))
+        response = run_contact_repair({"operation": "details", "personUids": [record["uid"]]})
+        fields = response.get("fields")
+        if not isinstance(fields, list) or len(fields) > 160:
+            raise RuntimeError("Contacts returned invalid detail fields")
+        for field in fields:
+            if (not isinstance(field, dict) or not isinstance(field.get("key"), str)
+                    or len(field["key"]) > 40 or not isinstance(field.get("label"), str)
+                    or len(field["label"]) > 80 or not isinstance(field.get("value"), str)
+                    or len(field["value"]) > 4096):
+                raise RuntimeError("Contacts returned an invalid detail field")
+        emit_resolve({"ok": True, "handle": original, "token": request["token"],
+                      "name": candidate["name"], "sourceName": candidate["cards"][number - 1]["sourceName"],
+                      "accountNumber": account, "fields": fields})
+        return
     if operation == "open":
         _, _, selected, selected_record, selected_card_number, selected_account_number = selected_card(
             request.get("handle"), request.get("token")
@@ -666,7 +683,7 @@ def _cmd_resolve(args):
         })
         return
     raise ValueError(
-        "operation must be candidates, fingerprint, audit, or open"
+        "operation must be candidates, fingerprint, audit, details, or open"
     )
 
 

--- a/bridge/mac/contacts_test.py
+++ b/bridge/mac/contacts_test.py
@@ -264,5 +264,30 @@ class SourceOrderTests(unittest.TestCase):
         ])
 
 
+class ContactDetailsTests(unittest.TestCase):
+    def test_details_resolves_exact_card_and_returns_fields(self):
+        token = "sha256:" + "a" * 64
+        fields = [{"key": "firstName", "label": "", "value": "Example"}]
+        selected = ("+15551234567", "key", {"name": "Example Person", "cards": [{"sourceName": "iCloud"}]},
+                    {"uid": "synthetic-card"}, 1, 1)
+        with mock.patch.object(contacts, "read_resolve_request", return_value={"operation": "details", "handle": "+15551234567", "token": token}), \
+             mock.patch.object(contacts, "selected_card", return_value=selected) as resolve, \
+             mock.patch.object(contacts, "run_contact_repair", return_value={"ok": True, "fields": fields}) as describe, \
+             mock.patch.object(contacts, "emit_resolve") as emit:
+            contacts._cmd_resolve(None)
+        resolve.assert_called_once_with("+15551234567", token)
+        describe.assert_called_once_with({"operation": "details", "personUids": ["synthetic-card"]})
+        self.assertEqual(emit.call_args.args[0]["fields"], fields)
+        self.assertEqual(emit.call_args.args[0]["token"], token)
+
+    def test_details_rejects_oversized_fields(self):
+        selected = ("+15551234567", "key", {}, {"uid": "synthetic-card"}, 1, 1)
+        with mock.patch.object(contacts, "read_resolve_request", return_value={"operation": "details"}), \
+             mock.patch.object(contacts, "selected_card", return_value=selected), \
+             mock.patch.object(contacts, "run_contact_repair", return_value={"fields": [{"key": "note", "label": "", "value": "x" * 4097}]}):
+            with self.assertRaisesRegex(RuntimeError, "invalid detail"):
+                contacts._cmd_resolve(None)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/contact-details.test.ts
+++ b/contact-details.test.ts
@@ -1,0 +1,32 @@
+import {test,expect} from 'bun:test';
+import {cardDetails} from './contact-details';
+const token='sha256:'+'a'.repeat(64);
+const request={handle:'+15551234567',token};
+const base={ok:true,...request,name:'Example Person',sourceName:'iCloud',accountNumber:1,fields:[
+  {key:'firstName',label:'',value:'Example'}, {key:'phone',label:'Mobile',value:'+15551234567'},
+  {key:'address',label:'Home',value:'Street: 10 Example Lane; City: Sample City'},
+  {key:'note',label:'',value:'A synthetic note with <b>plain text</b>'},
+]};
+function runner(body: unknown): any {return (_cmd:string,args:string[],options:any)=>{
+  expect(args).toEqual(['--json','resolve']);
+  expect(JSON.parse(options.input)).toEqual({operation:'details',...request});
+  expect(options.maxBuffer).toBe(48*1024);
+  return {status:0,stdout:JSON.stringify(body)};
+};}
+test('renders labeled contact fields from one exact card on bounded stdin',()=>{
+  const view=cardDetails(request,runner(base));
+  expect(view.source).toBe('iCloud · Account 1');
+  expect(view.fields[1]).toEqual({label:'Phone · Mobile',value:'+15551234567'});
+  expect(view.fields[3].value).toContain('<b>plain text</b>');
+});
+test('rejects mismatched cards and hostile detail shapes',()=>{
+  for(const body of [null,{}, {...base,token:'sha256:'+'b'.repeat(64)}, {...base,handle:'+15551234568'},
+    {...base,fields:Array(161).fill(base.fields[0])}, {...base,fields:[{key:'__proto__',label:'',value:'x'}]},
+    {...base,fields:[{key:'note',label:'',value:'x'.repeat(4097)}]}, {...base,accountNumber:0}])
+    expect(()=>cardDetails(request,runner(body))).toThrow();
+  expect(()=>cardDetails({...request,token:'bad'},runner(base))).toThrow();
+});
+test('strips control and direction overrides and rejects oversized process output',()=>{
+  expect(cardDetails(request,runner({...base,name:'Example\u202ePerson'})).name).toBe('Example Person');
+  expect(()=>cardDetails(request,(()=>({status:0,stdout:' '.repeat(49153)})) as any)).toThrow('too large');
+});

--- a/contact-details.ts
+++ b/contact-details.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+/** Exact-card, read-only field viewer. Contact contents stay in memory. */
+import {spawnSync} from 'node:child_process';
+import {homedir} from 'node:os';
+import {join} from 'node:path';
+import {normalizeHandle, identityKey, readStdinBounded} from './contact-review';
+const MAX_BYTES = 48 * 1024;
+const TOKEN = /^sha256:[0-9a-f]{64}$/;
+const LABELS: Record<string,string> = {
+  prefix:'Prefix',firstName:'First name',middleName:'Middle name',lastName:'Last name',suffix:'Suffix',
+  nickname:'Nickname',maidenName:'Maiden name',phoneticFirstName:'Phonetic first name',
+  phoneticMiddleName:'Phonetic middle name',phoneticLastName:'Phonetic last name',
+  organization:'Organization',department:'Department',jobTitle:'Job title',birthday:'Birthday',note:'Notes',
+  phone:'Phone',email:'Email',url:'Website',address:'Address',relatedName:'Related person',
+  date:'Date',socialProfile:'Social profile',instantMessage:'Instant message',
+};
+function text(value: unknown, max: number): string {
+  if (typeof value !== 'string' || value.length > max) throw new Error('Invalid contact detail text');
+  return value.replace(/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/g,' ').trim();
+}
+export function cardDetails(request: any, runner = spawnSync) {
+  const handle = normalizeHandle(request?.handle);
+  if (typeof request?.token !== 'string' || !TOKEN.test(request.token)) throw new Error('Invalid contact card token');
+  const result = runner(join(process.env.HOME ?? homedir(),'bin','contacts'),['--json','resolve'], {
+    input:JSON.stringify({operation:'details',handle,token:request.token}),encoding:'utf8',timeout:35000,maxBuffer:MAX_BYTES,
+  });
+  if (result.error) throw new Error('Could not read contact details');
+  if (Buffer.byteLength(String(result.stdout || '')) > MAX_BYTES) throw new Error('Contact details are too large');
+  let body: any;
+  try {body=JSON.parse(String(result.stdout));} catch {throw new Error('Invalid contact detail response');}
+  if (!body || result.status !== 0 || body.ok !== true)
+    throw new Error(text(body?.error || 'Could not read contact details',180));
+  if (identityKey(body.handle)!==identityKey(handle) || body.token!==request.token)
+    throw new Error('Contacts returned a different card');
+  if (!Array.isArray(body.fields) || body.fields.length > 160) throw new Error('Invalid contact fields');
+  if (!Number.isInteger(body.accountNumber) || body.accountNumber<1 || body.accountNumber>64)
+    throw new Error('Invalid contact account');
+  const fields=body.fields.map((field: any) => {
+    if (!field || !Object.hasOwn(LABELS,field.key)) throw new Error('Unknown contact field');
+    const label=text(field.label,80), value=text(field.value,4096);
+    return {label:LABELS[field.key]+(label ? ' · '+label : ''),value};
+  });
+  return {ok:true,name:text(body.name,160),source:text(body.sourceName,120)+' · Account '+body.accountNumber,fields};
+}
+if (import.meta.main) {
+  const timer=setTimeout(()=>{process.stdout.write('{"ok":false,"error":"Contact request timed out"}\n');process.exit(1);},5000);
+  try {
+    const request=JSON.parse(await readStdinBounded()); clearTimeout(timer);
+    const result=cardDetails(request);
+    const output=JSON.stringify(result);
+    if (Buffer.byteLength(output)>MAX_BYTES) throw new Error('Contact details are too large');
+    process.stdout.write(output+'\n');
+  } catch (error) {
+    clearTimeout(timer);
+    process.stdout.write(JSON.stringify({ok:false,error:String(error instanceof Error ? error.message : error).slice(0,180)})+'\n');
+    process.exitCode=1;
+  }
+}

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -91,3 +91,12 @@ timestamp when `chat.db` changes; the client then fetches privately.
 
 Send tapbacks, edit or unsend, see typing indicators.
 Those need Apple private APIs that Blip deliberately does not use.
+
+The read-only detail viewer resolves an explicit source-card token again before
+reading that card. Names, phone/email/website labels, addresses, dates, related
+people, social profiles, and notes stay in process memory on Linux. Details
+are never written to the audit cache. Requests and responses use the existing
+48 KiB bridge contract, with at most 160 fields, 32 values per collection,
+80-character labels, and 4,096-character values; oversized cards report an
+error instead of silently dropping fields. The reader uses the existing
+AddressBook object layer and enables no Contacts mutation operations.


### PR DESCRIPTION
Contact review currently shows only a card's name, source/account, match count, and photo availability. Add a **View details** action for each exact source card, with selectable values that wrap at menubar widths. Right-click copies a whole field; Ctrl+C/Ctrl+Insert copy the selection. A toast above the contact view confirms clipboard success or reports failure, with a five-second timeout.

This extracts the field-review portion of #25: names and phonetic names, organization/job fields, phones, emails, websites, postal addresses, birthdays and other dates, related people, social/IM profiles, and notes. It uses the existing AddressBook object layer with no Swift compilation and no mutation operations. Card tokens are revalidated immediately before reading. Details stay in memory and never enter the scan cache; oversized fields/cards report an error instead of silently dropping values.

Validation: 437 Bun tests and 15 Python bridge tests pass; Python compilation and JavaScript syntax checks pass. A native Mac check read an unsaved synthetic contact's scalar and labeled phone fields. The selectable/wrapping detail view was visually inspected at 360px. Disposable-VM checks verified selection, keyboard copying, right-click copying, and the success toast in both a 500px panel and a separate window; synthetic screenshots were inspected. No real conversation was opened, no message was sent, and no contact was saved.

Based directly on main and independent of #25. Editing, merging, linking, deletion, and undo remain in #25.
