### PR TITLE
List rows take the theme's hover fill, like the bubble cursor already does

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -115,6 +115,9 @@ FocusScope {
   readonly property color mineFill: accent
   readonly property color mineText: "#ffffff"
   readonly property color theirsFill: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
+  // Omarchy's hover-cursor fill for rows and the bubble band alike: the theme's
+  // colour and alpha (foreground at 0.08 by default), not a hard-coded copy of them.
+  readonly property color hoverFill: Style.hoverFillFor(foreground, accent)
   readonly property color theirsText: foreground
 
   // Links inside a bubble take the bubble's readable text color instead of
@@ -2237,7 +2240,7 @@ FocusScope {
                 implicitHeight: contactRow.implicitHeight + Style.space(12)
                 radius: Style.cornerRadius
                 color: contactHover.hovered || hasCursor
-                  ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+                  ? root.hoverFill
                   : "transparent"
                 HoverHandler { id: contactHover }
                 TapHandler { onTapped: root.openContact(modelData) }
@@ -2348,7 +2351,7 @@ FocusScope {
                   implicitHeight: pinnedColumn.implicitHeight + Style.space(12)
                   radius: Style.cornerRadius
                   color: pinnedHover.hovered || (hasCursor && root.cursorShown)
-                    ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+                    ? root.hoverFill
                     : "transparent"
 
                   HoverHandler { id: pinnedHover }
@@ -2504,7 +2507,7 @@ FocusScope {
                 implicitHeight: hitCol.implicitHeight + Style.space(12)
                 radius: Style.cornerRadius
                 color: hitHover.hovered || hasCursor
-                  ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+                  ? root.hoverFill
                   : "transparent"
                 HoverHandler { id: hitHover }
                 TapHandler { onTapped: root.openSearchHit(modelData) }
@@ -2588,7 +2591,7 @@ FocusScope {
                   implicitHeight: rowRow.implicitHeight + Style.space(root.splitView ? 30 : 18)
                   radius: Style.cornerRadius
                   color: highlighted
-                    ? Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.08)
+                    ? root.hoverFill
                     : "transparent"
 
                   HoverHandler {
@@ -2904,9 +2907,7 @@ FocusScope {
             y: root.bubbleCursorItem ? root.bubbleCursorItem.y - Style.space(2) : 0
             height: root.bubbleCursorItem ? root.bubbleCursorItem.height + Style.space(4) : 0
             radius: Style.cornerRadius
-            // Omarchy's cursor fill: the theme's hover-cursor colour and alpha
-            // (foreground at 0.08 by default), not a hard-coded copy of them.
-            color: Style.hoverFillFor(root.foreground, root.accent)
+            color: root.hoverFill
           }
           ColumnLayout {
             id: content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 - **Reactions on pictures show.** A message that is only a picture (or a file)
   has no text bubble, and that is where the tapback pill lived, so a reaction
   on a picture was never seen. The pill now sits on the picture or chip itself.
+- **List rows follow the theme's hover colour.** The thread list, pins, search
+  hits and new-message hits highlighted with a hard-coded 8 % foreground; they
+  now take Omarchy's `hover-cursor-fill-alpha` / `hover-cursor-color`, like the
+  conversation's bubble cursor already did. Default themes look the same.
 
 ## 2.4.0 — 2026-09-08 — read it from the keyboard, send without the wait
 

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -369,8 +369,10 @@ describe("QML safety invariants", () => {
     // The selection is a target for actions; it must never outlive the rows
     // it indexes (a reload renumbers them) and Esc must drop it before leaving.
     expect(panel).toContain("onBubblesChanged: clearBubbleCursor()");
-    // the band takes the theme's hover-cursor colour/alpha, like Omarchy's own rows
-    expect(panel).toContain("color: Style.hoverFillFor(root.foreground, root.accent)");
+    // the band and the list rows take the theme's hover-cursor colour/alpha through
+    // one property, like Omarchy's own rows; its default is never copied by hand
+    expect(panel).toContain("readonly property color hoverFill: Style.hoverFillFor(foreground, accent)");
+    expect(panel).not.toContain("foreground.b, 0.08)");
     expect(panel).toContain("onHasCursorChanged: if (hasCursor) root.bubbleCursorItem = bubbleRow");
     expect(panel).toContain("if (root.bubbleCursor >= 0) root.leaveBubbles(); else root.back()");
     const move = qmlFunction("moveBubbleCursor");


### PR DESCRIPTION
## What

The four list rows (threads, pins, search hits, new-message hits) highlight with Omarchy's hover token instead of a hard-coded 8 % foreground, through one `hoverFill` property the bubble cursor's band now shares. The conversation's bubble cursor already did. Default themes look exactly the same.

## Why

#39 gave the bubble cursor the theme's hover-cursor colour and alpha, with a comment saying "not a hard-coded copy of them" and a test pinning it. The rows kept the copy, `Qt.rgba(foreground, 0.08)`, in four places. A theme that sets `hover-cursor-fill-alpha` or `hover-cursor-color` (Omarchy's own rows follow both) moved the bubble band and left the list rows behind.

## How

- **`BlipView.qml`** — one derived property, `hoverFill: Style.hoverFillFor(foreground, accent)`, beside `dim` and `theirsFill` where the other derived colours live, with the band's comment moved to it. The band and the four rows read `root.hoverFill`. `hoverFillFor` resolves to `alpha(foreground, 0.08)` when the theme sets nothing (checked in `Commons/Style.qml`: `hover-cursor-color` defaults to `foreground`, `hover-cursor-fill-alpha` to `0.08`), so pixels are unchanged by default. `foreground` stays a parameter because the panel passes the bar's own foreground, which need not be `Color.foreground`; `accent` is Blip's blue, as the band already had it.
- **`ui.test.ts`** — the existing assertion becomes: the property exists, and no `foreground.b, 0.08)` anywhere in the file.
- **CHANGELOG** under Unreleased.

## How it was verified

- [x] `bun test` is green (CI will check) — 473 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → `qmlformat` parses; running on my Omarchy with a theme that sets neither key: rows highlight as before on hover and on the keyboard cursor, in the panel and the window; `status` healthy, no QML errors in the log
- [ ] Touches an invariant in `CLAUDE.md` → no
