### PR TITLE
spell= in bridge.conf picks the spelling dictionaries; off turns them off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 - **Reactions on pictures show.** A message that is only a picture (or a file)
   has no text bubble, and that is where the tapback pill lived, so a reaction
   on a picture was never seen. The pill now sits on the picture or chip itself.
+- **`spell=` in `bridge.conf` picks the spelling dictionaries.** The checker
+  from 2.4.x asked Hunspell for `en_US` only, so a draft in any other language
+  was underlined word for word. `spell=en_US,nb_NO` checks against several at
+  once, `spell=off` turns it off; the default is unchanged.
 
 ## 2.4.0 — 2026-09-08 — read it from the keyboard, send without the wait
 

--- a/README.md
+++ b/README.md
@@ -569,6 +569,10 @@ Misspellings receive red underlines using local Hunspell with an English (US)
 dictionary. Install `hunspell` and `hunspell-en_us` to enable this on Arch, or
 provide `en_US.aff` and `en_US.dic` under
 `$HOME/.local/share/blip/dictionaries/`. No packages are installed automatically.
+`spell=en_US,nb_NO` in `bridge.conf` checks against several dictionaries at
+once — a word found in any of them is fine, which is what a bilingual draft
+needs — and `spell=off` turns the underlines off. Names follow the dictionary
+files (`hunspell -D` lists them); a name that is not installed is skipped.
 Spelling checks debounce for 350 ms, inspect at most 256 words in drafts up to
 8 KiB, and skip URLs and email addresses. Missing dictionaries or checker errors
 leave the draft usable without underlines. Draft text travels only over stdin;

--- a/scripts/blip-setup
+++ b/scripts/blip-setup
@@ -49,7 +49,7 @@ if ! [[ "$host" =~ ^([A-Za-z0-9][A-Za-z0-9._-]*@)?[A-Za-z0-9][A-Za-z0-9._:-]*$ ]
 fi
 
 # 1. config. Keys the installer does not own — push_read, link_previews,
-# ui_font, ui_font_size, anything set by hand — must survive a re-run; a
+# spell, ui_font, ui_font_size, anything set by hand — must survive a re-run; a
 # wholesale rewrite silently re-enabled what the user had turned off (Astra #18).
 kept=""
 [[ -r "$conf" ]] && kept="$(grep -vE '^[[:space:]]*(#|$|host=|remote_bin=|python=|key=|automation=|country_code=)' "$conf" || true)"

--- a/spellcheck.test.ts
+++ b/spellcheck.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'bun:test';
-import { words, misspellings, check, MAX_BYTES } from './spellcheck';
+import { words, misspellings, check, dictionaries, dictionaryArg, MAX_BYTES } from './spellcheck';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 test('ranges use UTF-16 editor offsets and skip links and email',()=> {
  const text = '😀 teh https://example.com/mispell foo@example.com wrng';
  expect(misspellings(text,'teh\nwrng\nexample\n')).toEqual([{start:3,end:6},{start:51,end:55}]);
@@ -8,10 +11,10 @@ test('spelling is bounded, literal, and stdin-only',()=> {
  expect(words('x'.repeat(MAX_BYTES+1))).toEqual([]);
  expect(misspellings('teh','x'.repeat(MAX_BYTES+1))).toEqual([]);
  let args:any, options:any;
- const result=check('teh',((_:any,a:any,o:any)=>{args=a;options=o;return {status:0,stdout:'teh\n'}}) as any);
+ const result=check('teh',((_:any,a:any,o:any)=>{args=a;options=o;return {status:0,stdout:'teh\n'}}) as any,['en_US']);
  expect(args).not.toContain('teh'); expect(options.input).toBe('teh\n');
  expect(result).toEqual([{start:0,end:3}]);
- expect(check('teh',(()=>({status:1,stdout:''})) as any)).toEqual([]);
+ expect(check('teh',(()=>({status:1,stdout:''})) as any,['en_US'])).toEqual([]);
 });
 test('word and byte limits include Unicode and exact boundaries', () => {
  expect(words(' '.repeat(MAX_BYTES-3)+'teh')).toEqual([{word:'teh',start:MAX_BYTES-3,end:MAX_BYTES}]);
@@ -29,4 +32,27 @@ test('oversized stdin exits without waiting for EOF', async () => {
   expect(await child.exited).toBe(0);
   expect(await new Response(child.stdout).text()).toBe('[]\n');
  } finally { clearTimeout(timer); child.kill(); }
+});
+test('spell= in bridge.conf picks the dictionaries, off turns the checker off', () => {
+ const dir = mkdtempSync(join(tmpdir(), 'blip-spell-'));
+ const conf = (body:string) => { const p = join(dir, 'bridge.conf'); writeFileSync(p, body); return p; };
+ expect(dictionaries(join(dir, 'missing.conf'))).toEqual(['en_US']);          // no conf: as before
+ expect(dictionaries(conf('host=mac\n'))).toEqual(['en_US']);                 // no key: as before
+ expect(dictionaries(conf('spell=en_US,nb_NO\n'))).toEqual(['en_US','nb_NO']);
+ expect(dictionaries(conf('spell = nb_NO, en_US-large \n'))).toEqual(['nb_NO','en_US-large']);
+ expect(dictionaries(conf('spell=off\n'))).toEqual([]);
+ // only names reach the argv: a value outside [A-Za-z0-9_-] is not a list, so it is the default
+ expect(dictionaries(conf('spell=nb_NO,../../etc/passwd\n'))).toEqual(['en_US']);
+ expect(dictionaries(conf('spell=$(id)\n'))).toEqual(['en_US']);
+ expect(dictionaries(conf('spell=,\n'))).toEqual(['en_US']);
+ // off: hunspell is never run
+ let ran = false;
+ expect(check('teh', ((()=>{ ran = true; return {status:0,stdout:'teh\n'}; }) as any), [])).toEqual([]);
+ expect(ran).toBe(false);
+ // a dictionary dropped under the user dir wins over the system one of the same name
+ writeFileSync(join(dir, 'nb_NO.aff'), ''); writeFileSync(join(dir, 'nb_NO.dic'), '');
+ expect(dictionaryArg(['en_US','nb_NO'], dir)).toBe('en_US,' + join(dir, 'nb_NO'));
+ let args:any;
+ check('teh', ((_:any,a:any)=>{args=a;return {status:0,stdout:''}}) as any, ['en_US','nb_NO']);
+ expect(args.slice(0,2)).toEqual(['-l','-d']); expect(args[2].startsWith('en_US,')).toBe(true);
 });

--- a/spellcheck.ts
+++ b/spellcheck.ts
@@ -1,9 +1,36 @@
 // Local-only spelling: draft text uses bounded stdin and is never persisted.
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 export const MAX_BYTES = 8192;
+const CONF_PATH = join(homedir(), ".config/blip/bridge.conf");
+const USER_DICTS = join(homedir(), ".local/share/blip/dictionaries");
+/** `spell=` in bridge.conf: the dictionaries hunspell checks against, comma-separated
+ *  (`en_US,nb_NO` — a word found in any of them passes, which is what a bilingual draft
+ *  needs), or `off`. Parsed, never sourced: the value is one character class, so only
+ *  names reach the argv, and a value outside it means the default. Default `en_US`, as
+ *  #51 shipped; a name hunspell cannot find it skips itself, as long as one loads. */
+export function dictionaries(path = CONF_PATH): string[] {
+  try {
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      const m = /^\s*spell\s*=\s*([A-Za-z0-9_, -]+?)\s*$/.exec(line);
+      if (!m) continue;
+      if (/^(off|no|false|0)$/i.test(m[1]!)) return [];
+      const names = m[1]!.split(",").map(n => n.trim()).filter(Boolean);
+      return names.length ? names : ["en_US"];
+    }
+  } catch { /* no conf: the default */ }
+  return ["en_US"];
+}
+/** What `-d` gets. A dictionary dropped under ~/.local/share/blip/dictionaries wins over
+ *  the system one of the same name (a path is a valid `-d` entry). */
+export function dictionaryArg(names: string[], userDir = USER_DICTS): string {
+  return names.map(n => {
+    const local = join(userDir, n);
+    return existsSync(local + ".aff") && existsSync(local + ".dic") ? local : n;
+  }).join(",");
+}
 export function words(text: string): {word:string; start:number; end:number}[] {
   if (Buffer.byteLength(text) > MAX_BYTES) return [];
   const ignored = [...text.matchAll(/https?:\/\/\S+|[\w.+-]+@[\w.-]+\.[a-z]+/gi)]
@@ -17,12 +44,11 @@ export function misspellings(text: string, output: string) {
   const bad = new Set(output.split(/\r?\n/));
   return words(text).filter(w => bad.has(w.word)).map(({start,end})=>({start,end}));
 }
-export function check(text:string, runner = spawnSync) {
+export function check(text:string, runner = spawnSync, dicts = dictionaries()) {
+  if (!dicts.length) return [];
   const tokens = words(text);
   if (!tokens.length) return [];
-  const local = join(homedir(), '.local/share/blip/dictionaries/en_US');
-  const dictionary = existsSync(local+'.aff') && existsSync(local+'.dic') ? local : 'en_US';
-  const result = runner('/usr/bin/hunspell',['-l','-d',dictionary], {
+  const result = runner('/usr/bin/hunspell',['-l','-d',dictionaryArg(dicts)], {
     input: tokens.map(w=>w.word).join('\n')+'\n', encoding:'utf8', timeout:1500, maxBuffer:MAX_BYTES,
   });
   return result.status === 0 ? misspellings(text, result.stdout) : [];


### PR DESCRIPTION
## What

`spell=` in `bridge.conf` picks the dictionaries the spelling checker uses: `spell=en_US,nb_NO` checks against several at once, `spell=off` turns the underlines off. The default is unchanged (`en_US`).

## Why

The checker from #51 asks Hunspell for `en_US` and nothing else, so a draft in any other language is underlined word for word. A Norwegian message is "misspelled" from the first word to the last, and there is no way to say otherwise short of uninstalling the dictionary. Hunspell takes several dictionaries in one `-d` and accepts a word found in any of them, which is exactly what a bilingual draft needs.

## How

- **`spellcheck.ts`** — `dictionaries(path)` reads `spell=` from `bridge.conf` the way `push_read=` and `link_previews=` are read: one regex, first match, parsed and never sourced. The value is one character class (`[A-Za-z0-9_, -]`), so only names reach the argv; a value outside it is not a list and means the default, and `off`/`no`/`false`/`0` means none. `dictionaryArg(names)` keeps the user directory's precedence per name (`~/.local/share/blip/dictionaries/<name>` wins over the system one; a path is a valid `-d` entry). `check()` returns `[]` without spawning hunspell when the list is empty. A name that is not installed is skipped by hunspell itself as long as one loads (verified on hunspell 1.7.3: `-d en_US,xx_YY` exits 0 and checks against `en_US`). Draft text still travels on stdin only.
- **`spellcheck.test.ts`** — one test: missing conf, no key, list with and without spaces, off, values outside the class fall back (`../../etc/passwd`, `$(id)`, a bare comma), off never runs hunspell, the user-dir preference and the argv shape. The two existing `check()` tests now pass their dictionaries explicitly, so they no longer depend on the developer's own `bridge.conf`.
- **`README.md`** four lines in the spelling paragraph; **`scripts/blip-setup`** adds `spell` to the comment listing the keys a re-run must keep (the code already keeps every key it does not own); **CHANGELOG** under Unreleased.

Not changed: `ComposerInput.qml`. With `spell=off` it still runs the helper on the debounce and gets `[]` back; reading `bridge.conf` from QML to skip the spawn did not seem worth a second parser.

## How it was verified

- [x] `bun test` is green (CI will check) — 474 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → no QML in this change; verified live on Omarchy with `spell=en_US,nb_NO` and `hunspell-nb` installed: a Norwegian draft loses its underlines, an English typo keeps its one, and `spell=off` clears them
- [ ] Touches an invariant in `CLAUDE.md` → no; "draft text on stdin only, ranges back" holds
