### PR TITLE
imsg attachment serves stickers: StickerCache is part of the Messages store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@
 - **Reactions on pictures show.** A message that is only a picture (or a file)
   has no text bubble, and that is where the tapback pill lived, so a reaction
   on a picture was never seen. The pill now sits on the picture or chip itself.
+- **Stickers show.** Messages files stickers (Memoji, Genmoji, sticker packs)
+  under `StickerCache/`, not `Attachments/`, and the bridge's path guard knew
+  only the latter — every sticker anyone sent came back as "attachment path
+  escapes the Messages store". The guard now admits that directory too, with
+  the same resolve-then-check, regular-file and size rules. Re-run
+  `blip-setup` so the Mac `imsg` picks it up.
 
 ## 2.4.0 — 2026-09-08 — read it from the keyboard, send without the wait
 

--- a/bridge/mac/imsg
+++ b/bridge/mac/imsg
@@ -1428,11 +1428,22 @@ def cmd_groups(con, args):
 
 
 ATTACHMENTS_ROOT = os.path.expanduser("~/Library/Messages/Attachments")
+# Stickers (Memoji, Genmoji, sticker packs) are attachment rows like any other,
+# but Messages files them here instead of under Attachments/.
+STICKER_ROOT = os.path.expanduser("~/Library/Messages/StickerCache")
 # Files Blip sent: imsg-send keeps them here because Messages may leave the
 # attachment row pointing at the (deleted) ~/Pictures/.blip-outbox staging path.
 OUTBOX_ROOT = os.path.expanduser("~/Pictures/.blip-outbox")
 SENT_ROOT = os.path.expanduser("~/.blip/sent")
 ATTACH_MAX_BYTES = 100 * 1024 * 1024  # hard ceiling, deliberately no flag
+
+
+def _in_message_store(path: str) -> bool:
+    """`path`, symlinks resolved, sits under a directory message media lives in.
+    commonpath, not startswith: a sibling sharing the name prefix is outside."""
+    path = os.path.realpath(path)
+    roots = (ATTACHMENTS_ROOT, STICKER_ROOT, SENT_ROOT)
+    return any(os.path.commonpath([path, r]) == r for r in map(os.path.realpath, roots))
 
 
 def _sniff_image(head: bytes) -> str:
@@ -1859,8 +1870,7 @@ def cmd_attachment(con, args):
     if os.path.commonpath([os.path.realpath(raw), outbox]) == outbox and not os.path.exists(raw):
         raw = os.path.join(SENT_ROOT, os.path.relpath(os.path.realpath(raw), outbox))
     path = os.path.realpath(raw)
-    roots = [os.path.realpath(ATTACHMENTS_ROOT), os.path.realpath(SENT_ROOT)]
-    if not any(os.path.commonpath([path, r]) == r for r in roots):
+    if not _in_message_store(path):
         sys.exit("error: attachment path escapes the Messages store")
 
     # Ceiling applies to the SOURCE before any conversion — sips must not be

--- a/bridge/mac/imsg_test.py
+++ b/bridge/mac/imsg_test.py
@@ -8,6 +8,7 @@ import io
 import json
 import os
 import sqlite3
+import tempfile
 import unittest
 from types import SimpleNamespace
 
@@ -188,6 +189,39 @@ class ChatProjectionTests(unittest.TestCase):
         self.assertEqual(merged["messages"], 2)
         self.assertEqual(merged["pin_order"], 0)
         self.assertIn("other-group", [row["id"] for row in rows])
+
+
+class AttachmentStoreTests(unittest.TestCase):
+    """`imsg attachment` serves a file only from the directories message media
+    lives in. Stickers are the third one: Messages keeps them in StickerCache,
+    not Attachments, and the old two-root check refused every sticker sent."""
+
+    def test_stickers_are_served_and_everything_outside_the_store_is_not(self):
+        saved = (imsg.ATTACHMENTS_ROOT, imsg.STICKER_ROOT, imsg.SENT_ROOT)
+        with tempfile.TemporaryDirectory() as tmp:
+            roots = {n: os.path.join(tmp, "Messages", n) for n in ("Attachments", "StickerCache")}
+            roots["sent"] = os.path.join(tmp, ".blip", "sent")
+            outside = os.path.join(tmp, "Messages", "chat.db")
+            for d in roots.values():
+                os.makedirs(d)
+                open(os.path.join(d, "file.png"), "w").close()
+            open(outside, "w").close()
+            # a sibling directory that shares StickerCache's name as a prefix
+            os.makedirs(roots["StickerCache"] + "-evil")
+            open(os.path.join(roots["StickerCache"] + "-evil", "file.png"), "w").close()
+            # a link planted inside the sticker store, pointing out of it
+            os.symlink(outside, os.path.join(roots["StickerCache"], "link.png"))
+            try:
+                imsg.ATTACHMENTS_ROOT, imsg.STICKER_ROOT, imsg.SENT_ROOT = (
+                    roots["Attachments"], roots["StickerCache"], roots["sent"])
+                for d in roots.values():
+                    self.assertTrue(imsg._in_message_store(os.path.join(d, "file.png")), d)
+                self.assertFalse(imsg._in_message_store(outside))
+                self.assertFalse(imsg._in_message_store(os.path.join(roots["StickerCache"] + "-evil", "file.png")))
+                self.assertFalse(imsg._in_message_store(os.path.join(roots["StickerCache"], "link.png")))
+                self.assertFalse(imsg._in_message_store(os.path.join(roots["StickerCache"], "..", "chat.db")))
+            finally:
+                imsg.ATTACHMENTS_ROOT, imsg.STICKER_ROOT, imsg.SENT_ROOT = saved
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`imsg attachment` serves stickers. Messages files them under `~/Library/Messages/StickerCache/`, not `Attachments/`, and the bridge's path guard knew only the latter, so every sticker anyone sent came back as "attachment path escapes the Messages store".

## Why

The message was true about the guard and false about the file: the sticker is on the Mac, fully transferred, inside the Messages store, one directory over from where the guard looked. On one Mac, 50 of 2413 attachment rows live there (half PNG, half HEIC), so roughly one picture in fifty never showed, with an error that sent the reader looking for a path problem.

## How

- **`bridge/mac/imsg`** — `STICKER_ROOT` beside `ATTACHMENTS_ROOT`, and the three-root check moves into `_in_message_store(path)` so a test can reach it. Nothing else about the guard changes: the path is resolved before the check, a sibling that merely shares the name prefix does not match (`commonpath`, not `startswith`), and the size ceiling, the `O_NOFOLLOW` open and the `S_ISREG` check on the descriptor all still run after it. The group-photo guard keeps its own Attachments-only check; a group photo never lives elsewhere.
- **`bridge/mac/imsg_test.py`** — one test: a file under each of the three roots is admitted; `~/Library/Messages/chat.db` (inside Messages, not a root), a `StickerCache-evil` sibling, a symlink planted inside `StickerCache` that points outside, and `StickerCache/../chat.db` are all refused.
- **CHANGELOG** under Unreleased, with the re-run-`blip-setup` note, since this is Mac-side.

## How it was verified

- [x] `bun test` is green (CI will check) — no TypeScript in this change; `python3 bridge/mac/imsg_test.py` 5 pass, on Linux and on the Mac's Python 3.9
- [x] Any send/receive behavior was exercised against **my own number only** — this change does not send
- [x] On the Mac that had the failure: the sticker that failed now streams (26 KB JPEG) with the new `imsg` and is refused by the previous one; an attachment row pointing into `/var/folders` is refused by both; a non-decimal id is refused before any path is looked up
- [ ] UI change → no
- [ ] Touches an invariant in `CLAUDE.md` → no
