### PR TITLE
Secondary text dims by alpha, so it reads right on light themes too

### DIFF
--- a/BlipView.qml
+++ b/BlipView.qml
@@ -94,7 +94,10 @@ FocusScope {
   readonly property int fontCaption: Math.max(1, Math.round(Style.font.caption * uiFontScale))
   readonly property int fontBodySmall: Math.max(1, Math.round(Style.font.bodySmall * uiFontScale))
   readonly property int fontBody: Math.max(1, Math.round(Style.font.body * uiFontScale))
-  readonly property color dim: Qt.darker(foreground, 1.45)
+  // Secondary text: the foreground at 0.66, as Omarchy's own placeholder text
+  // is. Not Qt.darker: darker is dimmer only on a dark theme — on a light one
+  // it made timestamps heavier than the messages they sit under.
+  readonly property color dim: Qt.alpha(foreground, 0.66)
   /** An editor owns the keyboard — the host's key catcher must stand down. */
   readonly property bool editorActive:
     contactReview.opened || composeField.activeFocus || searchField.activeFocus || newField.activeFocus || bubbleFocused
@@ -3543,7 +3546,7 @@ FocusScope {
                   ? "caption (optional) — Enter sends the file"
                   : root.isSendable(root.active) ? "iMessage" : "Read-only — group id unknown"
                 color: root.foreground
-                placeholderTextColor: Qt.darker(root.foreground, 1.6)
+                placeholderTextColor: root.dim
                 selectionColor: Style.selectionFillFor(root.foreground, root.mineFill)
                 selectedTextColor: root.foreground
                 font.family: root.fontFamily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@
 - **Reactions on pictures show.** A message that is only a picture (or a file)
   has no text bubble, and that is where the tapback pill lived, so a reaction
   on a picture was never seen. The pill now sits on the picture or chip itself.
+- **Secondary text reads right on light themes.** Timestamps, previews and
+  labels dimmed with `Qt.darker`, which on a light theme made them *heavier*
+  than the messages (Catppuccin Latte: 10:1 against 7:1 for the text itself).
+  They now dim by alpha, as Omarchy's own placeholder text does. Dark themes
+  look the same.
 
 ## 2.4.0 — 2026-09-08 — read it from the keyboard, send without the wait
 

--- a/ui.test.ts
+++ b/ui.test.ts
@@ -403,6 +403,10 @@ describe("QML safety invariants", () => {
     // Empty status does not reserve a row; only failures are red.
     expect(panel).toContain('visible: root.note !== ""');
     expect(panel).toContain("color: calm ? root.dim : root.urgent");
+    // secondary text dims by alpha, which reads right on light and dark themes alike;
+    // Qt.darker on the foreground only works on a dark one
+    expect(panel).toContain("readonly property color dim: Qt.alpha(foreground, 0.66)");
+    expect(panel).not.toMatch(/Qt\.darker\((root\.)?foreground/);
   });
 
   test("a peeked thread is not read until the reader commits", () => {


### PR DESCRIPTION
## What

Secondary text (timestamps, previews, the Edited tag, the compose placeholder) dims by alpha instead of `Qt.darker`, so it reads as secondary on light themes too. Dark themes look as they did.

## Why

`dim` was `Qt.darker(foreground, 1.45)`. Darker is dimmer only when the foreground is light. On a light theme it goes the other way: Catppuccin Latte's text sits at 7:1 against its background and the "dim" text at 10:1, so every timestamp was heavier than the message above it, and the previews in the list outweighed the names.

Alpha does not have that problem: it blends toward whatever the background is. Foreground at 0.66 is what Omarchy uses for its own placeholder text (`Commons/Color.qml`), and on Tokyo Night it lands at 4.3:1 where `Qt.darker` gave 4.0:1.

Rendered with `scripts/demo/blip-shots` (invented data), before on the left, after on the right:

| Catppuccin Latte, list | Catppuccin Latte, conversation |
|---|---|
| ![light list](https://raw.githubusercontent.com/Fileri/blip/pr-assets/dim-alpha/light-panel.png) | ![light conversation](https://raw.githubusercontent.com/Fileri/blip/pr-assets/dim-alpha/light-panel-conversation.png) |

| Tokyo Night, conversation (unchanged to the eye) |
|---|
| ![dark conversation](https://raw.githubusercontent.com/Fileri/blip/pr-assets/dim-alpha/dark-panel-conversation.png) |

## How

- **`BlipView.qml`** — `dim` is `Qt.alpha(foreground, 0.66)`, with a comment saying why not `Qt.darker`. The compose placeholder had its own `Qt.darker(root.foreground, 1.6)` and now takes `dim`. Two lines of code.
- **`ui.test.ts`** — the invariant test pins the property and refuses `Qt.darker` on the foreground anywhere in the file.
- **CHANGELOG** under Unreleased.

Not in this PR: `ContactReview.qml`, `ContactDetails.qml` and `ContactButton.qml` carry the same `Qt.darker(root.foreground, …)` pattern in four places. #25 is open against those files, so they are left for after it lands.

A note on the harness, for whoever renders next: `blip-shots` draws the fallback palette, not the current theme, because the sandbox's `XDG_STATE_HOME` has no `omarchy/current/theme`; a symlink to the real one makes it render the theme in use. Happy to send that as its own small change if wanted.

## How it was verified

- [x] `bun test` is green (CI will check) — 473 pass
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] UI change → the renders above, both themes, before and after; `qmlformat` parses; running on my Omarchy (Tokyo Night): timestamps and previews read as before, status healthy, no QML errors in the log
- [ ] Touches an invariant in `CLAUDE.md` → no
