### PR TITLE
Tests read their own bridge.conf, not the developer's

### DIFF
--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,6 +1,9 @@
-// Tests must never touch the developer's real caches: point XDG_CACHE_HOME at
-// a scratch dir before any module computes CACHE_DIR / AVATAR_DIR.
+// Tests must never touch the developer's real caches or config: point
+// XDG_CACHE_HOME and XDG_CONFIG_HOME at scratch dirs before any module computes
+// CACHE_DIR / AVATAR_DIR or reads bridge.conf (country_code= would otherwise
+// change what a bare national number normalizes to).
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 process.env.XDG_CACHE_HOME = mkdtempSync(join(tmpdir(), "blip-test-cache-"));
+process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "blip-test-config-"));

--- a/tier2.test.ts
+++ b/tier2.test.ts
@@ -15,7 +15,7 @@ import {
   sniffImage,
 } from "./linkpreview";
 import { AVATAR_DIR, AVATAR_NONE_TTL_MS, AVATAR_TTL_MS, avatarArgs, avatarKey, fetchAvatar } from "./avatar";
-import { readFileSync, writeFileSync, unlinkSync, utimesSync, mkdtempSync } from "node:fs";
+import { readFileSync, writeFileSync, unlinkSync, utimesSync, mkdtempSync, mkdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
@@ -688,6 +688,17 @@ describe("country code + service (2.2.0)", () => {
     expect(normalizeHandle("07911 123456", "44")).toBe("+447911123456");
     expect(normalizeHandle("447911123456", "44")).toBe("+447911123456");
     expect(normalizeHandle("(404) 555-0123", "1")).toBe("+14045550123");
+  });
+  test("the default country code comes from the test's own bridge.conf, never the developer's", () => {
+    // test-setup.ts points XDG_CONFIG_HOME at a scratch dir; without that, a
+    // developer with country_code=47 saw the five NANP cases above fail.
+    const { defaultCountryCode } = require("./contact-search") as typeof import("./contact-search");
+    expect(process.env.XDG_CONFIG_HOME).toBeDefined();   // or the line below writes to ./undefined/
+    const dir = `${process.env.XDG_CONFIG_HOME}/blip`;
+    mkdirSync(dir, { recursive: true });
+    expect(defaultCountryCode()).toBe("1");
+    writeFileSync(`${dir}/bridge.conf`, "country_code=47\n");
+    try { expect(defaultCountryCode()).toBe("47"); } finally { unlinkSync(`${dir}/bridge.conf`); }
   });
   test("SMS threads send files on the SMS service; groups never carry --service", () => {
     let seen: string[] = [];

--- a/undefined/st.json
+++ b/undefined/st.json
@@ -1,1 +1,0 @@
-{"watermark":"","readMark":"","unreadCounts":{},"unreadOldest":{},"unreadInitialized":false,"selfChats":[],"readMarks":{},"groups":{},"toasted":["fail:sha256:55b7b8d5f857dd6abd1e27a00c5fdcf518e74324611b25afb2431071d63eb0bb"]}


### PR DESCRIPTION
## What

The test preload now points `XDG_CONFIG_HOME` at a scratch dir, the way it already does for `XDG_CACHE_HOME`, so no test reads the developer's own `bridge.conf`. One test proves the isolation reaches the reader.

## Why

`contact-search.ts` reads `country_code=` through `XDG_CONFIG_HOME` (falling back to `~/.config`), and the preload never set it. On a machine set up outside North America (`country_code=47`) five `tier2.test.ts` cases fail: `(404) 555-0123` normalizes to `+474045550123`. CI has no `bridge.conf`, so it stays green, and the failures only show up for a contributor who actually runs Blip. That is the wrong way round for a test suite.

## How

- **`test-setup.ts`** — one line: `XDG_CONFIG_HOME` gets a scratch dir beside the cache one; the comment says why.
- **`tier2.test.ts`** — one test in the country-code block: the default country code is `1` in the scratch dir, and a `bridge.conf` written there is what changes it to `47`. It first asserts the variable is set, because without it the scratch path is the literal `./undefined/`, which is how stray artifacts of that name get committed.
- **`undefined/st.json`** — removed again. 7d569c3 took it out after 2.2.0 and #50 brought it back; it is the collector's state file written with an unset directory variable, the same class of artifact this preload exists to prevent.

No production code changes.

## How it was verified

- [x] `bun test` is green (CI will check) — 474 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] Measured on the machine that had the failures (`country_code=47`): tier2 went from 80 pass / 5 fail to 85 pass / 0 fail; reproduced on a clean machine with a fake `$HOME` carrying `country_code=47` (5 fail before, 0 after); the new test fails without the preload change
- [ ] UI change → no
- [ ] Touches an invariant in `CLAUDE.md` → no
