### PR TITLE
Copy or save an exact contact source card as a vCard file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ what it is handed. Keep it that way.
   "Mom" cards outvote your own "Monica Gamble" for the same number.
 - **Contact review is read-only and separate from configuration.**
   `ContactReview.qml` opens from a conversation and renders models supplied by
-  `contact-review.ts`. Only candidates, audit, fingerprint, and exact-card open
+  `contact-review.ts`. Only candidates, audit, fingerprint, exact-card open, and exact-card vCard export
   cross the Mac protocol. Handles and opaque tokens travel on bounded stdin;
   no display-name choices or appearance preferences are saved. A group offers
   its participants, never the last speaker as a stand-in for the group.

--- a/ContactReview.qml
+++ b/ContactReview.qml
@@ -82,7 +82,7 @@ FocusScope {
         error = result && validText(result.error, 180) ? result.error : "Contact review failed"
         return
       }
-      if (["people", "cards", "scan", "opened", "copied"].indexOf(result.view) < 0
+      if (["people", "cards", "scan", "opened", "copied", "saved", "cancelled"].indexOf(result.view) < 0
           || !validText(result.title, 160) || !validText(result.detail, 480)
           || !Array.isArray(result.rows) || result.rows.length > 200) throw "schema"
       for (var i = 0; i < result.rows.length; i++) {
@@ -92,7 +92,7 @@ FocusScope {
             || typeof row.token !== "string" || (row.action === "open"
               ? !/^sha256:[0-9a-f]{64}$/.test(row.token) : row.token !== "")) throw "row"
       }
-      if ((result.view === "opened" || result.view === "copied")) notice = result.detail
+      if (["opened", "copied", "saved", "cancelled"].indexOf(result.view) >= 0) notice = result.detail
       else { model = result; reviewFlick.contentY = 0 }
     } catch (e) { error = "Contact review returned an invalid response" }
   }
@@ -183,13 +183,24 @@ FocusScope {
                 wrapMode: Text.WordWrap; color: Qt.darker(root.foreground, 1.3)
                 font.family: root.fontFamily; font.pixelSize: root.fontSize
               }
-              ContactButton {
+              RowLayout {
                 Layout.fillWidth: true
                 visible: modelData.action === "open"
-                text: "Copy vCard"
-                enabled: !root.busy
-                foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
-                onClicked: root.request("vcard", {handle: modelData.handle, token: modelData.token})
+                spacing: Style.space(6)
+                ContactButton {
+                  Layout.fillWidth: true
+                  text: "Copy vCard"
+                  enabled: !root.busy
+                  foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+                  onClicked: root.request("vcard", {handle: modelData.handle, token: modelData.token})
+                }
+                ContactButton {
+                  Layout.fillWidth: true
+                  text: "Save vCard…"
+                  enabled: !root.busy
+                  foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+                  onClicked: root.request("vcard", {handle: modelData.handle, token: modelData.token, action: "save"})
+                }
               }
               ContactButton {
                 Layout.fillWidth: true

--- a/ContactReview.qml
+++ b/ContactReview.qml
@@ -59,7 +59,9 @@ FocusScope {
     error = ""; notice = ""
     if (encoded.length > 49152) { error = "Too many contacts in this request"; return }
     worker.received = false
-    worker.command = ["bun", helper, operation]
+    worker.command = operation === "vcard"
+      ? ["bun", helper.replace(/contact-review\.ts$/, "contact-vcard.ts")]
+      : ["bun", helper, operation]
     busy = true
     worker.stdinEnabled = true
     worker.running = true
@@ -80,7 +82,7 @@ FocusScope {
         error = result && validText(result.error, 180) ? result.error : "Contact review failed"
         return
       }
-      if (["people", "cards", "scan", "opened"].indexOf(result.view) < 0
+      if (["people", "cards", "scan", "opened", "copied"].indexOf(result.view) < 0
           || !validText(result.title, 160) || !validText(result.detail, 480)
           || !Array.isArray(result.rows) || result.rows.length > 200) throw "schema"
       for (var i = 0; i < result.rows.length; i++) {
@@ -90,7 +92,7 @@ FocusScope {
             || typeof row.token !== "string" || (row.action === "open"
               ? !/^sha256:[0-9a-f]{64}$/.test(row.token) : row.token !== "")) throw "row"
       }
-      if (result.view === "opened") notice = result.detail
+      if ((result.view === "opened" || result.view === "copied")) notice = result.detail
       else { model = result; reviewFlick.contentY = 0 }
     } catch (e) { error = "Contact review returned an invalid response" }
   }
@@ -180,6 +182,14 @@ FocusScope {
                 Layout.fillWidth: true; text: modelData.detail; textFormat: Text.PlainText
                 wrapMode: Text.WordWrap; color: Qt.darker(root.foreground, 1.3)
                 font.family: root.fontFamily; font.pixelSize: root.fontSize
+              }
+              ContactButton {
+                Layout.fillWidth: true
+                visible: modelData.action === "open"
+                text: "Copy vCard"
+                enabled: !root.busy
+                foreground: root.foreground; accent: root.accent; fontFamily: root.fontFamily; fontSize: root.fontSize
+                onClicked: root.request("vcard", {handle: modelData.handle, token: modelData.token})
               }
               ContactButton {
                 Layout.fillWidth: true

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ unset, it follows Omarchy's type size.
 - Linux: [Omarchy](https://omarchy.org) (Hyprland + the Omarchy shell), and on
   the box: `bun`, `jq`, `openssh`, `libnotify`, `wl-clipboard`, `xdg-utils`.
   `blip-setup` checks for each and prints the `pacman` line for what's missing.
+  The optional **Save vCard…** action also uses `zenity` for its folder picker.
 
 > **Honest note on dependencies.** Blip is not a drop-in marketplace plugin
 > the way a clock widget is: it needs `bun` on the Linux side, a Mac you own
@@ -697,3 +698,16 @@ and it's the reason this took an evening, not a week.
 **Contributors:** [@jethrojones](https://github.com/jethrojones) — `blip-check` across every Contacts source (#2).
 
 MIT.
+
+
+### Export a contact
+
+In Contact review, choose the exact matching source card. **Copy vCard** copies
+a real `.vcf` file: press Ctrl+V directly in an app that supports pasting files,
+such as a file manager or an email attachment editor. Clipboard-history menus
+may retain only text and images, so selecting that entry again may lose its
+file type. Support for file pasting depends on the receiving app.
+
+**Save vCard…** lets you choose Downloads or another folder. It saves a named
+`.vcf` you can attach, drag, or keep; existing files are preserved by adding a
+number to the new filename. Neither action changes the contact on the Mac.

--- a/README.md
+++ b/README.md
@@ -708,6 +708,9 @@ such as a file manager or an email attachment editor. Clipboard-history menus
 may retain only text and images, so selecting that entry again may lose its
 file type. Support for file pasting depends on the receiving app.
 
+**Copy vCard** and **Save vCard…** name the file with the contact’s nickname,
+or first name when no nickname is set (for example, `Ex.vcf`).
+
 **Save vCard…** lets you choose Downloads or another folder. It saves a named
 `.vcf` you can attach, drag, or keep; existing files are preserved by adding a
 number to the new filename. Neither action changes the contact on the Mac.

--- a/bridge/mac/contact-repair.js
+++ b/bridge/mac/contact-repair.js
@@ -1,10 +1,10 @@
 #!/usr/bin/osascript -l JavaScript
 /*
- * Read-only Contacts availability check for Blip.
+ * Read-only Contacts availability and exact-card vCard export for Blip.
  *
  * The Python bridge sends one bounded JSON request on stdin. Raw Contacts
  * identifiers never appear in argv, and this helper emits a small JSON
- * result only. Its single operation answers which person ids the object
+ * result only. Its availability operation answers which person ids the object
  * layer can actually address — raw per-account databases can retain
  * inactive cache rows. It mutates nothing.
  */
@@ -36,7 +36,7 @@ function readRequest() {
 }
 
 function normalizeRequest(value) {
-  if (value.operation !== "available") throw new Error("repair operation is invalid");
+  if (["available", "vcard"].indexOf(value.operation) < 0) throw new Error("repair operation is invalid");
   if (!Array.isArray(value.personUids) || value.personUids.length < 1
       || value.personUids.length > MAX_PERSON_IDS)
     throw new Error("person id list is invalid");
@@ -47,7 +47,15 @@ function normalizeRequest(value) {
     seen[normalized] = true;
     return normalized;
   });
-  return { operation: "available", personUids: personUids };
+  if (value.operation === "vcard" && personUids.length !== 1) throw new Error("vCard requires one exact card");
+  return { operation: value.operation, personUids: personUids };
+}
+
+function exportPerson(person) {
+  const data = person.vCardRepresentation;
+  if (!data || Number(data.length) < 1 || Number(data.length) > 2 * 1024 * 1024)
+    throw new Error("The contact vCard is too large to copy");
+  return String(ObjC.unwrap(data.base64EncodedStringWithOptions(0)));
 }
 
 function perform(request) {
@@ -55,6 +63,11 @@ function perform(request) {
   // raw per-account databases can retain inactive cache rows.
   ObjC.import("AddressBook");
   const book = $.ABAddressBook.sharedAddressBook;
+  if (request.operation === "vcard") {
+    const person = book.recordForUniqueId($(request.personUids[0]));
+    if (!ObjC.unwrap(person)) throw new Error("This contact card is no longer available");
+    return {ok: true, vcard: exportPerson(person)};
+  }
   const available = request.personUids.filter(function(uid) {
     try {
       const person = book.recordForUniqueId($(uid));
@@ -69,9 +82,11 @@ function perform(request) {
 
 function run() {
   try {
-    const result = perform(normalizeRequest(readRequest()));
+    const request = normalizeRequest(readRequest());
+    const result = perform(request);
+    const maximum = request.operation === "vcard" ? 3 * 1024 * 1024 : MAX_OUTPUT_BYTES;
     const output = JSON.stringify(result);
-    if ($.NSString.alloc.initWithUTF8String(output).lengthOfBytesUsingEncoding($.NSUTF8StringEncoding) > MAX_OUTPUT_BYTES)
+    if ($.NSString.alloc.initWithUTF8String(output).lengthOfBytesUsingEncoding($.NSUTF8StringEncoding) > maximum)
       throw new Error("repair response is too large");
     return output;
   } catch (error) {

--- a/bridge/mac/contacts
+++ b/bridge/mac/contacts
@@ -581,7 +581,7 @@ def run_bounded_process(
         process.stderr.close()
 
 
-def run_contact_repair(request: dict) -> dict:
+def run_contact_repair(request: dict, output_limit: int = MAX_REPAIR_PROCESS_BYTES) -> dict:
     script = os.path.join(os.path.dirname(os.path.realpath(__file__)), "contact-repair.js")
     info = os.lstat(script)
     if not stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode) or info.st_uid != os.getuid():
@@ -590,7 +590,7 @@ def run_contact_repair(request: dict) -> dict:
     if len(payload) > MAX_REPAIR_INPUT_BYTES:
         raise RuntimeError("Contacts repair request is too large")
     code, stdout, stderr = run_bounded_process(
-        ["/usr/bin/osascript", "-l", "JavaScript", script], payload
+        ["/usr/bin/osascript", "-l", "JavaScript", script], payload, output_limit=output_limit
     )
     try:
         response = json.loads(stdout.decode("utf-8"))
@@ -644,6 +644,15 @@ def _cmd_resolve(args):
         emit_resolve({"ok": True, "fingerprint": fingerprint,
                       **audit_contact_handles(request.get("handles"))})
         return
+    if operation == "vcard":
+        original, _, candidate, record, _, _ = selected_card(request.get("handle"), request.get("token"))
+        response = run_contact_repair({"operation": "vcard", "personUids": [record["uid"]]}, 3 * 1024 * 1024)
+        encoded = response.get("vcard")
+        if not isinstance(encoded, str) or not encoded or len(encoded) > 3 * 1024 * 1024:
+            raise RuntimeError("Contacts returned an invalid vCard")
+        emit_resolve({"ok": True, "handle": original, "token": request["token"],
+                      "name": candidate["name"], "vcard": encoded}, 3 * 1024 * 1024)
+        return
     if operation == "open":
         _, _, selected, selected_record, selected_card_number, selected_account_number = selected_card(
             request.get("handle"), request.get("token")
@@ -666,7 +675,7 @@ def _cmd_resolve(args):
         })
         return
     raise ValueError(
-        "operation must be candidates, fingerprint, audit, or open"
+        "operation must be candidates, fingerprint, audit, vcard, or open"
     )
 
 

--- a/bridge/mac/contacts_test.py
+++ b/bridge/mac/contacts_test.py
@@ -264,5 +264,20 @@ class SourceOrderTests(unittest.TestCase):
         ])
 
 
+class ContactVcardTests(unittest.TestCase):
+    def test_export_requires_exact_card_and_bounds_response(self):
+        token = "sha256:" + "a" * 64
+        selected = ("+15551234567", "key", {"name": "Example Person"}, {"uid": "synthetic-card"}, 1, 1)
+        with mock.patch.object(contacts, "read_resolve_request", return_value={"operation": "vcard", "handle": "+15551234567", "token": token}), \
+             mock.patch.object(contacts, "selected_card", return_value=selected) as resolve, \
+             mock.patch.object(contacts, "run_contact_repair", return_value={"ok": True, "vcard": "YWJj"}) as export, \
+             mock.patch.object(contacts, "emit_resolve") as emit:
+            contacts._cmd_resolve(None)
+        resolve.assert_called_once_with("+15551234567", token)
+        export.assert_called_once_with({"operation": "vcard", "personUids": ["synthetic-card"]}, 3 * 1024 * 1024)
+        self.assertEqual(emit.call_args.args[1], 3 * 1024 * 1024)
+        self.assertEqual(emit.call_args.args[0]["token"], token)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/contact-vcard.test.ts
+++ b/contact-vcard.test.ts
@@ -1,10 +1,10 @@
 import {test,expect} from 'bun:test';
-import {mkdtempSync,rmSync,mkdirSync,symlinkSync,readdirSync,readFileSync,statSync} from 'node:fs';
+import {mkdtempSync,rmSync,mkdirSync,symlinkSync,readdirSync,readFileSync,statSync,writeFileSync,utimesSync} from 'node:fs';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {join,basename,dirname} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {vcardBytes,writeVcard,copyContactVcard,vcardFileName,saveVcardInFolder,exportContactVcard} from './contact-vcard';
-const card=Buffer.from('BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Example Person\r\nEND:VCARD\r\n');
+import {vcardBytes,writeVcard,copyContactVcard,vcardFileName,saveVcardInFolder,exportContactVcard,vcardShortName} from './contact-vcard';
+const card=Buffer.from('BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Example Person\r\nN:Person;Example;;;\r\nNICKNAME:Ex\r\nEND:VCARD\r\n');
 const token='sha256:'+'a'.repeat(64), handle='+15551234567';
 const body={ok:true,token,handle,vcard:card.toString('base64')};
 test('validates exact-card identity and bounded canonical vCard bytes',()=>{
@@ -28,6 +28,8 @@ test('copies a runtime file through clipboard stdin and reports failure honestly
     expect(calls[1].input.endsWith('\r\n')).toBe(true);
     const uri=calls[1].input.trim(),path=fileURLToPath(uri);
     expect(readFileSync(path)).toEqual(card);
+    expect(basename(path)).toBe('Ex.vcf');
+    expect(statSync(dirname(path)).mode&0o777).toBe(0o700);
     expect(statSync(path).mode&0o777).toBe(0o600);
     expect(()=>copyContactVcard({handle,token},((command:string)=>({status:command.endsWith('/contacts')?0:1,stdout:JSON.stringify(body)})) as any,dir)).toThrow('clipboard');
   } finally {rmSync(dir,{recursive:true,force:true});}
@@ -83,12 +85,56 @@ test('save uses the chosen folder and leaves the clipboard alone; cancellation w
     expect(readdirSync(dir)).toHaveLength(0);
     cancelled=false;
     expect(exportContactVcard({handle,token,action:'save'},runner).view).toBe('saved');
-    expect(readFileSync(join(dir,'Example Person.vcf'))).toEqual(card);
+    expect(readFileSync(join(dir,'Ex.vcf'))).toEqual(card);
     const picker=calls.find(call=>call.command.endsWith('/zenity'));
     expect(picker.args).toContain('--filename='+dir+'/');
     expect(picker.options.maxBuffer).toBe(4097);
     expect(picker.options.timeout).toBe(300000);
     expect(calls.some(call=>call.command.endsWith('/wl-copy'))).toBe(false);
     expect(()=>exportContactVcard({handle,token,action:'invalid'},runner)).toThrow('action');
+  } finally {rmSync(dir,{recursive:true,force:true});}
+});
+
+
+test('uses nickname, then structured first name, without shortening compound names',()=>{
+  const withFields=(fields:string)=>Buffer.from('BEGIN:VCARD\r\nVERSION:3.0\r\n'+fields+'\r\nEND:VCARD\r\n');
+  expect(vcardShortName(card,'Example Person')).toBe('Ex');
+  expect(vcardShortName(withFields('N:Person;Example Person;;;'))).toBe('Example Person');
+  expect(vcardShortName(withFields('N:Person;Example \r\n Person;;;'))).toBe('Example Person');
+  expect(vcardShortName(withFields('N:Person;;;;'))).toBe('Person');
+  expect(vcardShortName(withFields('NICKNAME:Ex\\, Jr,Other'))).toBe('Ex, Jr');
+  expect(vcardShortName(withFields('NICKNAME:   \r\nN:Person;Example;;;'))).toBe('Example');
+  expect(vcardShortName(withFields('FN:Example Organization'),'Example Organization')).toBe('Example Organization');
+  expect(vcardShortName(withFields('FN:'),null)).toBe('Contact');
+});
+test('repeated copies retain the same short filename without replacing earlier exports',()=>{
+  const dir=mkdtempSync(join(tmpdir(),'blip-short-vcard-'));
+  try {
+    const first=fileURLToPath(writeVcard(card,dir,'Ex'));
+    const next=fileURLToPath(writeVcard(Buffer.from('different synthetic bytes'),dir,'Ex'));
+    expect(basename(first)).toBe('Ex.vcf');
+    expect(basename(next)).toBe('Ex.vcf');
+    expect(dirname(first)).not.toBe(dirname(next));
+    expect(readFileSync(first)).toEqual(card);
+    const old=join(dir,'blip','vcards','contact-'+'a'.repeat(32)+'.vcf');
+    writeFileSync(old,card,{mode:0o600});utimesSync(old,0,0);
+    utimesSync(dirname(first),0,0);
+    writeVcard(card,dir,'Ex');
+    expect(()=>statSync(old)).toThrow();
+    expect(()=>statSync(dirname(first))).toThrow();
+    expect(readFileSync(next)).toEqual(Buffer.from('different synthetic bytes'));
+  } finally {rmSync(dir,{recursive:true,force:true});}
+});
+test('runtime cleanup refuses unexpected contents in a copy directory',()=>{
+  const dir=mkdtempSync(join(tmpdir(),'blip-copy-cleanup-'));
+  try {
+    const path=fileURLToPath(writeVcard(card,dir,'Ex'));
+    const target=join(dir,'keep.vcf');writeFileSync(target,card);
+    rmSync(path);symlinkSync(target,path);utimesSync(dirname(path),0,0);
+    expect(()=>writeVcard(card,dir,'Ex')).toThrow('Unexpected file');
+    expect(readFileSync(target)).toEqual(card);
+    rmSync(path);writeFileSync(path,card);writeFileSync(join(dirname(path),'extra.vcf'),card);utimesSync(dirname(path),0,0);
+    expect(()=>writeVcard(card,dir,'Ex')).toThrow('Too many files');
+    expect(readFileSync(path)).toEqual(card);
   } finally {rmSync(dir,{recursive:true,force:true});}
 });

--- a/contact-vcard.test.ts
+++ b/contact-vcard.test.ts
@@ -3,7 +3,7 @@ import {mkdtempSync,rmSync,mkdirSync,symlinkSync,readdirSync,readFileSync,statSy
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {vcardBytes,writeVcard,copyContactVcard} from './contact-vcard';
+import {vcardBytes,writeVcard,copyContactVcard,vcardFileName,saveVcardInFolder,exportContactVcard} from './contact-vcard';
 const card=Buffer.from('BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Example Person\r\nEND:VCARD\r\n');
 const token='sha256:'+'a'.repeat(64), handle='+15551234567';
 const body={ok:true,token,handle,vcard:card.toString('base64')};
@@ -42,4 +42,53 @@ test('rejects symlink directories and keeps at most 32 prior clipboard files',()
     expect(readdirSync(join(dir,'blip','vcards'))).toHaveLength(32);
     expect(()=>writeVcard(card,'relative')).toThrow('runtime');
   } finally {rmSync(dir,{recursive:true,force:true});rmSync(target,{recursive:true,force:true});}
+});
+
+test('saves a named private vCard without replacing existing files or links',()=>{
+  const dir=mkdtempSync(join(tmpdir(),'blip-save-vcard-'));
+  try {
+    const first=saveVcardInFolder(card,dir,'Example Person');
+    expect(first).toBe(join(dir,'Example Person.vcf'));
+    expect(readFileSync(first)).toEqual(card);
+    expect(statSync(first).mode&0o777).toBe(0o600);
+    symlinkSync(first,join(dir,'Example Person (2).vcf'));
+    const next=saveVcardInFolder(Buffer.from('different synthetic bytes'),dir,'Example Person');
+    expect(next).toBe(join(dir,'Example Person (3).vcf'));
+    expect(readFileSync(first)).toEqual(card);
+    expect(readdirSync(dir).some(name=>name.startsWith('.blip-'))).toBe(false);
+    expect(()=>saveVcardInFolder(card,'relative','Person')).toThrow('folder');
+    expect(()=>saveVcardInFolder(Buffer.alloc(2*1024*1024+1),dir,'Person')).toThrow('large');
+  } finally {rmSync(dir,{recursive:true,force:true});}
+});
+test('suggested vCard names are bounded basenames',()=>{
+  expect(vcardFileName('Example Person')).toBe('Example Person.vcf');
+  expect(vcardFileName('../Example/Person\n\u202e')).toBe('Example Person.vcf');
+  expect(vcardFileName(null)).toBe('Contact.vcf');
+  expect(vcardFileName('x'.repeat(161))).toBe('Contact.vcf');
+  expect(Buffer.byteLength(vcardFileName('界'.repeat(100)))).toBeLessThanOrEqual(124);
+});
+test('save uses the chosen folder and leaves the clipboard alone; cancellation writes nothing',()=>{
+  const dir=mkdtempSync(join(tmpdir(),'blip-save-picker-'));
+  try {
+    let cancelled=true;
+    const calls:any[]=[];
+    const runner=((command:string,args:string[],options:any)=>{
+      calls.push({command,args,options});
+      if(command.endsWith('/contacts')) return {status:0,stdout:JSON.stringify({...body,name:'Example Person'})};
+      if(command.endsWith('/xdg-user-dir')) return {status:0,stdout:dir+'\n'};
+      if(command.endsWith('/zenity')) return {status:cancelled?1:0,stdout:dir+'\n'};
+      throw new Error('Unexpected command');
+    }) as any;
+    expect(exportContactVcard({handle,token,action:'save'},runner).view).toBe('cancelled');
+    expect(readdirSync(dir)).toHaveLength(0);
+    cancelled=false;
+    expect(exportContactVcard({handle,token,action:'save'},runner).view).toBe('saved');
+    expect(readFileSync(join(dir,'Example Person.vcf'))).toEqual(card);
+    const picker=calls.find(call=>call.command.endsWith('/zenity'));
+    expect(picker.args).toContain('--filename='+dir+'/');
+    expect(picker.options.maxBuffer).toBe(4097);
+    expect(picker.options.timeout).toBe(300000);
+    expect(calls.some(call=>call.command.endsWith('/wl-copy'))).toBe(false);
+    expect(()=>exportContactVcard({handle,token,action:'invalid'},runner)).toThrow('action');
+  } finally {rmSync(dir,{recursive:true,force:true});}
 });

--- a/contact-vcard.test.ts
+++ b/contact-vcard.test.ts
@@ -24,8 +24,9 @@ test('copies a runtime file through clipboard stdin and reports failure honestly
     expect(copyContactVcard({handle,token},runner,dir).view).toBe('copied');
     expect(calls[0].args).toEqual(['--json','resolve']);
     expect(JSON.parse(calls[0].input)).toEqual({operation:'vcard',handle,token});
-    expect(calls[1].args).toEqual(['--type','x-special/gnome-copied-files']);
-    const uri=calls[1].input.split('\n')[1],path=fileURLToPath(uri);
+    expect(calls[1].args).toEqual(['--type','text/uri-list']);
+    expect(calls[1].input.endsWith('\r\n')).toBe(true);
+    const uri=calls[1].input.trim(),path=fileURLToPath(uri);
     expect(readFileSync(path)).toEqual(card);
     expect(statSync(path).mode&0o777).toBe(0o600);
     expect(()=>copyContactVcard({handle,token},((command:string)=>({status:command.endsWith('/contacts')?0:1,stdout:JSON.stringify(body)})) as any,dir)).toThrow('clipboard');

--- a/contact-vcard.test.ts
+++ b/contact-vcard.test.ts
@@ -1,0 +1,44 @@
+import {test,expect} from 'bun:test';
+import {mkdtempSync,rmSync,mkdirSync,symlinkSync,readdirSync,readFileSync,statSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {vcardBytes,writeVcard,copyContactVcard} from './contact-vcard';
+const card=Buffer.from('BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Example Person\r\nEND:VCARD\r\n');
+const token='sha256:'+'a'.repeat(64), handle='+15551234567';
+const body={ok:true,token,handle,vcard:card.toString('base64')};
+test('validates exact-card identity and bounded canonical vCard bytes',()=>{
+  expect(vcardBytes(body,handle,token)).toEqual(card);
+  for(const value of [null,{...body,token:'bad'},{...body,handle:'+15551234568'},
+    {...body,vcard:'!!!!'}, {...body,vcard:Buffer.from('BEGIN:VCARD\r\ntruncated').toString('base64')},
+    {...body,vcard:'A'.repeat(3*1024*1024+4)}]) expect(()=>vcardBytes(value,handle,token)).toThrow();
+});
+test('copies a runtime file through clipboard stdin and reports failure honestly',()=>{
+  const dir=mkdtempSync(join(tmpdir(),'blip-vcard-'));
+  try {
+    const calls:any[]=[];
+    const runner=((command:string,args:string[],options:any)=>{
+      calls.push({command,args,input:options.input});
+      return {status:0,stdout:command.endsWith('/contacts')?JSON.stringify(body):''};
+    }) as any;
+    expect(copyContactVcard({handle,token},runner,dir).view).toBe('copied');
+    expect(calls[0].args).toEqual(['--json','resolve']);
+    expect(JSON.parse(calls[0].input)).toEqual({operation:'vcard',handle,token});
+    expect(calls[1].args).toEqual(['--type','x-special/gnome-copied-files']);
+    const uri=calls[1].input.split('\n')[1],path=fileURLToPath(uri);
+    expect(readFileSync(path)).toEqual(card);
+    expect(statSync(path).mode&0o777).toBe(0o600);
+    expect(()=>copyContactVcard({handle,token},((command:string)=>({status:command.endsWith('/contacts')?0:1,stdout:JSON.stringify(body)})) as any,dir)).toThrow('clipboard');
+  } finally {rmSync(dir,{recursive:true,force:true});}
+});
+test('rejects symlink directories and keeps at most 32 prior clipboard files',()=>{
+  const dir=mkdtempSync(join(tmpdir(),'blip-vcard-')),target=mkdtempSync(join(tmpdir(),'blip-vcard-target-'));
+  try {
+    symlinkSync(target,join(dir,'blip'));
+    expect(()=>writeVcard(card,dir)).toThrow();
+    rmSync(join(dir,'blip'));
+    for(let i=0;i<34;i++) writeVcard(card,dir);
+    expect(readdirSync(join(dir,'blip','vcards'))).toHaveLength(32);
+    expect(()=>writeVcard(card,'relative')).toThrow('runtime');
+  } finally {rmSync(dir,{recursive:true,force:true});rmSync(target,{recursive:true,force:true});}
+});

--- a/contact-vcard.ts
+++ b/contact-vcard.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/** Copy an explicitly selected source card as a private runtime .vcf file.
+ * Adapted from contact-management's vCard export; no Contacts writes. */
+import {spawnSync} from 'node:child_process';
+import {randomBytes} from 'node:crypto';
+import {closeSync,constants,fstatSync,openSync,writeSync,mkdirSync,opendirSync,lstatSync,unlinkSync} from 'node:fs';
+import {join,isAbsolute} from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {homedir} from 'node:os';
+import {normalizeHandle,identityKey,readStdinBounded} from './contact-review';
+const MAX_CARD_BYTES=2*1024*1024, MAX_RESPONSE_BYTES=3*1024*1024;
+const TOKEN=/^sha256:[0-9a-f]{64}$/;
+const FILE=/^contact-[0-9a-f]{32}\.vcf$/;
+export function vcardBytes(body:any,handle:string,token:string): Buffer {
+  if (!body || body.ok!==true || identityKey(body.handle)!==identityKey(handle) || body.token!==token)
+    throw new Error('Contacts did not return the selected card');
+  if (typeof body.vcard!=='string' || body.vcard.length>MAX_RESPONSE_BYTES
+    || (body.vcard.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(body.vcard)))
+    throw new Error('Invalid contact vCard');
+  const bytes=Buffer.from(body.vcard,'base64');
+  if (bytes.toString('base64') !== body.vcard || !bytes.length || bytes.length>MAX_CARD_BYTES || !bytes.toString('utf8').startsWith('BEGIN:VCARD\r\n')
+    || !bytes.toString('utf8').trimEnd().endsWith('END:VCARD')) throw new Error('Invalid contact vCard');
+  return bytes;
+}
+function directory(path:string): number {
+  const fd=openSync(path,constants.O_RDONLY|constants.O_DIRECTORY|constants.O_NOFOLLOW|constants.O_NONBLOCK);
+  const st=fstatSync(fd);
+  if (!st.isDirectory() || st.uid!==process.getuid!() || (st.mode&0o077)!==0) {
+    closeSync(fd); throw new Error('Unsafe vCard runtime directory');
+  }
+  return fd;
+}
+export function writeVcard(bytes:Buffer,runtimeRoot:string): string {
+  if (!isAbsolute(runtimeRoot)) throw new Error('A private runtime directory is required');
+  if (bytes.length>MAX_CARD_BYTES) throw new Error('Contact vCard is too large');
+  let parent=directory(runtimeRoot);
+  try {
+    for(const component of ['blip','vcards']) {
+      const pinned=`/proc/self/fd/${parent}/${component}`;
+      try {mkdirSync(pinned,{mode:0o700});} catch(e:any) {if(e.code!=='EEXIST') throw e;}
+      const child=directory(pinned); closeSync(parent); parent=child;
+    }
+    const root=`/proc/self/fd/${parent}`;
+    const entries: string[]=[];
+    const listing=opendirSync(root,{bufferSize:32});
+    try {
+      let entry;
+      while((entry=listing.readSync())!==null) {
+        if(entries.length===256) throw new Error('Too many files in the vCard cache');
+        entries.push(entry.name);
+      }
+    } finally {listing.closeSync();}
+    const copies=entries.filter(name=>FILE.test(name)).map(name=>({name,stat:lstatSync(join(root,name))}))
+      .filter(file=>file.stat.isFile()).sort((a,b)=>b.stat.mtimeMs-a.stat.mtimeMs);
+    for(const [index,file] of copies.entries()) {
+      if(index>=31 || Date.now()-file.stat.mtimeMs>24*60*60*1000) unlinkSync(join(root,file.name));
+    }
+    const name='contact-'+randomBytes(16).toString('hex')+'.vcf';
+    const fd=openSync(join(root,name),constants.O_WRONLY|constants.O_CREAT|constants.O_EXCL|constants.O_NOFOLLOW,0o600);
+    try {let written=0;while(written<bytes.length) written+=writeSync(fd,bytes,written,bytes.length-written);} finally {closeSync(fd);}
+    return pathToFileURL(join(runtimeRoot,'blip','vcards',name)).href;
+  } finally {closeSync(parent);}
+}
+export function copyContactVcard(request:any,runner=spawnSync,runtimeRoot=process.env.XDG_RUNTIME_DIR || '') {
+  const handle=normalizeHandle(request?.handle),token=request?.token;
+  if(typeof token!=='string' || !TOKEN.test(token)) throw new Error('Invalid contact card token');
+  const result=runner(join(process.env.HOME??homedir(),'bin','contacts'),['--json','resolve'], {
+    encoding:'utf8',input:JSON.stringify({operation:'vcard',handle,token}),timeout:35000,maxBuffer:MAX_RESPONSE_BYTES,
+  });
+  if(result.error || result.status!==0) throw new Error('Could not export the contact vCard');
+  const output=String(result.stdout||'');
+  if(Buffer.byteLength(output)>MAX_RESPONSE_BYTES) throw new Error('Contact vCard response is too large');
+  let body:any;try {body=JSON.parse(output);} catch {throw new Error('Invalid contact vCard response');}
+  const uri=writeVcard(vcardBytes(body,handle,token),runtimeRoot);
+  const copied=runner('/usr/bin/wl-copy',['--type','x-special/gnome-copied-files'], {
+    input:'copy\n'+uri+'\n',encoding:'utf8',timeout:5000,maxBuffer:1024,
+  });
+  if(copied.error || copied.status!==0) throw new Error('Could not copy the vCard to the clipboard');
+  return {ok:true,view:'copied',title:'Contact review',detail:'Copied vCard — paste it as a contact file',rows:[]};
+}
+if(import.meta.main) {
+  const timer=setTimeout(()=>{process.stdout.write('{"ok":false,"error":"Contact request timed out"}\n');process.exit(1);},5000);
+  try {
+    const request=JSON.parse(await readStdinBounded()); clearTimeout(timer);
+    process.stdout.write(JSON.stringify(copyContactVcard(request))+'\n');
+  }
+  catch(error) {
+    clearTimeout(timer);
+    const message=String(error instanceof Error?error.message:error).replace(/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/g,' ').slice(0,180);
+    process.stdout.write(JSON.stringify({ok:false,error:message})+'\n');process.exitCode=1;
+  }
+}

--- a/contact-vcard.ts
+++ b/contact-vcard.ts
@@ -72,8 +72,8 @@ export function copyContactVcard(request:any,runner=spawnSync,runtimeRoot=proces
   if(Buffer.byteLength(output)>MAX_RESPONSE_BYTES) throw new Error('Contact vCard response is too large');
   let body:any;try {body=JSON.parse(output);} catch {throw new Error('Invalid contact vCard response');}
   const uri=writeVcard(vcardBytes(body,handle,token),runtimeRoot);
-  const copied=runner('/usr/bin/wl-copy',['--type','x-special/gnome-copied-files'], {
-    input:'copy\n'+uri+'\n',encoding:'utf8',timeout:5000,maxBuffer:1024,
+  const copied=runner('/usr/bin/wl-copy',['--type','text/uri-list'], {
+    input:uri+'\r\n',encoding:'utf8',timeout:5000,maxBuffer:1024,
   });
   if(copied.error || copied.status!==0) throw new Error('Could not copy the vCard to the clipboard');
   return {ok:true,view:'copied',title:'Contact review',detail:'Copied vCard — paste it as a contact file',rows:[]};

--- a/contact-vcard.ts
+++ b/contact-vcard.ts
@@ -3,7 +3,7 @@
  * Adapted from contact-management's vCard export; no Contacts writes. */
 import {spawnSync} from 'node:child_process';
 import {randomBytes} from 'node:crypto';
-import {closeSync,constants,fstatSync,openSync,writeSync,mkdirSync,opendirSync,lstatSync,unlinkSync,linkSync,fsyncSync,realpathSync} from 'node:fs';
+import {closeSync,constants,fstatSync,openSync,writeSync,mkdirSync,opendirSync,lstatSync,unlinkSync,rmdirSync,linkSync,fsyncSync,realpathSync} from 'node:fs';
 import {join,isAbsolute,basename} from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {homedir} from 'node:os';
@@ -11,6 +11,7 @@ import {normalizeHandle,identityKey,readStdinBounded} from './contact-review';
 const MAX_CARD_BYTES=2*1024*1024, MAX_RESPONSE_BYTES=3*1024*1024;
 const TOKEN=/^sha256:[0-9a-f]{64}$/;
 const FILE=/^contact-[0-9a-f]{32}\.vcf$/;
+const COPY=/^copy-[0-9a-f]{32}$/;
 export function vcardBytes(body:any,handle:string,token:string): Buffer {
   if (!body || body.ok!==true || identityKey(body.handle)!==identityKey(handle) || body.token!==token)
     throw new Error('Contacts did not return the selected card');
@@ -30,7 +31,30 @@ function directory(path:string): number {
   }
   return fd;
 }
-export function writeVcard(bytes:Buffer,runtimeRoot:string): string {
+function entries(path:string,maximum:number):string[] {
+  const names:string[]=[],listing=opendirSync(path,{bufferSize:32});
+  try {
+    let entry;while((entry=listing.readSync())!==null) {
+      if(names.length===maximum) throw new Error('Too many files in the vCard cache');
+      names.push(entry.name);
+    }
+  } finally {listing.closeSync();}
+  return names;
+}
+function removeCopy(root:string,name:string) {
+  const child=directory(join(root,name));
+  try {
+    const pinned=`/proc/self/fd/${child}`;
+    for(const file of entries(pinned,1)) {
+      const st=lstatSync(join(pinned,file));
+      if(!file.endsWith('.vcf') || vcardFileName(file.slice(0,-4))!==file
+        || !st.isFile() || st.uid!==process.getuid!()) throw new Error('Unexpected file in the vCard cache');
+      unlinkSync(join(pinned,file));
+    }
+    rmdirSync(join(root,name));
+  } finally {closeSync(child);}
+}
+export function writeVcard(bytes:Buffer,runtimeRoot:string,shortName:unknown='Contact'): string {
   if (!isAbsolute(runtimeRoot)) throw new Error('A private runtime directory is required');
   if (bytes.length>MAX_CARD_BYTES) throw new Error('Contact vCard is too large');
   let parent=directory(runtimeRoot);
@@ -41,24 +65,24 @@ export function writeVcard(bytes:Buffer,runtimeRoot:string): string {
       const child=directory(pinned); closeSync(parent); parent=child;
     }
     const root=`/proc/self/fd/${parent}`;
-    const entries: string[]=[];
-    const listing=opendirSync(root,{bufferSize:32});
-    try {
-      let entry;
-      while((entry=listing.readSync())!==null) {
-        if(entries.length===256) throw new Error('Too many files in the vCard cache');
-        entries.push(entry.name);
-      }
-    } finally {listing.closeSync();}
-    const copies=entries.filter(name=>FILE.test(name)).map(name=>({name,stat:lstatSync(join(root,name))}))
-      .filter(file=>file.stat.isFile()).sort((a,b)=>b.stat.mtimeMs-a.stat.mtimeMs);
+    const copies=entries(root,256).filter(name=>FILE.test(name) || COPY.test(name))
+      .map(name=>({name,stat:lstatSync(join(root,name))}))
+      .filter(file=>(FILE.test(file.name) ? file.stat.isFile() : file.stat.isDirectory()) && file.stat.uid===process.getuid!())
+      .sort((a,b)=>b.stat.mtimeMs-a.stat.mtimeMs);
     for(const [index,file] of copies.entries()) {
-      if(index>=31 || Date.now()-file.stat.mtimeMs>24*60*60*1000) unlinkSync(join(root,file.name));
+      if(index>=31 || Date.now()-file.stat.mtimeMs>24*60*60*1000) {
+        if(FILE.test(file.name)) unlinkSync(join(root,file.name));
+        else removeCopy(root,file.name);
+      }
     }
-    const name='contact-'+randomBytes(16).toString('hex')+'.vcf';
-    const fd=openSync(join(root,name),constants.O_WRONLY|constants.O_CREAT|constants.O_EXCL|constants.O_NOFOLLOW,0o600);
-    try {let written=0;while(written<bytes.length) written+=writeSync(fd,bytes,written,bytes.length-written);} finally {closeSync(fd);}
-    return pathToFileURL(join(runtimeRoot,'blip','vcards',name)).href;
+    const copy='copy-'+randomBytes(16).toString('hex');
+    mkdirSync(join(root,copy),{mode:0o700});
+    const child=directory(join(root,copy)),name=vcardFileName(shortName);
+    try {
+      const fd=openSync(`/proc/self/fd/${child}/${name}`,constants.O_WRONLY|constants.O_CREAT|constants.O_EXCL|constants.O_NOFOLLOW,0o600);
+      try {let written=0;while(written<bytes.length) written+=writeSync(fd,bytes,written,bytes.length-written);} finally {closeSync(fd);}
+    } finally {closeSync(child);}
+    return pathToFileURL(join(runtimeRoot,'blip','vcards',copy,name)).href;
   } finally {closeSync(parent);}
 }
 function fetchContactVcard(request:any,runner:typeof spawnSync) {
@@ -71,16 +95,42 @@ function fetchContactVcard(request:any,runner:typeof spawnSync) {
   const output=String(result.stdout||'');
   if(Buffer.byteLength(output)>MAX_RESPONSE_BYTES) throw new Error('Contact vCard response is too large');
   let body:any;try {body=JSON.parse(output);} catch {throw new Error('Invalid contact vCard response');}
-  return {bytes:vcardBytes(body,handle,token),name:body.name};
+  const bytes=vcardBytes(body,handle,token);
+  return {bytes,name:vcardShortName(bytes,body.name)};
 }
 export function copyContactVcard(request:any,runner=spawnSync,runtimeRoot=process.env.XDG_RUNTIME_DIR || '') {
-  const {bytes}=fetchContactVcard(request,runner);
-  const uri=writeVcard(bytes,runtimeRoot);
+  const {bytes,name}=fetchContactVcard(request,runner);
+  const uri=writeVcard(bytes,runtimeRoot,name);
   const copied=runner('/usr/bin/wl-copy',['--type','text/uri-list'], {
     input:uri+'\r\n',encoding:'utf8',timeout:5000,maxBuffer:1024,
   });
   if(copied.error || copied.status!==0) throw new Error('Could not copy the vCard to the clipboard');
   return {ok:true,view:'copied',title:'Contact review',detail:'Copied vCard — paste it as a contact file',rows:[]};
+}
+/** Read only the short-name fields from Apple's bounded vCard text. */
+export function vcardShortName(bytes:Buffer,fallback:unknown='Contact'):string {
+  if(bytes.length>MAX_CARD_BYTES) throw new Error('Contact vCard is too large');
+  const names:Record<string,string[]>={};
+  for(const line of bytes.toString('utf8').replace(/\r?\n[ \t]/g,'').split(/\r?\n/)) {
+    const match=/^(?:[a-z0-9-]+\.)?(NICKNAME|N)(?:;[^:]*)?:(.*)$/i.exec(line);
+    if(!match || match[2].length>1024) continue;
+    const key=match[1].toUpperCase(),separator=key==='N'?';':',';
+    const parts=[''];
+    for(let i=0;i<match[2].length;i++) {
+      const ch=match[2][i];
+      if(ch==='\\' && i+1<match[2].length) {
+        const next=match[2][++i];parts[parts.length-1]+=/[nN]/.test(next)?' ':next;
+      } else if(ch===separator) parts.push('');
+      else parts[parts.length-1]+=ch;
+    }
+    if(!names[key]) names[key]=parts;
+  }
+  for(const value of [names.NICKNAME?.[0],names.N?.[1],names.N?.[0],fallback]) {
+    if(typeof value!=='string' || value.length>160) continue;
+    const clean=value.replace(/[\x00-\x1f\x7f-\x9f\u202a-\u202e\u2066-\u2069]/g,' ').trim();
+    if(clean) return clean;
+  }
+  return 'Contact';
 }
 /** A display name becomes only a suggested basename, never a directory. */
 export function vcardFileName(value:unknown):string {

--- a/contact-vcard.ts
+++ b/contact-vcard.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
-/** Copy an explicitly selected source card as a private runtime .vcf file.
+/** Copy or save an explicitly selected source card as a private .vcf file.
  * Adapted from contact-management's vCard export; no Contacts writes. */
 import {spawnSync} from 'node:child_process';
 import {randomBytes} from 'node:crypto';
-import {closeSync,constants,fstatSync,openSync,writeSync,mkdirSync,opendirSync,lstatSync,unlinkSync} from 'node:fs';
-import {join,isAbsolute} from 'node:path';
+import {closeSync,constants,fstatSync,openSync,writeSync,mkdirSync,opendirSync,lstatSync,unlinkSync,linkSync,fsyncSync,realpathSync} from 'node:fs';
+import {join,isAbsolute,basename} from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {homedir} from 'node:os';
 import {normalizeHandle,identityKey,readStdinBounded} from './contact-review';
@@ -61,7 +61,7 @@ export function writeVcard(bytes:Buffer,runtimeRoot:string): string {
     return pathToFileURL(join(runtimeRoot,'blip','vcards',name)).href;
   } finally {closeSync(parent);}
 }
-export function copyContactVcard(request:any,runner=spawnSync,runtimeRoot=process.env.XDG_RUNTIME_DIR || '') {
+function fetchContactVcard(request:any,runner:typeof spawnSync) {
   const handle=normalizeHandle(request?.handle),token=request?.token;
   if(typeof token!=='string' || !TOKEN.test(token)) throw new Error('Invalid contact card token');
   const result=runner(join(process.env.HOME??homedir(),'bin','contacts'),['--json','resolve'], {
@@ -71,18 +71,84 @@ export function copyContactVcard(request:any,runner=spawnSync,runtimeRoot=proces
   const output=String(result.stdout||'');
   if(Buffer.byteLength(output)>MAX_RESPONSE_BYTES) throw new Error('Contact vCard response is too large');
   let body:any;try {body=JSON.parse(output);} catch {throw new Error('Invalid contact vCard response');}
-  const uri=writeVcard(vcardBytes(body,handle,token),runtimeRoot);
+  return {bytes:vcardBytes(body,handle,token),name:body.name};
+}
+export function copyContactVcard(request:any,runner=spawnSync,runtimeRoot=process.env.XDG_RUNTIME_DIR || '') {
+  const {bytes}=fetchContactVcard(request,runner);
+  const uri=writeVcard(bytes,runtimeRoot);
   const copied=runner('/usr/bin/wl-copy',['--type','text/uri-list'], {
     input:uri+'\r\n',encoding:'utf8',timeout:5000,maxBuffer:1024,
   });
   if(copied.error || copied.status!==0) throw new Error('Could not copy the vCard to the clipboard');
   return {ok:true,view:'copied',title:'Contact review',detail:'Copied vCard — paste it as a contact file',rows:[]};
 }
+/** A display name becomes only a suggested basename, never a directory. */
+export function vcardFileName(value:unknown):string {
+  let name=typeof value==='string' && value.length<=160 ? value : '';
+  name=name.replace(/[^\p{L}\p{N} _.-]/gu,' ').replace(/\s+/g,' ').replace(/^\.+/,'').trim();
+  while(Buffer.byteLength(name)>120) name=Array.from(name).slice(0,-1).join('');
+  return (name.trim() || 'Contact')+'.vcf';
+}
+/** Pin the chosen folder; create privately and publish without replacing files. */
+export function saveVcardInFolder(bytes:Buffer,folder:string,name:unknown):string {
+  if(typeof folder!=='string' || folder.length>4096 || !isAbsolute(folder) || /[\x00-\x1f\x7f-\x9f]/.test(folder))
+    throw new Error('Invalid destination folder');
+  if(!bytes.length || bytes.length>MAX_CARD_BYTES) throw new Error('Contact vCard is too large');
+  const resolved=realpathSync(folder),flags=constants.O_RDONLY|constants.O_DIRECTORY|constants.O_NOFOLLOW|constants.O_NONBLOCK;
+  let parent=openSync('/',flags);
+  let staging='';
+  try {
+    for(const component of resolved.split('/').filter(Boolean)) {
+      const child=openSync(`/proc/self/fd/${parent}/${component}`,flags);
+      closeSync(parent);parent=child;
+    }
+    if(fstatSync(parent).uid!==process.getuid!()) throw new Error('Choose a folder you own');
+    const root=`/proc/self/fd/${parent}`;
+    const temporary=join(root,'.blip-vcard-'+randomBytes(16).toString('hex'));
+    const fd=openSync(temporary,constants.O_WRONLY|constants.O_CREAT|constants.O_EXCL|constants.O_NOFOLLOW,0o600);
+    staging=temporary;
+    try {
+      let written=0;while(written<bytes.length) written+=writeSync(fd,bytes,written,bytes.length-written);
+      fsyncSync(fd);
+    } finally {closeSync(fd);}
+    const base=vcardFileName(name).slice(0,-4);
+    for(let index=1;index<=100;index++) {
+      const filename=base+(index===1?'':` (${index})`)+'.vcf';
+      try {linkSync(staging,join(root,filename));}
+      catch(error:any) {if(error.code==='EEXIST') continue;throw error;}
+      return join(resolved,filename);
+    }
+    throw new Error('Too many vCards with this name in the selected folder');
+  } finally {
+    try {if(staging) unlinkSync(staging);} finally {closeSync(parent);}
+  }
+}
+export function saveContactVcard(request:any,runner=spawnSync) {
+  const {bytes,name}=fetchContactVcard(request,runner);
+  const downloads=runner('/usr/bin/xdg-user-dir',['DOWNLOAD'],{encoding:'utf8',timeout:2000,maxBuffer:4097});
+  const location=String(downloads.stdout || '').trim();
+  const initial=downloads.status===0 && location.length<=4096 && isAbsolute(location) && !/[\x00-\x1f\x7f-\x9f]/.test(location)
+    ? location : homedir();
+  const choice=runner('/usr/bin/zenity',['--file-selection','--directory','--title=Save vCard to folder',
+    '--filename='+initial+'/'],{encoding:'utf8',timeout:300000,maxBuffer:4097});
+  if(choice.error) throw new Error((choice.error as NodeJS.ErrnoException).code==='ENOENT'
+    ? 'Save vCard requires zenity to choose a folder' : 'The folder picker failed or timed out');
+  if(choice.status===1) return {ok:true,view:'cancelled',title:'Contact review',detail:'Save cancelled',rows:[]};
+  if(choice.status!==0) throw new Error('Could not choose a destination folder');
+  const folder=String(choice.stdout || '').replace(/\r?\n$/,'');
+  const path=saveVcardInFolder(bytes,folder,name);
+  return {ok:true,view:'saved',title:'Contact review',detail:'Saved '+basename(path)+' to the selected folder',rows:[]};
+}
+export function exportContactVcard(request:any,runner=spawnSync,runtimeRoot=process.env.XDG_RUNTIME_DIR || '') {
+  if(request?.action==='save') return saveContactVcard(request,runner);
+  if(request?.action!==undefined && request.action!=='copy') throw new Error('Invalid vCard action');
+  return copyContactVcard(request,runner,runtimeRoot);
+}
 if(import.meta.main) {
   const timer=setTimeout(()=>{process.stdout.write('{"ok":false,"error":"Contact request timed out"}\n');process.exit(1);},5000);
   try {
     const request=JSON.parse(await readStdinBounded()); clearTimeout(timer);
-    process.stdout.write(JSON.stringify(copyContactVcard(request))+'\n');
+    process.stdout.write(JSON.stringify(exportContactVcard(request))+'\n');
   }
   catch(error) {
     clearTimeout(timer);

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -100,8 +100,16 @@ stdin/stdout, never argv, and never pass through the QML model.
 
 An explicit copy creates a private `.vcf` file under
 `$XDG_RUNTIME_DIR/blip/vcards` (directories 0700, files 0600) and places a file
-reference on the clipboard. Runtime directories are pinned and reject links
+reference on the clipboard as `text/uri-list` for native file pasting. Runtime directories are pinned and reject links
 or incorrect ownership/permissions. On each copy, Blip removes its files older
 than 24 hours and retains at most 32 files including the new one. Runtime
 files disappear when the login runtime directory is cleared. This is contact
 export data, not message content; no message text is persisted.
+
+Save vCard opens a folder picker (zenity), starting in the configured Downloads
+folder. The export is saved only after a folder is chosen. The destination
+is pinned, the file is created privately (0600), and publication never replaces
+an existing file or symbolic link; duplicate names receive a numbered suffix.
+Saved files are permanent user exports, outside runtime cleanup. Cancelling
+creates no file and leaves the clipboard unchanged. The folder-picker result
+is capped at 4,097 bytes with a five-minute deadline.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -91,3 +91,17 @@ timestamp when `chat.db` changes; the client then fetches privately.
 
 Send tapbacks, edit or unsend, see typing indicators.
 Those need Apple private APIs that Blip deliberately does not use.
+
+Copy vCard exports only the explicitly selected source card, revalidating its
+opaque token on the Mac. Apple's AddressBook vCard representation supplies the
+file; Blip does not merge or save cards in Contacts. The export is limited to
+2 MiB (3 MiB for the base64 JSON response). Contact bytes travel on bounded
+stdin/stdout, never argv, and never pass through the QML model.
+
+An explicit copy creates a private `.vcf` file under
+`$XDG_RUNTIME_DIR/blip/vcards` (directories 0700, files 0600) and places a file
+reference on the clipboard. Runtime directories are pinned and reject links
+or incorrect ownership/permissions. On each copy, Blip removes its files older
+than 24 hours and retains at most 32 files including the new one. Runtime
+files disappear when the login runtime directory is cleared. This is contact
+export data, not message content; no message text is persisted.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -100,7 +100,11 @@ stdin/stdout, never argv, and never pass through the QML model.
 
 An explicit copy creates a private `.vcf` file under
 `$XDG_RUNTIME_DIR/blip/vcards` (directories 0700, files 0600) and places a file
-reference on the clipboard as `text/uri-list` for native file pasting. Runtime directories are pinned and reject links
+reference on the clipboard as `text/uri-list` for native file pasting. Each
+copy gets a separate random subdirectory, so its basename can remain the
+contact’s short name without replacing a previous export. Short names come
+from the selected vCard’s nickname or given-name fields; card bytes remain
+unchanged. Runtime directories are pinned and reject links
 or incorrect ownership/permissions. On each copy, Blip removes its files older
 than 24 hours and retains at most 32 files including the new one. Runtime
 files disappear when the login runtime directory is cleared. This is contact


### PR DESCRIPTION
Add **Copy vCard** and **Save vCard…** to each matching source card in Contact review. Copy creates a private `.vcf` and offers it as `text/uri-list`, so a browser or file manager can receive a file on Ctrl+V. Save opens a folder picker at Downloads and writes a `.vcf` named after the contact’s short name in the chosen folder, adding a number when that name already exists. Both actions use the selected card’s nickname, then its given name (for example, `Ex.vcf`). Separate private folders let clipboard copies retain that basename without replacing earlier exports. Clipboard-history menus may retain only text and images; use direct paste or the saved file.

This extracts read-only export from #25 using Apple's AddressBook vCard representation, without Swift compilation, write gates, or Contacts mutations. Exact-card tokens are revalidated. Exports stay under 2 MiB and travel over bounded stdin/stdout, never argv or the QML model. Copy files use private runtime storage with bounded retention. Saved files use a pinned destination, private permissions, and publication that cannot overwrite an existing file or link. Cancelling the folder picker writes nothing and preserves the review screen. The optional save action uses zenity; copying needs no new dependency.

Validation: 443 Bun tests and 14 Python bridge tests pass. Tests cover identity validation, bounded vCards, clipboard file format, retention, private permissions, hostile filenames, duplicate/link protection, folder selection, cancellation, short-name parsing, repeated copies, legacy-file cleanup, unexpected cleanup contents, and failures. A synthetic vCard was copied through the real Wayland clipboard and received by Chromium as a `text/vcard` file in its paste event; the previous clipboard image was restored. The buttons and saved notice were inspected at 360px, and the native folder picker was inspected. Native Mac export was verified on an unsaved synthetic contact. No real conversation was opened, no message was sent, and no contact was changed on the Mac.

Based directly on main and independent of #25. Exports preserve the selected source card; merging and editing remain separate.
