### PR TITLE
README: say at the Full Disk Access step that the grant covers every ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,12 @@ wizard pauses here and re-checks when you press Enter)
 
 - *Full Disk Access* → System Settings → Privacy & Security → Full Disk
   Access → add `/usr/libexec/sshd-keygen-wrapper` (⌘⇧G in the file picker).
-  That is what lets an ssh session read `chat.db`.
+  That is what lets an ssh session read `chat.db` — **any** ssh session: the
+  grant is per `sshd-keygen-wrapper`, not per key, so from here on every key
+  that can open a shell on this account can read your messages. Blip's own
+  key runs only the bridge tools (step 2), and reading messages is their job;
+  keep the other keys few, and see [docs/SECURITY.md](docs/SECURITY.md) for
+  pinning them or closing port 22 one layer down.
 - *Automation → Messages* → the first send from ssh pops an Allow prompt on
   the Mac's screen; click it once — **within about two minutes, at the Mac.**
   An unanswered prompt is recorded by macOS as a *denial* (`auth_reason 9`,


### PR DESCRIPTION
## What

Five lines in the README, at the Full Disk Access step of the install: the grant covers every ssh key that can open a shell on the account, not just Blip's; what Blip's own key can and cannot do; and where the two ways to narrow the rest are described.

## Why

The wizard pauses at the broadest permission Blip asks for, and the README explains it as "what lets an ssh session read `chat.db`". True, and incomplete in the way that matters: the grant is per `sshd-keygen-wrapper`, not per key, so from that click on every key that can open a shell on the account can read the messages. `docs/SECURITY.md` has said so since 1.10.0, two pages away from where the decision is made. On my own Mac the grant was already in place from earlier work, and it took setting up Blip to notice what it covered.

## How

- **`README.md`** — the *Full Disk Access* bullet under "Two grants on the Mac" gains: **any** ssh session, per-wrapper not per-key, what the Blip key can do (only the bridge tools, and reading messages is their job — the confinement protects the Mac, not the messages, as SECURITY.md finding 13 puts it), keep the other keys few, and a link to `docs/SECURITY.md` for pinning them or closing port 22 one layer down. Nothing else changes; SECURITY.md already carries the detail.

Checked on macOS 26.6.2 before writing it down, not taken from SECURITY.md on trust: launchd's ssh service program is `/usr/libexec/sshd-keygen-wrapper` (`ssh.plist`); the TCC rows name that path as the client (`client_type` 1) and carry no key or user; a session over an unrelated key with no TCC row of its own lists `~/Library/Messages`; and `blip-dispatch` refuses the confined key a shell, arbitrary commands and port forwarding while `blip-check` over the same key still reads `chat.db`.

## How it was verified

- [x] `bun test` is green (CI will check) — 473 pass; `ui.test.ts` pins parts of the README and is unaffected
- [x] Any send/receive behavior was exercised against **my own number only** — docs only
- [ ] UI change → no
- [ ] Touches an invariant in `CLAUDE.md` → no
